### PR TITLE
메모 저장 시 id 값 null 반환 해결 (Fix/#201 -> develop)

### DIFF
--- a/src/main/java/org/project/ttokttok/domain/memo/domain/Memo.java
+++ b/src/main/java/org/project/ttokttok/domain/memo/domain/Memo.java
@@ -7,15 +7,17 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.project.ttokttok.domain.applicant.domain.DocumentPhase;
 
+import java.util.UUID;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Memo {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
+//    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(length = 36, updatable = false, unique = true)
-    private String id;
+    private String id = UUID.randomUUID().toString();
 
     @Column(nullable = false, length = 100)
     private String content;


### PR DESCRIPTION
## ✨ 작업 내용
- 기존에 `@GeneratedValue` 어노테이션으로 영속성 컨텍스트에서 DB에 flush 된 후에 id가 생성되는 방식에서, 객체 생성 시 즉시 UUID 형태의 ID를 할당하도록 수정했습니다.

---

## 🔍 관련 이슈
- 해결한 이슈 번호: #201
- 관련된 이슈 번호 (선택): 

---

## ✅ 체크리스트
- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요?
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항
> 리뷰어가 알아야 할 특이사항, 주의사항이 있다면 작성해주세요.
