### PR TITLE
사용자 비밀번호 재설정 로직 수정 (Develop -> main)

### DIFF
--- a/src/main/java/org/project/ttokttok/domain/user/repository/EmailVerificationRepository.java
+++ b/src/main/java/org/project/ttokttok/domain/user/repository/EmailVerificationRepository.java
@@ -30,4 +30,6 @@ public interface EmailVerificationRepository extends JpaRepository<EmailVerifica
 
     // 특정 이메일의 인증 완료 여부 확인
     boolean existsByEmailAndIsVerifiedTrue(String email);
+
+    boolean existsByEmailAndCodeAndIsVerifiedTrue(String email, String code);
 }

--- a/src/main/java/org/project/ttokttok/domain/user/service/UserAuthService.java
+++ b/src/main/java/org/project/ttokttok/domain/user/service/UserAuthService.java
@@ -29,7 +29,6 @@ import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.UUID;
 
-import static org.project.ttokttok.global.entity.Role.ROLE_ADMIN;
 import static org.project.ttokttok.global.entity.Role.ROLE_USER;
 
 @Slf4j
@@ -190,7 +189,7 @@ public class UserAuthService {
         }
 
         // 5-2. 인증코드 검증
-        verifyEmail(request.email(), request.verificationCode());
+        checkVerificationCode(request.email(), request.verificationCode());
 
         // 5-3. 사용자 조회 및 비밀번호 업데이트
         User user = userRepository.findByEmail(request.email())
@@ -306,6 +305,12 @@ public class UserAuthService {
     private void validateTokenFromCookie(String refreshToken) {
         if (refreshToken == null) {
             throw new InvalidTokenFromCookieException();
+        }
+    }
+
+    private void checkVerificationCode(String email, String code) {
+        if (!emailVerificationRepository.existsByEmailAndCodeAndIsVerifiedTrue(email, code)) {
+            throw new IllegalArgumentException("인증 코드 성공 여부가 존재하지 않습니다.");
         }
     }
 }

--- a/src/main/resources/testdata/2_user.sql
+++ b/src/main/resources/testdata/2_user.sql
@@ -50,7 +50,7 @@ INSERT INTO users (id, email, password, name, is_email_verified, terms_agreed, c
 ('user-048', 'student048@sangmyung.kr', '$2a$10$dummyUserPassword048', '목현수', true, true, NOW(), NOW()),
 ('user-049', 'student049@sangmyung.kr', '$2a$10$dummyUserPassword049', '욕지민', true, true, NOW(), NOW()),
 ('user-050', 'student050@sangmyung.kr', '$2a$10$dummyUserPassword050', '값태영', true, true, NOW(), NOW()),
-('user-100', '202221593@sangmyung.kr', '$2a$10$dummyUserPassword050', '엄준식', true, true, NOW(), NOW()),
+('user-100', '202221593@sangmyung.kr', '$2a$12$M82Uj0Duqz1l32gRnYU2aO.lH99LDWeZtkVbe2d8.IdvCbeVBYp.G', '엄준식', true, true, NOW(), NOW()),
 ('user-101', '202021000@sangmyung.kr', '$2a$10$dummyUserPassword050', '가김원', true, true, NOW(), NOW()),
 
 ('user-051', 'user4@example.com', 'password', '최대현', true, true, NOW(), NOW()),


### PR DESCRIPTION
## 🚀 Release PR: develop → main -> (PR 제목)

**릴리즈 브랜치(`main`)로 병합하는 PR입니다. 반드시 아래 내용을 확인해주세요.**

---

## 📦 릴리즈 내용 요약
- 중복 검증으로 인한 비밀번호 재설정 실패를 수정했습니다.
---

## 🔍 관련 이슈
- 총 포함된 이슈: #121

---

## ✅ 배포 전 체크리스트
- [x] 모든 기능 브랜치가 `develop`에 병합되었나요?
- [x] Swagger 문서 최신 상태인가?
- [x] `.env` 설정 등 환경 변수 확인 완료되었는가?
- [x] 배포 서버에서 사전 테스트 완료하였는가?
- [x] 릴리즈 버전 태그를 지정했는가? (ex. `v1.2.0`)

---

## ⚠️ 기타 주의사항
> 특별한 롤백 요건, 배포 순서, 환경 설정 변경 등 주의사항을 작성해주세요.
