### PR TITLE
🚀 Release: v0.0.5 (develop -> main)

### DIFF
--- a/src/main/java/org/project/ttokttok/global/auth/jwt/TokenProperties.java
+++ b/src/main/java/org/project/ttokttok/global/auth/jwt/TokenProperties.java
@@ -6,10 +6,14 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum TokenProperties {
-    //토큰 관련 상슈
+    //토큰 관련 상수
     AUTH_HEADER("Authorization"),
     REFRESH_KEY("ttref"),
-    ACCESS_TOKEN_COOKIE("ttac"); // 액세스 토큰 쿠키 이름 추가
+    ACCESS_TOKEN_COOKIE("ttac"), // 액세스 토큰 쿠키 이름 추가
+    
+    // 사용자용 쿠키 이름 (관리자와 구분하기 위해)
+    USER_REFRESH_KEY("ttref_user"),
+    USER_ACCESS_TOKEN_COOKIE("ttac_user");
 
     final String value;
 }

--- a/src/main/java/org/project/ttokttok/global/auth/jwt/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/org/project/ttokttok/global/auth/jwt/filter/TokenAuthenticationFilter.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import static org.project.ttokttok.global.auth.jwt.TokenProperties.ACCESS_TOKEN_COOKIE;
+import static org.project.ttokttok.global.auth.jwt.TokenProperties.USER_ACCESS_TOKEN_COOKIE;
 import static org.project.ttokttok.global.auth.security.SecurityWhiteList.ALLOW_URLS;
 import static org.project.ttokttok.global.auth.security.SecurityWhiteList.SWAGGER_URLS;
 
@@ -55,12 +56,24 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    // 쿠키에서 액세스 토큰 추출
+    // 쿠키에서 액세스 토큰 추출 (관리자용 또는 사용자용)
     private String getAccessTokenFromCookie(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
-            return Arrays.stream(cookies)
+            // 먼저 관리자용 쿠키 확인
+            String adminToken = Arrays.stream(cookies)
                     .filter(cookie -> ACCESS_TOKEN_COOKIE.getValue().equals(cookie.getName()))
+                    .map(Cookie::getValue)
+                    .findFirst()
+                    .orElse(null);
+            
+            if (adminToken != null) {
+                return adminToken;
+            }
+            
+            // 관리자용 쿠키가 없으면 사용자용 쿠키 확인
+            return Arrays.stream(cookies)
+                    .filter(cookie -> USER_ACCESS_TOKEN_COOKIE.getValue().equals(cookie.getName()))
                     .map(Cookie::getValue)
                     .findFirst()
                     .orElse(null);

--- a/src/main/java/org/project/ttokttok/global/config/SwaggerConfig.java
+++ b/src/main/java/org/project/ttokttok/global/config/SwaggerConfig.java
@@ -23,24 +23,40 @@ public class SwaggerConfig {
     public OpenAPI boardAPI() {
         Info info = createSwaggerInfo();
 
-        // 쿠키 기반 인증 설정
-        SecurityScheme cookieAuth = new SecurityScheme()
+        // 관리자용 쿠키 기반 인증 설정
+        SecurityScheme adminCookieAuth = new SecurityScheme()
                 .type(SecurityScheme.Type.APIKEY)
                 .in(SecurityScheme.In.COOKIE)
-                .name("ttac") // Access Token 쿠키
-                .description("로그인 후 자동으로 설정되는 액세스 토큰 쿠키");
+                .name("ttac") // 관리자 Access Token 쿠키
+                .description("관리자 로그인 후 자동으로 설정되는 액세스 토큰 쿠키");
 
-        // 리프레시 토큰 쿠키 설정
-        SecurityScheme refreshCookieAuth = new SecurityScheme()
+        // 관리자용 리프레시 토큰 쿠키 설정
+        SecurityScheme adminRefreshCookieAuth = new SecurityScheme()
                 .type(SecurityScheme.Type.APIKEY)
                 .in(SecurityScheme.In.COOKIE)
-                .name("ttref") // Refresh Token 쿠키
-                .description("로그인 후 자동으로 설정되는 리프레시 토큰 쿠키");
+                .name("ttref") // 관리자 Refresh Token 쿠키
+                .description("관리자 로그인 후 자동으로 설정되는 리프레시 토큰 쿠키");
+
+        // 사용자용 쿠키 기반 인증 설정
+        SecurityScheme userCookieAuth = new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.COOKIE)
+                .name("ttac_user") // 사용자 Access Token 쿠키
+                .description("사용자 로그인 후 자동으로 설정되는 액세스 토큰 쿠키");
+
+        // 사용자용 리프레시 토큰 쿠키 설정
+        SecurityScheme userRefreshCookieAuth = new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.COOKIE)
+                .name("ttref_user") // 사용자 Refresh Token 쿠키
+                .description("사용자 로그인 후 자동으로 설정되는 리프레시 토큰 쿠키");
 
         // 보안 요구사항 설정
         SecurityRequirement securityRequirement = new SecurityRequirement()
-                .addList("cookieAuth")
-                .addList("refreshCookieAuth");
+                .addList("adminCookieAuth")
+                .addList("adminRefreshCookieAuth")
+                .addList("userCookieAuth")
+                .addList("userRefreshCookieAuth");
 
         // 환경별 서버 설정
         List<Server> servers = createServersByEnvironment();
@@ -49,8 +65,10 @@ public class SwaggerConfig {
                 .info(info)
                 .servers(servers)
                 .components(new Components()
-                        .addSecuritySchemes("cookieAuth", cookieAuth)
-                        .addSecuritySchemes("refreshCookieAuth", refreshCookieAuth))
+                        .addSecuritySchemes("adminCookieAuth", adminCookieAuth)
+                        .addSecuritySchemes("adminRefreshCookieAuth", adminRefreshCookieAuth)
+                        .addSecuritySchemes("userCookieAuth", userCookieAuth)
+                        .addSecuritySchemes("userRefreshCookieAuth", userRefreshCookieAuth))
                 .security(Collections.singletonList(securityRequirement));
     }
 
