### PR TITLE
🚀 Release: v0.0.6 (develop -> main)

### DIFF
--- a/src/main/java/org/project/ttokttok/domain/club/service/ClubUserService.java
+++ b/src/main/java/org/project/ttokttok/domain/club/service/ClubUserService.java
@@ -205,9 +205,19 @@ public class ClubUserService {
      * @return 다음 커서 문자열
      */
     private String generateNextCursor(String lastItemId, String sort) {
-        // TODO: 정렬 방식(sort)에 따라 다른 커서 생성 로직 필요
-        // 현재는 정렬 방식에 관계없이 마지막 아이템의 ID를 커서로 사용
-        return lastItemId;
+        // 정렬 방식에 따라 다른 커서 생성
+        switch (sort) {
+            case "latest":
+                // 최신순은 createdAt 기준으로 정렬되므로 ID만 사용
+                return lastItemId;
+            case "popular":
+            case "member_count":
+                // 인기도순과 멤버많은순은 복합 정렬이므로 ID만 사용
+                // TODO: 향후 정렬 기준값과 ID를 조합한 복합 커서로 개선 가능
+                return lastItemId;
+            default:
+                return lastItemId;
+        }
     }
 
     /**

--- a/src/main/java/org/project/ttokttok/global/config/DummyDataLoader.java
+++ b/src/main/java/org/project/ttokttok/global/config/DummyDataLoader.java
@@ -178,9 +178,8 @@ public class DummyDataLoader implements ApplicationRunner {
         log.info("엣지 케이스 ApplyForm 데이터 로딩...");
 
         // 마감된 모집 (INACTIVE 상태) - recruiting: false가 되어야 함
-        String inactiveFormId = "inactive-applyform-001";
         String sql1 = readSqlFile("testdata/12_edge_case_apply_form_inactive.sql");
-        jdbcTemplate.update(sql1, inactiveFormId);
+        jdbcTemplate.execute(sql1);
 
         // 2학년만 모집하는 특별한 케이스
         String specialFormId = "special-applyform-001";

--- a/src/main/resources/testdata/12_edge_case_apply_form_inactive.sql
+++ b/src/main/resources/testdata/12_edge_case_apply_form_inactive.sql
@@ -1,5 +1,66 @@
 -- 마감된 모집 (INACTIVE 상태) - recruiting: false가 되어야 함
 INSERT INTO applyforms (id, title, sub_title, status, apply_start_date, apply_end_date, 
                                        has_interview, max_apply_count, club_id, form_json, created_at, updated_at) 
-VALUES (?, '연극반 모집 마감', '모집이 마감되었습니다', 'INACTIVE', 
-        '2025-02-01', '2025-02-15', false, 5, 'club-005', '[]', NOW(), NOW());
+VALUES 
+(gen_random_uuid(), '연극반 모집 마감', '모집이 마감되었습니다', 'INACTIVE', 
+ '2025-02-01', '2025-02-15', false, 5, 'club-005', '[]', NOW(), NOW()),
+
+(gen_random_uuid(), '벽외조사 동아리 모집 마감', '모집이 마감되었습니다', 'INACTIVE', 
+ '2025-02-01', '2025-02-15', false, 5, 'club-031', '[]', NOW(), NOW()),
+
+(gen_random_uuid(), '자유동아리 모집 마감', '모집이 마감되었습니다', 'INACTIVE', 
+ '2025-02-01', '2025-02-15', false, 11, 'club-030', '[]', NOW(), NOW()),
+
+(gen_random_uuid(), '기독교동아리 모집 마감', '모집이 마감되었습니다', 'INACTIVE', 
+ '2025-02-01', '2025-02-15', false, 9, 'club-029', '[]', NOW(), NOW()),
+
+(gen_random_uuid(), '등산동아리 모집 마감', '모집이 마감되었습니다', 'INACTIVE', 
+ '2025-02-01', '2025-02-15', false, 1, 'club-028', '[]', NOW(), NOW()),
+
+(gen_random_uuid(), '게임동아리 모집 마감', '모집이 마감되었습니다', 'INACTIVE', 
+ '2025-02-01', '2025-02-15', false, 10, 'club-027', '[]', NOW(), NOW()),
+
+(gen_random_uuid(), '스터디모임 모집 마감', '모집이 마감되었습니다', 'INACTIVE', 
+ '2025-02-01', '2025-02-15', false, 13, 'club-026', '[]', NOW(), NOW()),
+
+(gen_random_uuid(), '카페동아리 모집 마감', '모집이 마감되었습니다', 'INACTIVE', 
+ '2025-02-01', '2025-02-15', false, 8, 'club-025', '[]', NOW(), NOW()),
+
+(gen_random_uuid(), '여행동아리 모집 마감', '모집이 마감되었습니다', 'INACTIVE', 
+ '2025-02-01', '2025-02-15', false, 2, 'club-024', '[]', NOW(), NOW()),
+
+(gen_random_uuid(), '과학탐구 모집 마감', '모집이 마감되었습니다', 'INACTIVE', 
+ '2025-02-01', '2025-02-15', false, 6, 'club-023', '[]', NOW(), NOW()),
+
+(gen_random_uuid(), '러닝크루 모집 마감', '모집이 마감되었습니다', 'INACTIVE', 
+ '2025-02-01', '2025-02-15', false, 15, 'club-022', '[]', NOW(), NOW()),
+
+(gen_random_uuid(), '창작문예 모집 마감', '모집이 마감되었습니다', 'INACTIVE', 
+ '2025-02-01', '2025-02-15', false, 7, 'club-021', '[]', NOW(), NOW()),
+
+(gen_random_uuid(), '체스동아리 모집 마감', '모집이 마감되었습니다', 'INACTIVE', 
+ '2025-02-01', '2025-02-15', false, 3, 'club-020', '[]', NOW(), NOW()),
+
+(gen_random_uuid(), '사랑나눔 모집 마감', '모집이 마감되었습니다', 'INACTIVE', 
+ '2025-02-01', '2025-02-15', false, 11, 'club-019', '[]', NOW(), NOW()),
+
+(gen_random_uuid(), '요리연구회 모집 마감', '모집이 마감되었습니다', 'INACTIVE', 
+ '2025-02-01', '2025-02-15', false, 9, 'club-018', '[]', NOW(), NOW()),
+
+(gen_random_uuid(), '배드민턴 모집 마감', '모집이 마감되었습니다', 'INACTIVE', 
+ '2025-02-01', '2025-02-15', false, 4, 'club-017', '[]', NOW(), NOW()),
+
+(gen_random_uuid(), '기타동아리 모집 마감', '모집이 마감되었습니다', 'INACTIVE', 
+ '2025-02-01', '2025-02-15', false, 11, 'club-016', '[]', NOW(), NOW()),
+
+(gen_random_uuid(), '영화감상 모집 마감', '모집이 마감되었습니다', 'INACTIVE', 
+ '2025-02-01', '2025-02-15', false, 8, 'club-015', '[]', NOW(), NOW()),
+
+(gen_random_uuid(), '환경지키미 모집 마감', '모집이 마감되었습니다', 'INACTIVE', 
+ '2025-02-01', '2025-02-15', false, 11, 'club-014', '[]', NOW(), NOW()),
+
+(gen_random_uuid(), '토론동아리 모집 마감', '모집이 마감되었습니다', 'INACTIVE', 
+ '2025-02-01', '2025-02-15', false, 5, 'club-013', '[]', NOW(), NOW()),
+
+(gen_random_uuid(), '밴드동아리 모집 마감', '모집이 마감되었습니다', 'INACTIVE',
+ '2025-02-01', '2025-02-15', false, 6, 'club-009', '[]', NOW(), NOW());

--- a/src/main/resources/testdata/12_edge_case_apply_form_special.sql
+++ b/src/main/resources/testdata/12_edge_case_apply_form_special.sql
@@ -1,5 +1,5 @@
 -- 2학년만 모집하는 특별한 케이스
 INSERT INTO applyforms (id, title, sub_title, status, apply_start_date, apply_end_date, 
                                        has_interview, max_apply_count, club_id, form_json, created_at, updated_at) 
-VALUES (?, '밴드동아리 2학년 특별모집', '2학년만 특별 모집합니다', 'ACTIVE', 
+VALUES (?, '밴드동아리 2학년 특별모집', '2학년만 특별 모집합니다', 'INACTIVE', 
         '2025-03-01', '2025-03-20', true, 3, 'club-009', '[]', NOW(), NOW());


### PR DESCRIPTION
## 🚀 Release PR: develop → main
```
🚨릴리즈 브랜치(`main`)로 병합하는 PR입니다. 반드시 아래 내용을 확인해주세요.🚨
```
---

## 📦 릴리즈 내용 요약
- 무한스크롤 정렬 시 동아리 중복 표시 버그 수정
- 인기도순, 멤버많은순 정렬에서 안정적인 커서 기반 페이징 구현
- JOIN/GROUP BY 대신 서브쿼리 사용으로 중복 제거
- ID 기반 보조 정렬로 일관된 정렬 순서 보장
- `/api/clubs` 및 `/api/clubs/popular` API 안정성 향상
- 무한스크롤 사용자 경험 개선

---

## 🔍 관련 이슈
- 총 포함된 이슈: #124, #125 

---

## ✅ 배포 전 체크리스트
- [x] 모든 기능 브랜치가 `develop`에 병합되었나요?
- [x] Swagger 문서 최신 상태인가?
- [x] `.env` 설정 등 환경 변수 확인 완료되었는가?
- [x] 배포 서버에서 사전 테스트 완료하였는가?
- [x] 릴리즈 버전 태그를 지정했는가? (ex. `v1.2.0`)

---

## ⚠️ 기타 주의사항
- 관리자 관련 코드는 변경되지 않아 기존 호환성 유지