### PR TITLE
CORS 설정 및 application-prod.yml 추가 설정 (fix/#62 -> develop)

### DIFF
--- a/src/main/java/org/project/ttokttok/global/config/WebMvcConfig.java
+++ b/src/main/java/org/project/ttokttok/global/config/WebMvcConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.project.ttokttok.global.annotationresolver.auth.AuthUserInfoResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
@@ -20,5 +21,20 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(authUserInfoResolver);
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**") // 모든 경로에 대해 CORS 허용
+                .allowedOrigins(
+                    "http://localhost:3000", // 개발 환경 프론트엔드 URL (필요시 추가)
+                    "http://localhost:8080", // 로컬 Swagger UI URL (필요시 추가)
+                    "https://www.hearmeout.kr", // 실제 서비스 도메인
+                    "https://hearmeout.kr"      // www 없는 버전도 추가
+                )
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS") // 허용할 HTTP 메서드
+                .allowedHeaders("*") // 모든 헤더 허용
+                .allowCredentials(true) // 자격 증명(쿠키, 인증 헤더 등) 허용
+                .maxAge(3600); // pre-flight 요청 캐싱 시간
     }
 }


### PR DESCRIPTION
## ✨ 작업 내용
- 현재 배포된 백엔드 애플리케이션ㄴ의 Swagger UI 에서 API 호출 시 `Failed to fetch` 오류가 발생하여 프론트엔드 개발의 난항 예상
- **`application-prod.yml` 설정 추가:**
   - `server.url`을 `https://www.hearmeout.kr`로 명시하여 백엔드 API의 기본 URL을 HTTPS로 설정했습니다.
   - `springdoc.swagger-ui.url`을 `https://www.hearmeout.kr/v3/api-docs`로 설정하여 Swagger UI가 API 정의를 HTTPS로 가져오도록 했습니다.
   - 이 두 설정은 Swagger UI가 API 요청을 보낼 때 HTTP 대신 HTTPS를 사용하도록 강제하여 Mixed Content 문제를 해결합니다.

---

## 🔍 관련 이슈
- 해결한 이슈 번호: #62 
- 관련된 이슈 번호 (선택): #62, #61 

---

## ✅ 체크리스트
- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요?
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항
> 해당 PR은 이전 PR 에서 진행된 운영 환경 더미 데이터 로더 활성 (`DummyDataLoader.java` 수정)와는 별개의 변경사항입니다. 해당 기능은 프론트엔드 테스트 기간 종료 후 비활성화하는 후속 작업이 필요합니다.
> 로컬 환경에서는 현재 문제가 없으므로 배포후 배포 환경에서 테스트를 간단히 한번 거친후 지켜봐야 할 것 같습니다.