### PR TITLE
TokenAuthenticationFilter 쿠키 추출 로직 수정으로 즐겨찾기 API 401 에러 해결

### DIFF
--- a/src/main/java/org/project/ttokttok/global/auth/jwt/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/org/project/ttokttok/global/auth/jwt/filter/TokenAuthenticationFilter.java
@@ -71,8 +71,8 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
                         .map(Cookie::getValue)
                         .findFirst()
                         .orElse(null);
-            } else if (requestURI.contains(API_USER.getValue())) {
-                // 그렇지 않은 경우 사용자용 쿠키에서 추출
+            } else {
+                // 그 외의 경우 사용자용 쿠키에서 추출 (favorites, clubs 등)
                 return Arrays.stream(cookies)
                         .filter(cookie -> USER_ACCESS_TOKEN_COOKIE.getValue().equals(cookie.getName()))
                         .map(Cookie::getValue)


### PR DESCRIPTION
## ✨ 작업 내용
- `TokenAuthenticationFilter`의 `getAccessTokenFromCookie` 메서드 수정
- `/api/favorites/**` 경로에서 사용자용 쿠키(`ttac_user`)를 인식하도록 개선
- 즐겨찾기 토글 API에서 발생하던 401 "Expired Token Or Need Authentication" 에러 해결

---

## 🔍 관련 이슈
- 해결한 이슈 번호: #124 
- 관련된 이슈 번호 (선택): #124 

---

## ✅ 체크리스트
- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요?
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항
> `/api/admin/**` 경로는 여전히 관리자용 쿠키(`ttac`) 사용
그 외 모든 경로는 사용자용 쿠키(`ttac_user`) 사용하도록 변경
다른 사용자 관련 API들도 동일한 방식으로 작동할 예정