### PR TITLE
사용자 인증 방식 또한 쿠키 방식으로 통일 (refactor/#24 -> develop)

### DIFF
--- a/src/main/java/org/project/ttokttok/domain/user/controller/UserAuthController.java
+++ b/src/main/java/org/project/ttokttok/domain/user/controller/UserAuthController.java
@@ -25,9 +25,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import org.springframework.web.bind.annotation.*;
 
+import static org.project.ttokttok.global.auth.jwt.TokenExpiry.ACCESS_TOKEN_EXPIRY_TIME;
 import static org.project.ttokttok.global.auth.jwt.TokenExpiry.REFRESH_TOKEN_EXPIRY_TIME;
-import static org.project.ttokttok.global.auth.jwt.TokenProperties.AUTH_HEADER;
 import static org.project.ttokttok.global.auth.jwt.TokenProperties.REFRESH_KEY;
+import static org.project.ttokttok.global.auth.jwt.TokenProperties.ACCESS_TOKEN_COOKIE;
 
 
 import java.time.Duration;
@@ -136,7 +137,7 @@ public class UserAuthController {
     @io.swagger.v3.oas.annotations.responses.ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "200",
-                    description = "로그인 성공, 액세스 토큰 헤더로 반환"
+                    description = "로그인 성공, 액세스 토큰 쿠키로 반환"
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "400",
@@ -155,8 +156,18 @@ public class UserAuthController {
         LoginResponse loginResponse = LoginResponse.from(serviceResponse);
 
         // 리프레시 토큰을 쿠키로 설정 (로그인 유지 옵션이 true인 경우에만)
+        // ResponseEntity.BodyBuilder responseBuilder = ResponseEntity.ok()
+        //        .header(AUTH_HEADER.getValue(), "Bearer " + serviceResponse.accessToken());
+
+        // 액세스 토큰을 쿠키로 설정
+        ResponseCookie accessCookie = CookieUtil.createResponseCookie(
+                ACCESS_TOKEN_COOKIE.getValue(),
+                serviceResponse.accessToken(),
+                Duration.ofMillis(ACCESS_TOKEN_EXPIRY_TIME.getExpiry())
+        );
+
         ResponseEntity.BodyBuilder responseBuilder = ResponseEntity.ok()
-                .header(AUTH_HEADER.getValue(), "Bearer " + serviceResponse.accessToken());
+                .header(HttpHeaders.SET_COOKIE, accessCookie.toString()); // 수정된 부분
 
         if (request.rememberMe()) {
             ResponseCookie refreshCookie = CookieUtil.createResponseCookie(

--- a/src/main/java/org/project/ttokttok/domain/user/controller/dto/response/LoginResponse.java
+++ b/src/main/java/org/project/ttokttok/domain/user/controller/dto/response/LoginResponse.java
@@ -5,13 +5,12 @@ import org.project.ttokttok.domain.user.service.dto.response.LoginServiceRespons
 
 @Builder
 public record LoginResponse(
-        String accessToken,     // 액세스 토큰 (헤더 대신 응답 바디에 포함)
+        // String accessToken,     // 액세스 토큰 (헤더 대신 응답 바디에 포함)
         UserResponse user       // 사용자 정보
         // refreshToken은 쿠키로 전달하므로 응답에 포함하지 않음
 ) {
     public static LoginResponse from(final LoginServiceResponse serviceResponse) {
         return LoginResponse.builder()
-                .accessToken(serviceResponse.accessToken())
                 .user(UserResponse.from(serviceResponse.user()))
                 .build();
     }


### PR DESCRIPTION
## ✨ 작업 내용
- 사용자 인증또한 쿠키 방식으로 통일하여 JWT 필터 연동 문제 해결
- `UserAuthController.login()` 메서드에서 액세스 토큰을 쿠키로 설정
- 필요한 import 추가 (`ACCESS_TOKEN_EXPIRY_TIME`, `ACCESS_TOKEN_COOKIE`)
- Swagger 문서 설명 업데이트

---

## 🔍 관련 이슈
- 해결한 이슈 번호: #24 
- 관련된 이슈 번호 (선택): #23 , #24 

---

## ✅ 체크리스트
- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요?
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항
> 리뷰어가 알아야 할 특이사항, 주의사항이 있다면 작성해주세요.
