### PR TITLE
프론트  이슈 대응 (test/#124 -> develop)

### DIFF
--- a/src/main/java/org/project/ttokttok/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/org/project/ttokttok/domain/favorite/service/FavoriteService.java
@@ -14,6 +14,7 @@ import org.project.ttokttok.domain.favorite.service.dto.request.FavoriteToggleSe
 import org.project.ttokttok.domain.favorite.service.dto.response.FavoriteListServiceResponse;
 import org.project.ttokttok.domain.favorite.service.dto.response.FavoriteToggleServiceResponse;
 import org.project.ttokttok.domain.user.domain.User;
+import org.project.ttokttok.domain.user.exception.UserNotFoundException;
 import org.project.ttokttok.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,7 +55,7 @@ public class FavoriteService {
 
         // 사용자 존재 확인
         User user = userRepository.findByEmail(request.userEmail())
-                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new UserNotFoundException());
 
         // 기존 즐겨찾기 확인
         Optional<Favorite> existingFavorite = favoriteRepository.findByUserEmailAndClubId(

--- a/src/main/java/org/project/ttokttok/global/annotationresolver/auth/AuthUserInfoResolver.java
+++ b/src/main/java/org/project/ttokttok/global/annotationresolver/auth/AuthUserInfoResolver.java
@@ -57,7 +57,13 @@ public class AuthUserInfoResolver implements HandlerMethodArgumentResolver {
                 .orElse(null);
 
         if (token != null) {
-            return tokenProvider.getUsernameFromToken(token);
+            try {
+                return tokenProvider.getUsernameFromToken(token);
+            } catch (Exception e) {
+                // 토큰이 만료되었거나 잘못된 경우 null 반환
+                // (컨트롤러에서 null 체크하여 401 처리)
+                return null;
+            }
         }
 
         return null;


### PR DESCRIPTION
## ✨ 작업 내용
- **즐겨찾기 토글 500 에러 해결**: `AuthUserInfoResolver`에서 만료된 JWT 토큰 처리 시 예외 발생 수정
- **동아리 모집상태 필터링 오류 해결**: 무한스크롤에서 `recruiting=false` 필터링 시 모집중 동아리가 섞이는 문제 수정
- **JWT 토큰 만료 시간 정규화**: 개발용으로 임시 연장했던 시간을 원래 15분으로 복구
- 토큰 재발급 API 활용 권장으로 보안성과 사용자 경험 모두 확보
- 실시간 로그 모니터링 방법 정립으로 운영환경 이슈 대응 체계 구축

---

## 🔍 관련 이슈
- 해결한 이슈 번호: #124 
- 관련된 이슈 번호 (선택): #124 

---

## ✅ 체크리스트
- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요?
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항
- 실시간 로그 모니터링 명령어 정립으로 프론트엔드 이슈 즉시 대응 가능
- JWT 토큰 재발급 API를 활용한 안정적인 인증 체계 구축 권장
