### PR TITLE
지원폼 수정 후 조회 시 질문 id null로 내려오던 문제 수정 (Develop -> main)

### DIFF
--- a/src/main/java/org/project/ttokttok/domain/applyform/controller/dto/request/ApplyFormUpdateRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/applyform/controller/dto/request/ApplyFormUpdateRequest.java
@@ -15,7 +15,7 @@ public record ApplyFormUpdateRequest(
         JsonNullable<String> subtitle,
 
         @Schema(description = "선택적 필드 (null 가능)", nullable = true, example = "값 또는 null")
-        JsonNullable<List<Question>> questions
+        JsonNullable<List<QuestionRequestDto>> questions
 ) {
     public ApplyFormUpdateServiceRequest toServiceRequest(String username, String formId) {
         return ApplyFormUpdateServiceRequest.builder()
@@ -23,7 +23,17 @@ public record ApplyFormUpdateRequest(
                 .applyFormId(formId)
                 .title(title)
                 .subtitle(subtitle)
-                .questions(questions)
+                .questions(questionRequestPresent(questions))
                 .build();
+    }
+
+    private JsonNullable<List<Question>> questionRequestPresent(JsonNullable<List<QuestionRequestDto>> questions) {
+        if (questions.isPresent()) {
+            return JsonNullable.of(questions.get().stream()
+                    .map(QuestionRequestDto::toQuestion)
+                    .toList());
+        }
+
+        return JsonNullable.undefined();
     }
 }

--- a/src/main/java/org/project/ttokttok/domain/applyform/service/ApplyFormAdminService.java
+++ b/src/main/java/org/project/ttokttok/domain/applyform/service/ApplyFormAdminService.java
@@ -82,7 +82,6 @@ public class ApplyFormAdminService {
     }
 
     // 지원 폼 수정 메서드
-    // todo: 이미 지원한 사용자가 있는 경우, 수정 불가능하도록 예외 처리 필요.
     @Transactional
     public void updateApplyForm(ApplyFormUpdateServiceRequest request) {
         ApplyForm applyForm = applyFormRepository.findById(request.applyFormId())


### PR DESCRIPTION
## 🚀 Release PR: develop → main -> (PR 제목)

**릴리즈 브랜치(`main`)로 병합하는 PR입니다. 반드시 아래 내용을 확인해주세요.**

---

## 📦 릴리즈 내용 요약
- 지원폼 수정 후 조회 시 질문 id가 null로 내려오던 문제를 수정했습니다.

---

## 🔍 관련 이슈
- 총 포함된 이슈: #205

---

## ✅ 배포 전 체크리스트
- [x] 모든 기능 브랜치가 `develop`에 병합되었나요?
- [x] Swagger 문서 최신 상태인가?
- [x] `.env` 설정 등 환경 변수 확인 완료되었는가?
- [x] 배포 서버에서 사전 테스트 완료하였는가?
- [x] 릴리즈 버전 태그를 지정했는가? (ex. `v1.2.0`)

---

## ⚠️ 기타 주의사항
> x
