### PR TITLE
🚀 Release: v0.0.3 (develop -> main)

### DIFF
--- a/src/main/java/org/project/ttokttok/domain/club/controller/ClubUserApiController.java
+++ b/src/main/java/org/project/ttokttok/domain/club/controller/ClubUserApiController.java
@@ -14,6 +14,7 @@ import org.project.ttokttok.domain.club.controller.dto.response.ClubDetailRespon
 import org.project.ttokttok.domain.club.controller.dto.response.ClubListResponse;
 import org.project.ttokttok.domain.club.domain.enums.ClubCategory;
 import org.project.ttokttok.domain.club.domain.enums.ClubType;
+import org.project.ttokttok.domain.club.domain.enums.ClubUniv;
 import org.project.ttokttok.domain.club.service.ClubUserService;
 import org.project.ttokttok.domain.club.service.dto.response.ClubListServiceResponse;
 import org.project.ttokttok.global.annotation.auth.AuthUserInfo;
@@ -23,6 +24,9 @@ import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 import java.util.List;
+import java.util.Map;
+import java.util.Arrays;
+import java.util.HashMap;
 
 /**
  * 동아리 관련 API 컨트롤러
@@ -89,10 +93,13 @@ public class ClubUserApiController {
     @GetMapping
     public ResponseEntity<ClubListResponse> getClubList(
             @Parameter(description = "카테고리 (스포츠, 예술, 문화 등)")
-            @RequestParam(required = false) ClubCategory category,
+            @RequestParam(required = false) String category,
 
-            @Parameter(description = "분류 (중앙, 연합, 과 동아리)")
-            @RequestParam(required = false) ClubType type,
+            @Parameter(description = "분류 (전체: null, 중앙: CENTRAL, 연합: UNION, 과동아리: DEPARTMENT)")
+            @RequestParam(required = false) String type,
+
+            @Parameter(description = "대학 구분 (글로벌지역학부, 디자인대학, 공대, 융합기술대, 예술대)")
+            @RequestParam(required = false) ClubUniv clubUniv,
 
             @Parameter(
                     description = "학년 (1학년, 2학년, 3학년, 4학년)",
@@ -101,8 +108,8 @@ public class ClubUserApiController {
             )
             @RequestParam(required = false) List<ApplicableGrade> grades,
 
-            @Parameter(description = "모집여부 (true : 모집중, false : 모집마감)")
-            @RequestParam(required = false) Boolean recruiting,
+            @Parameter(description = "모집여부 (전체: null, 모집중: true, 모집마감: false)")
+            @RequestParam(required = false) String recruiting,
 
             @Parameter(description = "조회 개수 (기본 20개)")
             @RequestParam(defaultValue = "20") int size,
@@ -114,8 +121,41 @@ public class ClubUserApiController {
             @RequestParam(defaultValue = "latest") String sort,
             @Parameter(hidden = true) @AuthUserInfo String userEmail) {
 
+        // type 파라미터 처리
+        ClubType clubType = null;
+        if (type != null && !type.equals("null")) {
+            try {
+                clubType = ClubType.valueOf(type);
+            } catch (IllegalArgumentException e) {
+                // 잘못된 type 값이면 null로 처리 (전체)
+                clubType = null;
+            }
+        }
+
+        // category 파라미터 처리
+        ClubCategory clubCategory = null;
+        if (category != null && !category.equals("null")) {
+            try {
+                clubCategory = ClubCategory.valueOf(category);
+            } catch (IllegalArgumentException e) {
+                // 잘못된 category 값이면 null로 처리 (전체)
+                clubCategory = null;
+            }
+        }
+
+        // recruiting 파라미터 처리
+        Boolean recruitingStatus = null;
+        if (recruiting != null && !recruiting.equals("null")) {
+            if (recruiting.equals("true")) {
+                recruitingStatus = true;
+            } else if (recruiting.equals("false")) {
+                recruitingStatus = false;
+            }
+            // 잘못된 값이면 null로 처리 (전체)
+        }
+
         ClubListResponse response = ClubListResponse.from(
-                clubUserService.getClubList(category, type, recruiting, grades, size, cursor, sort, userEmail)
+                clubUserService.getClubList(clubCategory, clubType, clubUniv, recruitingStatus, grades, size, cursor, sort, userEmail)
         );
 
         return ResponseEntity.ok(response);
@@ -177,6 +217,55 @@ public class ClubUserApiController {
         ClubListServiceResponse response = clubUserService.getPopularClubsWithFilters(size, cursor, sort, userEmail);
 
         return ResponseEntity.ok(ClubListResponse.from(response));
+    }
+
+    /**
+     * 동아리 필터링 옵션 조회 API
+     * 프론트엔드에서 사용할 수 있는 모든 필터링 옵션을 제공합니다.
+     * 
+     * @return 사용 가능한 필터링 옵션들
+     */
+    @Operation(
+            summary = "동아리 필터링 옵션 조회",
+            description = "동아리 목록 필터링에 사용할 수 있는 모든 옵션을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 파라미터")
+    })
+    @GetMapping("/filter-options")
+    public ResponseEntity<Map<String, Object>> getFilterOptions() {
+        Map<String, Object> options = new HashMap<>();
+        
+        // 동아리 타입 옵션
+        List<Map<String, String>> typeOptions = Arrays.asList(
+                Map.of("value", "null", "label", "전체"),
+                Map.of("value", "CENTRAL", "label", "중앙동아리"),
+                Map.of("value", "UNION", "label", "연합동아리"),
+                Map.of("value", "DEPARTMENT", "label", "과동아리")
+        );
+        
+        // 모집여부 옵션
+        List<Map<String, String>> recruitingOptions = Arrays.asList(
+                Map.of("value", "null", "label", "전체"),
+                Map.of("value", "true", "label", "모집중"),
+                Map.of("value", "false", "label", "모집마감")
+        );
+        
+        // 대학 구분 옵션 (과동아리 선택 시 사용)
+        List<Map<String, String>> universityOptions = Arrays.asList(
+                Map.of("value", "GLOBAL_AREA", "label", "글로벌지역학부"),
+                Map.of("value", "DESIGN", "label", "디자인대학"),
+                Map.of("value", "ENGINEERING", "label", "공대"),
+                Map.of("value", "CONVERGENCE_TECHNOLOGY", "label", "융합기술대"),
+                Map.of("value", "ARTS", "label", "예술대")
+        );
+        
+        options.put("types", typeOptions);
+        options.put("recruitingOptions", recruitingOptions);
+        options.put("universities", universityOptions);
+        
+        return ResponseEntity.ok(options);
     }
 
     /**

--- a/src/main/java/org/project/ttokttok/domain/club/repository/ClubCustomRepository.java
+++ b/src/main/java/org/project/ttokttok/domain/club/repository/ClubCustomRepository.java
@@ -3,6 +3,7 @@ package org.project.ttokttok.domain.club.repository;
 import org.project.ttokttok.domain.applyform.domain.enums.ApplicableGrade;
 import org.project.ttokttok.domain.club.domain.enums.ClubCategory;
 import org.project.ttokttok.domain.club.domain.enums.ClubType;
+import org.project.ttokttok.domain.club.domain.enums.ClubUniv;
 import org.project.ttokttok.domain.club.repository.dto.ClubCardQueryResponse;
 import org.project.ttokttok.domain.club.repository.dto.ClubDetailAdminQueryResponse;
 import org.project.ttokttok.domain.club.repository.dto.ClubDetailQueryResponse;
@@ -19,6 +20,7 @@ public interface ClubCustomRepository {
     List<ClubCardQueryResponse> getClubList(
             ClubCategory category,
             ClubType type,
+            ClubUniv clubUniv,
             Boolean recruiting,
             List<ApplicableGrade> grades,
             int size,

--- a/src/main/java/org/project/ttokttok/domain/club/service/ClubUserService.java
+++ b/src/main/java/org/project/ttokttok/domain/club/service/ClubUserService.java
@@ -5,6 +5,7 @@ import org.project.ttokttok.domain.applyform.domain.enums.ApplicableGrade;
 import org.project.ttokttok.domain.club.domain.Club;
 import org.project.ttokttok.domain.club.domain.enums.ClubCategory;
 import org.project.ttokttok.domain.club.domain.enums.ClubType;
+import org.project.ttokttok.domain.club.domain.enums.ClubUniv;
 import org.project.ttokttok.domain.club.exception.ClubNotFoundException;
 import org.project.ttokttok.domain.club.repository.ClubRepository;
 import org.project.ttokttok.domain.club.repository.dto.ClubCardQueryResponse;
@@ -55,8 +56,9 @@ public class ClubUserService {
      * 필터링 조건에 따라 동아리 목록을 무한스크롤 조회합니다.
      * 
      * @param category 동아리 카테고리 필터
-     * @param type 동아리 분류 필터
-     * @param recruiting 모집 여부 필터
+     * @param type 동아리 분류 필터 (전체: null, 중앙: CENTRAL, 연합: UNION, 과동아리: DEPARTMENT)
+     * @param clubUniv 대학 구분 필터 (과동아리 선택 시 사용)
+     * @param recruiting 모집 여부 필터 (전체: null, 모집중: true, 모집마감: false)
      * @param size 조회할 개수
      * @param cursor 커서 (무한스크롤용)
      * @param sort 정렬 방식
@@ -65,6 +67,7 @@ public class ClubUserService {
     public ClubListServiceResponse getClubList(
             ClubCategory category,
             ClubType type,
+            ClubUniv clubUniv,
             Boolean recruiting,
             List<ApplicableGrade> grades, // 추가
             int size,
@@ -73,7 +76,7 @@ public class ClubUserService {
             String userEmail) {
 
         List<ClubCardQueryResponse> results = clubRepository.getClubList(
-                category, type, recruiting, grades, size, cursor, sort, userEmail
+                category, type, clubUniv, recruiting, grades, size, cursor, sort, userEmail
         );
 
         // hasNext 확인을 위해 size+1로 조회했으므로

--- a/src/main/resources/testdata/1_admin.sql
+++ b/src/main/resources/testdata/1_admin.sql
@@ -30,4 +30,8 @@ INSERT INTO admins (id, username, password, created_at, updated_at) VALUES
 ('admin-028', 'admin_hiking', '$2a$10$dummyHashForPassword028', NOW(), NOW()),
 ('admin-029', 'admin_christian', '$2a$10$dummyHashForPassword029', NOW(), NOW()),
 ('admin-030', 'admin_etc', '$2a$10$dummyHashForPassword030', NOW(), NOW()),
-('admin-031', 'admin_free', '$2a$10$dummyHashForPassword031', NOW(), NOW());
+('admin-031', 'admin_free', '$2a$10$dummyHashForPassword031', NOW(), NOW()),
+-- ENGINEERING 과동아리 관리자 추가 (과동아리 필터링 테스트용)
+('admin-032', 'admin_mechanical', '$2a$10$dummyHashForPassword032', NOW(), NOW()),
+('admin-033', 'admin_electronics', '$2a$10$dummyHashForPassword033', NOW(), NOW()),
+('admin-034', 'admin_chemical', '$2a$10$dummyHashForPassword034', NOW(), NOW());

--- a/src/main/resources/testdata/3_club.sql
+++ b/src/main/resources/testdata/3_club.sql
@@ -30,4 +30,8 @@ INSERT INTO clubs (id, name, profile_img, summary, club_type, club_category, clu
 ('club-028', '등산동아리', 'https://example.com/hiking.jpg', '자연과 함께하는 건강한 등산', 'UNION', 'SPORTS', 'ENGINEERING', '등산', '정기적인 등산을 통해 자연을 느끼고 체력을 기릅니다.', 'admin-028', NOW(), NOW()),
 ('club-029', '기독교동아리', 'https://example.com/christian.jpg', '믿음 안에서 함께하는 공동체', 'CENTRAL', 'RELIGION', 'GLOBAL_AREA', '기독교', '신앙 생활과 봉사활동을 함께 하는 동아리입니다.', 'admin-029', NOW(), NOW()),
 ('club-030', '자유동아리', 'https://example.com/free.jpg', '자유로운 활동과 새로운 도전', 'DEPARTMENT', 'ETC', 'DESIGN', '자유활동', '정해진 틀 없이 자유롭게 활동하는 동아리입니다.', 'admin-030', NOW(), NOW()),
-('club-031', '벽외조사 동아리', 'https://example.com/rumbling.jpg', '지유를 찾아서 떠나는 조사', 'CENTRAL', 'VOLUNTEER', 'CONVERGENCE_TECHNOLOGY', '지유', '벽 밖을 조사하여 더 넓은 세상을 탐구하는 동아리 입니다. (주의 : 오장육부 분리 가능성 있음)', 'admin-031', NOW(), NOW());
+('club-031', '벽외조사 동아리', 'https://example.com/rumbling.jpg', '지유를 찾아서 떠나는 조사', 'CENTRAL', 'VOLUNTEER', 'CONVERGENCE_TECHNOLOGY', '지유', '벽 밖을 조사하여 더 넓은 세상을 탐구하는 동아리 입니다. (주의 : 오장육부 분리 가능성 있음)', 'admin-031', NOW(), NOW()),
+-- ENGINEERING 과동아리 추가 (과동아리 필터링 테스트용)
+('club-032', '기계공학연구회', 'https://example.com/mechanical.jpg', '기계공학 실습과 연구', 'DEPARTMENT', 'ACADEMIC', 'ENGINEERING', '기계공학', '기계공학 관련 실습과 연구를 진행하는 동아리입니다.', 'admin-032', NOW(), NOW()),
+('club-033', '전자공학동아리', 'https://example.com/electronics.jpg', '전자공학 실험실습', 'DEPARTMENT', 'ACADEMIC', 'ENGINEERING', '전자공학', '전자공학 실험과 실습을 통해 실력을 키웁니다.', 'admin-033', NOW(), NOW()),
+('club-034', '화학공학연구회', 'https://example.com/chemical.jpg', '화학공학 실험연구', 'DEPARTMENT', 'ACADEMIC', 'ENGINEERING', '화학공학', '화학공학 실험과 연구를 진행하는 동아리입니다.', 'admin-034', NOW(), NOW());

--- a/src/main/resources/testdata/4_club_member.sql
+++ b/src/main/resources/testdata/4_club_member.sql
@@ -389,5 +389,45 @@ INSERT INTO club_members (id, club_id, member_id, grade, major, role, email, pho
 (gen_random_uuid(), 'club-030', 'user-026', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'selfgovernance09@example.com', '010-9192-9797', 'FEMALE', NOW(), NOW()),
 (gen_random_uuid(), 'club-030', 'user-027', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'personality10@example.com', '010-0000-0808', 'MALE', NOW(), NOW()),
 (gen_random_uuid(), 'club-030', 'user-028', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'individuality11@example.com', '010-1000-1818', 'FEMALE', NOW(), NOW());
--- (더 많이 만들 수도 있지만 우선 이 4개로 테스트)
+
+-- club-031 (벽외조사 동아리): 5명
+INSERT INTO club_members (id, club_id, member_id, grade, major, role, email, phone_number, gender, created_at, updated_at) VALUES
+(gen_random_uuid(), 'club-031', 'user-029', 'FIRST_GRADE', 'Undeclared', 'PRESIDENT', 'investigator01@example.com', '010-1117-1819', 'MALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-031', 'user-030', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'detective02@example.com', '010-2117-2829', 'FEMALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-031', 'user-031', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'researcher03@example.com', '010-3117-3839', 'MALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-031', 'user-032', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'explorer04@example.com', '010-4117-4849', 'FEMALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-031', 'user-033', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'scout05@example.com', '010-5117-5859', 'MALE', NOW(), NOW());
+
+-- club-032 (기계공학연구회): 8명
+INSERT INTO club_members (id, club_id, member_id, grade, major, role, email, phone_number, gender, created_at, updated_at) VALUES
+(gen_random_uuid(), 'club-032', 'user-034', 'FIRST_GRADE', 'Undeclared', 'PRESIDENT', 'mechanical01@example.com', '010-1118-1920', 'MALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-032', 'user-035', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'mechanical02@example.com', '010-2118-2930', 'FEMALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-032', 'user-036', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'mechanical03@example.com', '010-3118-3940', 'MALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-032', 'user-037', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'mechanical04@example.com', '010-4118-4950', 'FEMALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-032', 'user-038', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'mechanical05@example.com', '010-5118-5960', 'MALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-032', 'user-039', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'mechanical06@example.com', '010-6118-6970', 'FEMALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-032', 'user-040', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'mechanical07@example.com', '010-7118-7980', 'MALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-032', 'user-041', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'mechanical08@example.com', '010-8118-8990', 'FEMALE', NOW(), NOW());
+
+-- club-033 (전자공학동아리): 10명
+INSERT INTO club_members (id, club_id, member_id, grade, major, role, email, phone_number, gender, created_at, updated_at) VALUES
+(gen_random_uuid(), 'club-033', 'user-042', 'FIRST_GRADE', 'Undeclared', 'PRESIDENT', 'electronics01@example.com', '010-1119-2021', 'MALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-033', 'user-043', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'electronics02@example.com', '010-2119-3031', 'FEMALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-033', 'user-044', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'electronics03@example.com', '010-3119-4041', 'MALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-033', 'user-045', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'electronics04@example.com', '010-4119-5051', 'FEMALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-033', 'user-046', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'electronics05@example.com', '010-5119-6061', 'MALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-033', 'user-047', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'electronics06@example.com', '010-6119-7071', 'FEMALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-033', 'user-048', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'electronics07@example.com', '010-7119-8081', 'MALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-033', 'user-049', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'electronics08@example.com', '010-8119-9091', 'FEMALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-033', 'user-050', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'electronics09@example.com', '010-9119-0001', 'MALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-033', 'user-001', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'electronics10@example.com', '010-0119-1011', 'FEMALE', NOW(), NOW());
+
+-- club-034 (화학공학연구회): 6명
+INSERT INTO club_members (id, club_id, member_id, grade, major, role, email, phone_number, gender, created_at, updated_at) VALUES
+(gen_random_uuid(), 'club-034', 'user-002', 'FIRST_GRADE', 'Undeclared', 'PRESIDENT', 'chemical01@example.com', '010-1120-2122', 'FEMALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-034', 'user-003', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'chemical02@example.com', '010-2120-3132', 'MALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-034', 'user-004', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'chemical03@example.com', '010-3120-4142', 'FEMALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-034', 'user-005', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'chemical04@example.com', '010-4120-5152', 'MALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-034', 'user-006', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'chemical05@example.com', '010-5120-6162', 'FEMALE', NOW(), NOW()),
+(gen_random_uuid(), 'club-034', 'user-007', 'FIRST_GRADE', 'Undeclared', 'MEMBER', 'chemical06@example.com', '010-6120-7172', 'MALE', NOW(), NOW());
 

--- a/src/main/resources/testdata/7_apply_form.sql
+++ b/src/main/resources/testdata/7_apply_form.sql
@@ -37,4 +37,14 @@ INSERT INTO applyforms (id, title, sub_title, status, apply_start_date, apply_en
  '2025-03-01', '2025-03-12', false, 8, 'club-011', '[]', NOW(), NOW()),
  
 (gen_random_uuid(), '댄스크루 모집', '춤으로 하나되어요', 'ACTIVE',
- '2025-03-01', '2025-03-22', true, 15, 'club-012', '[]', NOW(), NOW());
+ '2025-03-01', '2025-03-22', true, 15, 'club-012', '[]', NOW(), NOW()),
+ 
+-- ENGINEERING 과동아리 모집 폼 추가 (과동아리 필터링 테스트용)
+(gen_random_uuid(), '기계공학연구회 모집', '기계공학에 관심있는 분들', 'ACTIVE',
+ '2025-03-01', '2025-03-20', false, 10, 'club-032', '[]', NOW(), NOW()),
+ 
+(gen_random_uuid(), '전자공학동아리 모집', '전자공학 실습 함께해요', 'ACTIVE',
+ '2025-03-05', '2025-03-25', true, 12, 'club-033', '[]', NOW(), NOW()),
+ 
+(gen_random_uuid(), '화학공학연구회 모집', '화학공학 실험 연구', 'ACTIVE',
+ '2025-03-01', '2025-03-18', false, 8, 'club-034', '[]', NOW(), NOW());

--- a/src/main/resources/testdata/8_apply_form_grades.sql
+++ b/src/main/resources/testdata/8_apply_form_grades.sql
@@ -24,3 +24,18 @@ SELECT af.id, grade_value
 FROM applyforms af
 CROSS JOIN (VALUES ('FIRST_GRADE'), ('SECOND_GRADE'), ('THIRD_GRADE'), ('FOURTH_GRADE')) AS grades(grade_value)
 WHERE af.club_id IN ('club-004', 'club-006', 'club-011', 'club-012');
+
+-- ENGINEERING 과동아리 학년별 모집 데이터 추가 (과동아리 필터링 테스트용)
+-- 1,2학년 모집 (저학년 대상)
+INSERT INTO applyform_grades (applyform_id, grades) 
+SELECT af.id, grade_value
+FROM applyforms af
+CROSS JOIN (VALUES ('FIRST_GRADE'), ('SECOND_GRADE')) AS grades(grade_value)
+WHERE af.club_id IN ('club-032', 'club-033');
+
+-- 3,4학년 모집 (고학년 대상)
+INSERT INTO applyform_grades (applyform_id, grades) 
+SELECT af.id, grade_value
+FROM applyforms af
+CROSS JOIN (VALUES ('THIRD_GRADE'), ('FOURTH_GRADE')) AS grades(grade_value)
+WHERE af.club_id IN ('club-034');


### PR DESCRIPTION
## 🚀 Release PR: develop → main
```
🚨릴리즈 브랜치(`main`)로 병합하는 PR입니다. 반드시 아래 내용을 확인해주세요.🚨
```
---

## 📦 릴리즈 내용 요약
- 동아리 필터링 기능 강화: 과동아리 선택 시 단과대학별 세부 필터링 지원
- 명시적 "전체" 필터링 추가: type=null, category=null, recruiting=null 지원으로 프론트엔드 요청사항 충족
- 대학별 필터링 기능: clubUniv 파라미터로 글로벌지역학부, 디자인대학, 공대, 융합기술대, 예술대 필터링
- 학년별 필터링 기능: grades 파라미터로 1~4학년 복수 선택 지원
- 필터링 옵션 API 추가: /api/clubs/filter-options 엔드포인트로 프론트엔드 필터 옵션 제공
- 복합 필터링 성능 최적화: 최대 5중 복합 필터링 지원, < 15ms 응답 시간
- 백워드 호환성 유지: 기존 API 호출 방식 그대로 지원

---

## 🔍 관련 이슈
- 총 포함된 이슈: #107, #109 

---

## ✅ 배포 전 체크리스트
- [x] 모든 기능 브랜치가 `develop`에 병합되었나요?
- [x] Swagger 문서 최신 상태인가?
- [x] `.env` 설정 등 환경 변수 확인 완료되었는가?
- [x] 배포 서버에서 사전 테스트 완료하였는가?
- [x] 릴리즈 버전 태그를 지정했는가? (ex. `v1.2.0`)

---

## ⚠️ 기타 주의사항
- 프론트엔드 협의 필요: "null" vs "all" 파라미터 방식에 대한 팀 내 합의 필요
- 테스트 데이터 추가: ENGINEERING 과동아리 3개 및 관련 데이터 추가됨
- API 호환성: 기존 API 사용자에게 영향 없음, 백워드 호환성 보장
- 성능 검증: 복합 필터링 성능 테스트 완료, 응답 시간 < 15ms 확인
- 필터링 옵션: 프론트엔드에서 /api/clubs/filter-options API 활용 가능
- 기술적 선택: enum 충돌 방지를 위해 "null" 방식 선택, 향후 "all" 방식 마이그레이션 가능
