### PR TITLE
동아리 중복표시 방지를 위해 distinct() 쿼리 추가 (fix/#205 -> develop)

### DIFF
--- a/src/main/java/org/project/ttokttok/domain/club/repository/ClubCustomRepositoryImpl.java
+++ b/src/main/java/org/project/ttokttok/domain/club/repository/ClubCustomRepositoryImpl.java
@@ -155,6 +155,7 @@ public class ClubCustomRepositoryImpl implements ClubCustomRepository {
                         bookmarkedSubQuery
                 ))
                 .from(club)
+                .distinct()  // ✅ DISTINCT 추가로 중복 제거
                 .where(
                         categoryEq(category),
                         typeEq(type),
@@ -359,6 +360,7 @@ public class ClubCustomRepositoryImpl implements ClubCustomRepository {
                         bookmarkedSubQuery
                 ))
                 .from(club)
+                .distinct()  // ✅ DISTINCT 추가로 중복 제거
                 .where(
                         popularityScore.goe(minScore),
                         cursorCondition(cursor, sort)
@@ -409,6 +411,7 @@ public class ClubCustomRepositoryImpl implements ClubCustomRepository {
                         bookmarkedSubQuery
                 ))
                 .from(club)
+                .distinct()  // ✅ DISTINCT 추가로 중복 제거
                 .where(
                         club.name.containsIgnoreCase(keyword)
                                 .or(club.summary.containsIgnoreCase(keyword))


### PR DESCRIPTION
## ✨ 작업 내용
- 동아리가 중복으로 표시되는 문제를 방지하기 위해 distinct() 쿼리문을 추가했습니다.

---

## 🔍 관련 이슈
- 해결한 이슈 번호: #205 
- 관련된 이슈 번호 (선택): #205 

---

## ✅ 체크리스트
- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요?
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항
> 일단 운영환경과 개발환경의 차이점 때문에 계속 지켜봐야할 듯 합니다.