@@ -87,16 +105,13 @@ public class SwaggerConfig {
                         ## 현재 환경: %s
                         
                         ## 인증 방법
-                        1. 로그인 API를 호출합니다
-                        2. 응답으로 받은 토큰을 브라우저 콘솔에서 쿠키로 설정합니다:
-                        
-                        ```javascript
-                        // 로그인 응답에서 토큰 복사 후 실행
-                        document.cookie = "ttac=액세스토큰; path=/; max-age=900; SameSite=Lax";
-                        document.cookie = "ttref=리프레시토큰; path=/; max-age=604800; SameSite=Lax";
-                        ```
-                        
+                        1. 로그인 API를 호출합니다 (관리자: `/api/admin/auth/login`, 사용자: `/api/user/auth/login`)
+                        2. 응답으로 자동으로 쿠키가 설정됩니다:
+                           - 관리자: `ttac` (액세스 토큰), `ttref` (리프레시 토큰)
+                           - 사용자: `ttac_user` (액세스 토큰), `ttref_user` (리프레시 토큰)
                         3. 이후 API 호출 시 자동으로 쿠키가 전송됩니다
+                        
+                        **참고**: 쿠키는 httpOnly로 설정되어 있어 JavaScript로 직접 접근할 수 없습니다.
                         
                         ## 서버 전환
                         - 개발 환경: Local Development Server 사용 권장

--- a/src/main/java/org/project/ttokttok/global/util/CookieUtil.java
+++ b/src/main/java/org/project/ttokttok/global/util/CookieUtil.java
@@ -8,6 +8,8 @@ import java.time.Duration;
 
 import static org.project.ttokttok.global.auth.jwt.TokenProperties.ACCESS_TOKEN_COOKIE;
 import static org.project.ttokttok.global.auth.jwt.TokenProperties.REFRESH_KEY;
+import static org.project.ttokttok.global.auth.jwt.TokenProperties.USER_ACCESS_TOKEN_COOKIE;
+import static org.project.ttokttok.global.auth.jwt.TokenProperties.USER_REFRESH_KEY;
 
 @Component
 public class CookieUtil {
@@ -41,10 +43,18 @@ public class CookieUtil {
                 .build();
     }
 
-    // 액세스 토큰과 리프레시 토큰을 모두 만료시키는 메서드
+    // 액세스 토큰과 리프레시 토큰을 모두 만료시키는 메서드 (관리자용)
     public ResponseCookie[] expireBothTokenCookies() {
         ResponseCookie expiredAccessCookie = expireResponseCookie(ACCESS_TOKEN_COOKIE.getValue());
         ResponseCookie expiredRefreshCookie = expireResponseCookie(REFRESH_KEY.getValue());
+
+        return new ResponseCookie[] { expiredAccessCookie, expiredRefreshCookie };
+    }
+
+    // 사용자용 쿠키를 모두 만료시키는 메서드
+    public ResponseCookie[] expireUserTokenCookies() {
+        ResponseCookie expiredAccessCookie = expireResponseCookie(USER_ACCESS_TOKEN_COOKIE.getValue());
+        ResponseCookie expiredRefreshCookie = expireResponseCookie(USER_REFRESH_KEY.getValue());
 
         return new ResponseCookie[] { expiredAccessCookie, expiredRefreshCookie };
     }


### PR DESCRIPTION
## 🚀 Release PR: develop → main
```
🚨릴리즈 브랜치(`main`)로 병합하는 PR입니다. 반드시 아래 내용을 확인해주세요.🚨
```
---

## 📦 릴리즈 내용 요약
- 관리자/사용자 쿠키 이름 중복으로 인한 세션 충돌 문제 해결
- 사용자 쿠키를 ttac_user, ttref_user로 변경하여 관리자와 구분
- 관리자 쿠키는 기존 ttac, ttref 유지하여 호환성 보장
- Swagger 문서 업데이트 (httpOnly 쿠키 설명 수정)

---

## 🔍 관련 이슈
- 총 포함된 이슈: #118 , #122 

---

## ✅ 배포 전 체크리스트
- [x] 모든 기능 브랜치가 `develop`에 병합되었나요?
- [x] Swagger 문서 최신 상태인가?
- [x] `.env` 설정 등 환경 변수 확인 완료되었는가?
- [x] 배포 서버에서 사전 테스트 완료하였는가?
- [x] 릴리즈 버전 태그를 지정했는가? (ex. `v1.2.0`)

---

## ⚠️ 기타 주의사항
- 관리자 관련 코드는 변경되지 않아 기존 호환성 유지