### PR TITLE
빈 바디 응답 API 메시지 추가 (Develop->main)

### DIFF
--- a/src/main/java/org/project/ttokttok/domain/admin/controller/AdminAuthApiController.java
+++ b/src/main/java/org/project/ttokttok/domain/admin/controller/AdminAuthApiController.java
@@ -18,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.Duration;
+import java.util.Map;
 
 import static org.project.ttokttok.global.auth.jwt.TokenExpiry.ACCESS_TOKEN_EXPIRY_TIME;
 import static org.project.ttokttok.global.auth.jwt.TokenExpiry.REFRESH_TOKEN_EXPIRY_TIME;
@@ -61,7 +62,7 @@ public class AdminAuthApiController implements AdminAuthDocs {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(@AuthUserInfo String adminName) {
+    public ResponseEntity<Map<String, String>> logout(@AuthUserInfo String adminName) {
         adminAuthService.logout(adminName);
 
         // 두 쿠키 모두 만료시키기
@@ -70,11 +71,11 @@ public class AdminAuthApiController implements AdminAuthDocs {
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, expiredCookies[0].toString())
                 .header(HttpHeaders.SET_COOKIE, expiredCookies[1].toString())
-                .build();
+                .body(Map.of("message", "로그아웃이 완료되었습니다."));
     }
 
     @PostMapping("/re-issue")
-    public ResponseEntity<Void> reissue(
+    public ResponseEntity<Map<String, String>> reissue(
             @AuthUserInfo String adminName,
             @CookieValue(value = "ttref", required = false) String refreshToken) {
 
@@ -97,7 +98,7 @@ public class AdminAuthApiController implements AdminAuthDocs {
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, accessCookie.toString())
                 .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
-                .build();
+                .body(Map.of("message", "토큰이 재발급되었습니다."));
     }
 
     // todo: 추후 삭제 - 관리자 가입 메서드

--- a/src/main/java/org/project/ttokttok/domain/admin/controller/docs/AdminAuthDocs.java
+++ b/src/main/java/org/project/ttokttok/domain/admin/controller/docs/AdminAuthDocs.java
@@ -13,6 +13,8 @@ import org.project.ttokttok.global.exception.dto.ErrorResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 
+import java.util.Map;
+
 @Tag(name = "[관리자] 관리자 인증 API", description = "관리자 인증 / 인가 관련 API 입니다.")
 public interface AdminAuthDocs {
 
@@ -91,7 +93,7 @@ public interface AdminAuthDocs {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
-    ResponseEntity<Void> logout(
+    ResponseEntity<Map<String, String>> logout(
             @Parameter(description = "인증된 관리자 이름", hidden = true)
             String adminName
     );
@@ -125,7 +127,7 @@ public interface AdminAuthDocs {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
-    ResponseEntity<Void> reissue(
+    ResponseEntity<Map<String, String>> reissue(
             @Parameter(description = "인증된 관리자 이름", hidden = true)
             String adminName,
             @Parameter(description = "리프레시 토큰 (쿠키에서 자동 추출)")

--- a/src/main/java/org/project/ttokttok/domain/applicant/controller/ApplicantAdminApiController.java
+++ b/src/main/java/org/project/ttokttok/domain/applicant/controller/ApplicantAdminApiController.java
@@ -16,6 +16,8 @@ import org.project.ttokttok.global.annotation.auth.AuthUserInfo;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin/applies")
@@ -130,7 +132,7 @@ public class ApplicantAdminApiController implements ApplicantAdminDocs {
 
     // 지원자 상태 업데이트 - status 부분 리팩토링 필요
     @PatchMapping("/evaluations/{applicantId}")
-    public ResponseEntity<Void> updateApplicantEvaluation(@AuthUserInfo String username,
+    public ResponseEntity<Map<String, String>> updateApplicantEvaluation(@AuthUserInfo String username,
                                                           @PathVariable String applicantId,
                                                           @RequestBody Status status) {
 
@@ -143,7 +145,7 @@ public class ApplicantAdminApiController implements ApplicantAdminDocs {
         applicantAdminService.updateApplicantStatus(request);
 
         return ResponseEntity.ok()
-                .build();
+                .body(Map.of("message", "지원자 상태가 성공적으로 업데이트되었습니다."));
     }
 
     // 지원자 상태 최종 확정
@@ -164,9 +166,9 @@ public class ApplicantAdminApiController implements ApplicantAdminDocs {
     }
 
     @PostMapping("/{clubId}/send-email")
-    public ResponseEntity<Void> sendEmailToApplicants(@AuthUserInfo String username,
-                                                      @PathVariable String clubId,
-                                                      @Valid @RequestBody SendResultMailRequest request) {
+    public ResponseEntity<Map<String, String>> sendEmailToApplicants(@AuthUserInfo String username,
+                                                                     @PathVariable String clubId,
+                                                                     @Valid @RequestBody SendResultMailRequest request) {
 
         applicantAdminService.sendResultMailToApplicants(
                 request.toServiceRequest(),
@@ -175,6 +177,6 @@ public class ApplicantAdminApiController implements ApplicantAdminDocs {
         );
 
         return ResponseEntity.ok()
-                .build();
+                .body(Map.of("message", "이메일 전송이 완료되었습니다."));
     }
 }

--- a/src/main/java/org/project/ttokttok/domain/applicant/controller/docs/ApplicantAdminDocs.java
+++ b/src/main/java/org/project/ttokttok/domain/applicant/controller/docs/ApplicantAdminDocs.java
@@ -16,6 +16,8 @@ import org.project.ttokttok.domain.applicant.domain.enums.Status;
 import org.project.ttokttok.global.exception.dto.ErrorResponse;
 import org.springframework.http.ResponseEntity;
 
+import java.util.Map;
+
 @Tag(name = "[관리자] 지원자 관리 API", description = "관리자가 지원자를 조회, 평가, 상태 관리하는 API입니다.")
 public interface ApplicantAdminDocs {
 
@@ -289,7 +291,7 @@ public interface ApplicantAdminDocs {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
-    ResponseEntity<Void> updateApplicantEvaluation(
+    ResponseEntity<Map<String, String>> updateApplicantEvaluation(
             @Parameter(hidden = true) String username,
             @Parameter(description = "지원자 ID", example = "UUID") String applicantId,
             @Parameter(description = "변경할 상태", schema = @Schema(implementation = Status.class), example = "PASS") Status status
@@ -386,7 +388,7 @@ public interface ApplicantAdminDocs {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
-    ResponseEntity<Void> sendEmailToApplicants(
+    ResponseEntity<Map<String, String>> sendEmailToApplicants(
             @Parameter(hidden = true) String username,
             @Parameter(description = "동아리 ID", example = "UUID") String clubId,
             @Parameter(description = "이메일 발송 요청 정보") SendResultMailRequest request

--- a/src/main/java/org/project/ttokttok/domain/applyform/controller/ApplyFormAdminApiController.java
+++ b/src/main/java/org/project/ttokttok/domain/applyform/controller/ApplyFormAdminApiController.java
@@ -16,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -53,15 +54,15 @@ public class ApplyFormAdminApiController implements ApplyFormAdminDocs {
 
     // 지원 폼 수정하기
     @PatchMapping("/{formId}")
-    public ResponseEntity<Void> updateApplyForm(@AuthUserInfo String username,
-                                                @PathVariable String formId,
-                                                @RequestBody ApplyFormUpdateRequest request) {
+    public ResponseEntity<Map<String, String>> updateApplyForm(@AuthUserInfo String username,
+                                                               @PathVariable String formId,
+                                                               @RequestBody ApplyFormUpdateRequest request) {
         applyFormAdminService.updateApplyForm(
                 request.toServiceRequest(username, formId)
         );
 
         return ResponseEntity.ok()
-                .build();
+                .body(Map.of("message", "지원 폼이 성공적으로 수정되었습니다."));
     }
 
     // 이전에 만들어둔 지원 폼 질문 형태 받아오기

--- a/src/main/java/org/project/ttokttok/domain/applyform/controller/docs/ApplyFormAdminDocs.java
+++ b/src/main/java/org/project/ttokttok/domain/applyform/controller/docs/ApplyFormAdminDocs.java
@@ -17,6 +17,8 @@ import org.project.ttokttok.global.exception.dto.ErrorResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 
+import java.util.Map;
+
 @Tag(name = "[관리자] 지원폼 관리 API", description = "동아리 관리자용 지원폼 생성/수정/조회 API 입니다.")
 public interface ApplyFormAdminDocs {
 
@@ -173,7 +175,7 @@ public interface ApplyFormAdminDocs {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
-    ResponseEntity<Void> updateApplyForm(
+    ResponseEntity<Map<String, String>> updateApplyForm(
             @Parameter(description = "인증된 관리자 이름", hidden = true)
             String username,
             @Parameter(description = "지원폼 ID", required = true, example = "UUID")

--- a/src/main/java/org/project/ttokttok/domain/club/controller/ClubAdminApiController.java
+++ b/src/main/java/org/project/ttokttok/domain/club/controller/ClubAdminApiController.java
@@ -16,6 +16,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Map;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin/clubs")
@@ -26,14 +28,14 @@ public class ClubAdminApiController implements ClubAdminApiDocs {
     // 동아리 소개 수정 로직
     @PatchMapping(value = "/{clubId}/content",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<Void> updateClubContent(@AuthUserInfo String username,
+    public ResponseEntity<Map<String, String>> updateClubContent(@AuthUserInfo String username,
                                                     @PathVariable String clubId,
                                                     @Valid @RequestPart UpdateClubContentRequest request,
                                                     @RequestPart(required = false) MultipartFile profileImage) {
         clubAdminService.updateContent(username, request.toServiceRequest(clubId));
 
         return ResponseEntity.ok()
-                .build();
+                .body(Map.of("message", "동아리 소개가 수정되었습니다."));
     }
 
     @PostMapping(value = "/{clubId}/update-image",
@@ -69,12 +71,12 @@ public class ClubAdminApiController implements ClubAdminApiDocs {
 
     // 모집 마감, 재시작 토글 api
     @PatchMapping("/{clubId}/toggle-recruitment")
-    public ResponseEntity<Void> toggleRecruitment(@AuthUserInfo String username,
-                                                  @PathVariable String clubId) {
+    public ResponseEntity<Map<String, String>> toggleRecruitment(@AuthUserInfo String username,
+                                                                 @PathVariable String clubId) {
         clubAdminService.toggleRecruitment(username, clubId);
 
         return ResponseEntity.ok()
-                .build();
+                .body(Map.of("message", "동아리 모집 상태가 변경되었습니다."));
     }
 
     // 관리자 동아리 소개 조회 API

--- a/src/main/java/org/project/ttokttok/domain/club/controller/docs/ClubAdminApiDocs.java
+++ b/src/main/java/org/project/ttokttok/domain/club/controller/docs/ClubAdminApiDocs.java
@@ -19,6 +19,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Map;
+
 @Tag(name = "[관리자] 동아리 관련 API", description = "관리자 동아리 정보 관리용 API 입니다.")
 public interface ClubAdminApiDocs {
 
@@ -111,7 +113,7 @@ public interface ClubAdminApiDocs {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))
                     )
             })
-    ResponseEntity<Void> updateClubContent(
+    ResponseEntity<Map<String, String>> updateClubContent(
             @Parameter(
                     description = "인증된 사용자 정보",
                     hidden = true
@@ -323,7 +325,7 @@ public interface ClubAdminApiDocs {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
-    ResponseEntity<Void> toggleRecruitment(
+    ResponseEntity<Map<String, String>> toggleRecruitment(
             @Parameter(description = "인증된 사용자 정보", hidden = true)
             String username,
             @Parameter(description = "동아리 ID", required = true, example = "UUID")

--- a/src/main/java/org/project/ttokttok/domain/clubMember/controller/ClubMemberApiController.java
+++ b/src/main/java/org/project/ttokttok/domain/clubMember/controller/ClubMemberApiController.java
@@ -28,6 +28,7 @@ import org.springframework.web.bind.annotation.*;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -65,10 +66,10 @@ public class ClubMemberApiController implements ClubMemberDocs {
     }
 
     @PatchMapping("/{clubId}/{memberId}/role")
-    public ResponseEntity<Void> changeRole(@AuthUserInfo String username,
-                                           @PathVariable String clubId,
-                                           @PathVariable String memberId,
-                                           @Valid @RequestBody RoleChangeRequest request) {
+    public ResponseEntity<Map<String, String>> changeRole(@AuthUserInfo String username,
+                                                          @PathVariable String clubId,
+                                                          @PathVariable String memberId,
+                                                          @Valid @RequestBody RoleChangeRequest request) {
 
         ChangeRoleServiceRequest serviceRequest = ChangeRoleServiceRequest.of(
                 username,
@@ -84,9 +85,9 @@ public class ClubMemberApiController implements ClubMemberDocs {
     }
 
     @DeleteMapping("/{clubId}/{memberId}")
-    public ResponseEntity<Void> deleteMember(@AuthUserInfo String username,
-                                             @PathVariable String clubId,
-                                             @PathVariable String memberId) {
+    public ResponseEntity<Map<String, String>> deleteMember(@AuthUserInfo String username,
+                                                            @PathVariable String clubId,
+                                                            @PathVariable String memberId) {
 
         DeleteMemberServiceRequest serviceRequest = DeleteMemberServiceRequest.of(
                 username,
@@ -136,8 +137,8 @@ public class ClubMemberApiController implements ClubMemberDocs {
 
     @PostMapping("/{clubId}/add")
     public ResponseEntity<ClubMemberCreateResponse> addMembers(@AuthUserInfo String username,
-                                             @PathVariable String clubId,
-                                             @Valid @RequestBody ClubMemberAddRequest request) {
+                                                               @PathVariable String clubId,
+                                                               @Valid @RequestBody ClubMemberAddRequest request) {
         String clubMemberId = clubMemberService.addMember(
                 username, clubId, request.toServiceRequest()
         );

--- a/src/main/java/org/project/ttokttok/domain/clubMember/controller/docs/ClubMemberDocs.java
+++ b/src/main/java/org/project/ttokttok/domain/clubMember/controller/docs/ClubMemberDocs.java
@@ -21,6 +21,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.Map;
+
 @Tag(name = "[관리자] 동아리 부원 관리 API", description = "동아리 관리자용 부원 관리 API 입니다.")
 public interface ClubMemberDocs {
 
@@ -169,7 +171,7 @@ public interface ClubMemberDocs {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
-    ResponseEntity<Void> deleteMember(
+    ResponseEntity<Map<String, String>> deleteMember(
             @Parameter(description = "인증된 관리자 이름", hidden = true)
             @AuthUserInfo String username,
             @Parameter(description = "동아리 ID", required = true, example = "UUID")
@@ -226,7 +228,7 @@ public interface ClubMemberDocs {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
-    ResponseEntity<Void> changeRole(
+    ResponseEntity<Map<String, String>> changeRole(
             @Parameter(description = "인증된 관리자 이름", hidden = true)
             @AuthUserInfo String username,
             @Parameter(description = "동아리 ID", required = true, example = "UUID")

--- a/src/main/java/org/project/ttokttok/domain/memo/controller/MemoApiController.java
+++ b/src/main/java/org/project/ttokttok/domain/memo/controller/MemoApiController.java
@@ -13,6 +13,8 @@ import org.project.ttokttok.global.annotation.auth.AuthUserInfo;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin/applies/{applicantId}/memos")
@@ -23,8 +25,8 @@ public class MemoApiController implements MemoDocs {
     // 메모 생성
     @PostMapping
     public ResponseEntity<MemoCreateResponse> createMemo(@AuthUserInfo String username,
-                                             @PathVariable String applicantId,
-                                             @Valid @RequestBody MemoRequest request) {
+                                                         @PathVariable String applicantId,
+                                                         @Valid @RequestBody MemoRequest request) {
 
         var serviceRequest = CreateMemoServiceRequest.of(
                 username,
@@ -42,10 +44,10 @@ public class MemoApiController implements MemoDocs {
 
     // 메모 수정
     @PatchMapping("/{memoId}")
-    public ResponseEntity<Void> updateMemo(@AuthUserInfo String username,
-                                             @PathVariable String applicantId,
-                                             @PathVariable String memoId,
-                                             @Valid @RequestBody MemoRequest request) {
+    public ResponseEntity<Map<String, String>> updateMemo(@AuthUserInfo String username,
+                                                          @PathVariable String applicantId,
+                                                          @PathVariable String memoId,
+                                                          @Valid @RequestBody MemoRequest request) {
 
         var serviceRequest = UpdateMemoServiceRequest.of(
                 memoId,
@@ -57,14 +59,14 @@ public class MemoApiController implements MemoDocs {
         memoService.updateMemo(serviceRequest);
 
         return ResponseEntity.ok()
-                .build();
+                .body(Map.of("message", "메모 수정에 성공했습니다."));
     }
 
     // 메모 삭제
     @DeleteMapping("/{memoId}")
-    public ResponseEntity<Void> deleteMemo(@AuthUserInfo String username,
-                                             @PathVariable String applicantId,
-                                             @PathVariable String memoId) {
+    public ResponseEntity<Map<String, String>> deleteMemo(@AuthUserInfo String username,
+                                                          @PathVariable String applicantId,
+                                                          @PathVariable String memoId) {
 
         var serviceRequest = DeleteMemoServiceRequest.of(
                 memoId,
@@ -75,6 +77,6 @@ public class MemoApiController implements MemoDocs {
         memoService.deleteMemo(serviceRequest);
 
         return ResponseEntity.ok()
-                .build();
+                .body(Map.of("message", "메모 삭제에 성공했습니다."));
     }
 }

--- a/src/main/java/org/project/ttokttok/domain/memo/controller/docs/MemoDocs.java
+++ b/src/main/java/org/project/ttokttok/domain/memo/controller/docs/MemoDocs.java
@@ -14,6 +14,8 @@ import org.project.ttokttok.global.exception.dto.ErrorResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 
+import java.util.Map;
+
 @Tag(name = "[관리자] 메모 API", description = "지원자 별 메모 관리용 API 입니다.")
 public interface MemoDocs {
 
@@ -113,7 +115,7 @@ public interface MemoDocs {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
-    ResponseEntity<Void> updateMemo(
+    ResponseEntity<Map<String, String>> updateMemo(
             @Parameter(description = "인증된 관리자 이름", hidden = true)
             String username,
             @Parameter(description = "지원자 ID", required = true, example = "UUID")
@@ -161,7 +163,7 @@ public interface MemoDocs {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
-    ResponseEntity<Void> deleteMemo(
+    ResponseEntity<Map<String, String>> deleteMemo(
             @Parameter(description = "인증된 관리자 이름", hidden = true)
             @AuthUserInfo String username,
             @Parameter(description = "지원자 ID", required = true, example = "UUID")

--- a/src/main/java/org/project/ttokttok/global/auth/security/SecurityWhiteList.java
+++ b/src/main/java/org/project/ttokttok/global/auth/security/SecurityWhiteList.java
@@ -20,7 +20,7 @@ public enum SecurityWhiteList {
             "/api/user/auth/reset-password",
             "/api/admin/auth/reissue",
             "/health",
-            "/api/applies", // 테스트용
+            "/api/user/applies", // 테스트용
             "/api/admin/auth/join" // todo: 추후 삭제 예정 - 관리자 가입 API 엔드포인트
     }),
 

--- a/src/main/java/org/project/ttokttok/infrastructure/health/HealthCheckController.java
+++ b/src/main/java/org/project/ttokttok/infrastructure/health/HealthCheckController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Map;
+
 @Tag(name = "Health Check API", description = "API 서버의 헬스 체크를 위한 엔드포인트입니다.")
 @RestController
 @RequestMapping("/health")
@@ -27,9 +29,9 @@ public class HealthCheckController {
             )
     })
     @GetMapping
-    public ResponseEntity<String> healthCheck() {
+    public ResponseEntity<Map<String, String>> healthCheck() {
         // 헬스 체크를 위한 간단한 응답
         return ResponseEntity.ok()
-                .body("Healthy");
+                .body(Map.of("status", "Healthy"));
     }
 }


### PR DESCRIPTION
## 🚀 Release PR: develop → main -> (PR 제목)

**릴리즈 브랜치(`main`)로 병합하는 PR입니다. 반드시 아래 내용을 확인해주세요.**

---

## 📦 릴리즈 내용 요약
- 빈 바디로 응답하던 api들 json 양식 메시지 포함하여 반환하도록 수정

---

## 🔍 관련 이슈
- 총 포함된 이슈: #95

---

## ✅ 배포 전 체크리스트
- [x] 모든 기능 브랜치가 `develop`에 병합되었나요?
- [x] Swagger 문서 최신 상태인가?
- [x] `.env` 설정 등 환경 변수 확인 완료되었는가?
- [x] 배포 서버에서 사전 테스트 완료하였는가?
- [x] 릴리즈 버전 태그를 지정했는가? (ex. `v1.2.0`)

---

## ⚠️ 기타 주의사항
> 특별한 롤백 요건, 배포 순서, 환경 설정 변경 등 주의사항을 작성해주세요.
