### PR TITLE
인기동아리 API 정렬 기능 추가 및 필터 리팩토링 (refactor/#36 -> develop)

### DIFF
--- a/src/main/java/org/project/ttokttok/domain/club/controller/ClubUserApiController.java
+++ b/src/main/java/org/project/ttokttok/domain/club/controller/ClubUserApiController.java
@@ -136,18 +136,16 @@ public class ClubUserApiController {
     /**
      * 전체 인기 동아리 목록 조회 API
      * "더보기" 클릭 시 보여지는 전체 인기 동아리 목록을 조회합니다.
-     * 카테고리, 분류, 모집여부 필터링과 함께 무한스크롤 또는 페이지네이션 제공됩니다.
+     * "인기도순", "멤버많은순", "최신등록순" 정렬과 무한스크롤을 지원합니다.
      *
-     * @param category 동아리 카테고리 필터 (봉사, 예술, 문화 등) - 선택사항
-     * @param type 동아리 분류 필터 (중앙, 연합, 학과) - 선택사항
-     * @param recruiting 모집 여부 필터 (true: 모집중, false: 모집마감) - 선택사항
      * @param size 페이지 크기 (기본값: 20)
      * @param cursor 무한스크롤 커서 (첫 요청시 생략)
+     * @param sort 정렬 방식 (popular : 인기도순, member_count : 멤버많은 순, latest : 최신등록 순) - 기본값 : popular
      * @return 멤버수 기준으로 정렬된 인기 동아리 목록
      * */
     @Operation(
             summary = "전체 인기 동아리 목록 조회",
-            description = "멤버수가 많은 순으로 전체 인기 동아리를 조회합니다. 필터링 및 무한스크롤 지원."
+            description = "전체 인기 동아리를 조회합니다. '인기도순', '멤버많은순', '최신등록순' 정렬 및 무한스크롤을 지원합니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
@@ -155,22 +153,16 @@ public class ClubUserApiController {
     })
     @GetMapping("/popular")
     public ResponseEntity<ClubListResponse> getPopularClubs(
-            @Parameter(description = "카테고리 (스포츠, 예술, 문화 등)")
-            @RequestParam(required = false) ClubCategory category,
-
-            @Parameter(description = "분류 (중앙, 연합, 과 동아리)")
-            @RequestParam(required = false) ClubType type,
-
-            @Parameter(description = "모집여부 (true : 모집중, false : 모집마감)")
-            @RequestParam(required = false) Boolean recruiting,
-
             @Parameter(description = "조회 개수 (기본 20개)")
             @RequestParam(defaultValue = "20") int size,
 
             @Parameter(description = "무한스크롤 커서 (첫 요청시 생략)")
-            @RequestParam(required = false) String cursor) {
+            @RequestParam(required = false) String cursor,
 
-        ClubListServiceResponse response = clubUserService.getPopularClubsWithFilters(category, type, recruiting, size, cursor);
+            @Parameter(description = "정렬 (popular: 인기도순, member_count: 멤버많은순, latest: 최신등록순)")
+            @RequestParam(defaultValue = "popular") String sort) {
+
+        ClubListServiceResponse response = clubUserService.getPopularClubsWithFilters(size, cursor, sort);
 
         return ResponseEntity.ok(ClubListResponse.from(response));
     }

--- a/src/main/java/org/project/ttokttok/domain/club/repository/ClubCustomRepository.java
+++ b/src/main/java/org/project/ttokttok/domain/club/repository/ClubCustomRepository.java
@@ -28,11 +28,9 @@ public interface ClubCustomRepository {
     List<ClubCardQueryResponse> getAllPopularClubs(String userEmail, double minScore);
 
     List<ClubCardQueryResponse> getPopularClubsWithFilters(
-            ClubCategory category,
-            ClubType type,
-            Boolean recruiting,
             int size,
             String cursor,
+            String sort,
             String userEmail,
             double minScore
     );


### PR DESCRIPTION
## ✨ 작업 내용
- 해당 API 의 불필요한 필터 로직을 제거
- 요구사항에 맞춘 세 가지 동적 정렬 기능('인기도순', '멤버많은순', '최신등록순')을 추가
- API 명세 최신화

---

## 🔍 관련 이슈
- 해결한 이슈 번호: #36 
- 관련된 이슈 번호 (선택): #36 

---

## ✅ 체크리스트
- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요?
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항
> API 테스트 도구 (Postman, Swagger 등)을 통해 엔드포인트 확인 후 동작 확인 가능
인기도순 (기본값): GET /api/clubs/popular?sort=popular
멤버많은순: GET /api/clubs/popular?sort=member_count
최신등록순: GET /api/clubs/popular?sort=latest
