### PR TITLE
[#205] -  지원폼 수정 시 questionId가 null로 나오던 문제 수정 (fix/#205 -> develop)

### DIFF
--- a/src/main/java/org/project/ttokttok/domain/applyform/controller/dto/request/ApplyFormUpdateRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/applyform/controller/dto/request/ApplyFormUpdateRequest.java
@@ -15,7 +15,7 @@ public record ApplyFormUpdateRequest(
         JsonNullable<String> subtitle,
 
         @Schema(description = "선택적 필드 (null 가능)", nullable = true, example = "값 또는 null")
-        JsonNullable<List<Question>> questions
+        JsonNullable<List<QuestionRequestDto>> questions
 ) {
     public ApplyFormUpdateServiceRequest toServiceRequest(String username, String formId) {
         return ApplyFormUpdateServiceRequest.builder()
@@ -23,7 +23,17 @@ public record ApplyFormUpdateRequest(
                 .applyFormId(formId)
                 .title(title)
                 .subtitle(subtitle)
-                .questions(questions)
+                .questions(questionRequestPresent(questions))
                 .build();
+    }
+
+    private JsonNullable<List<Question>> questionRequestPresent(JsonNullable<List<QuestionRequestDto>> questions) {
+        if (questions.isPresent()) {
+            return JsonNullable.of(questions.get().stream()
+                    .map(QuestionRequestDto::toQuestion)
+                    .toList());
+        }
+
+        return JsonNullable.undefined();
     }
 }

--- a/src/main/java/org/project/ttokttok/domain/applyform/service/ApplyFormAdminService.java
+++ b/src/main/java/org/project/ttokttok/domain/applyform/service/ApplyFormAdminService.java
@@ -82,7 +82,6 @@ public class ApplyFormAdminService {
     }
 
     // 지원 폼 수정 메서드
-    // todo: 이미 지원한 사용자가 있는 경우, 수정 불가능하도록 예외 처리 필요.
     @Transactional
     public void updateApplyForm(ApplyFormUpdateServiceRequest request) {
         ApplyForm applyForm = applyFormRepository.findById(request.applyFormId())


### PR DESCRIPTION
## ✨ 작업 내용
- 지원폼 수정 시 질문 id가 null로 내려오던 문제를 수정했습니다.

---

## 🔍 관련 이슈
- 해결한 이슈 번호: x
- 관련된 이슈 번호 (선택): #205

---

## ✅ 체크리스트
- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요?
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항
> 

