### PR TITLE
메모 생성 시 id 값 null 반환 해결 (Develop -> main)

### DIFF
--- a/src/main/java/org/project/ttokttok/domain/memo/domain/Memo.java
+++ b/src/main/java/org/project/ttokttok/domain/memo/domain/Memo.java
@@ -7,15 +7,17 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.project.ttokttok.domain.applicant.domain.DocumentPhase;
 
+import java.util.UUID;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Memo {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
+//    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(length = 36, updatable = false, unique = true)
-    private String id;
+    private String id = UUID.randomUUID().toString();
 
     @Column(nullable = false, length = 100)
     private String content;


### PR DESCRIPTION

## 🚀 Release PR: develop → main -> (PR 제목)

**릴리즈 브랜치(`main`)로 병합하는 PR입니다. 반드시 아래 내용을 확인해주세요.**

---

## 📦 릴리즈 내용 요약
- Memo 엔티티의 id 생성 로직을 UUID 즉시 할당 방식으로 수정했습니다.

---

## 🔍 관련 이슈
- 총 포함된 이슈: #201

---

## ✅ 배포 전 체크리스트
- [x] 모든 기능 브랜치가 `develop`에 병합되었나요?
- [x] Swagger 문서 최신 상태인가?
- [x] `.env` 설정 등 환경 변수 확인 완료되었는가?
- [x] 배포 서버에서 사전 테스트 완료하였는가?
- [x] 릴리즈 버전 태그를 지정했는가? (ex. `v1.2.0`)

---

## ⚠️ 기타 주의사항
> x
