### PR TITLE
동아리 검색 기능 동아리 이름으로 제한 (fix/#205 -> develop)

### DIFF
--- a/src/main/java/org/project/ttokttok/domain/club/controller/ClubUserApiController.java
+++ b/src/main/java/org/project/ttokttok/domain/club/controller/ClubUserApiController.java
@@ -270,18 +270,18 @@ public class ClubUserApiController {
 
     /**
      * 동아리 검색 API
-     * 동아리 이름, 소개, 카테고리 등을 기준으로 검색합니다.
+     * 동아리 이름을 기준으로 검색합니다.
      * 검색 결과는 커서 기반 페이지네이션을 지원합니다.
-     * 검색 키워드에 따라 동아리 이름, 소개글, 카테고리 등을 포함한 결과를 반환합니다.
+     * 검색 키워드가 동아리 이름에 포함되는 결과를 반환합니다.
      *
-     * @param keyword 검색 키워드 (동아리 이름, 소개글 등)
+     * @param keyword 검색 키워드 (동아리 이름)
      * @param sort 정렬 기준 (latest, member, popular)
      * @param cursor 커서 기반 페이지네이션을 위한 기준 ID
      * @param size 페이지당 로드할 개수 (기본값 20)
      */
     @Operation(
             summary = "동아리 검색",
-            description = "동아리 이름, 소개, 카테고리 등을 기준으로 검색합니다."
+            description = "동아리 이름을 기준으로 검색합니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "검색 성공"),

--- a/src/main/java/org/project/ttokttok/domain/club/repository/ClubCustomRepositoryImpl.java
+++ b/src/main/java/org/project/ttokttok/domain/club/repository/ClubCustomRepositoryImpl.java
@@ -413,9 +413,7 @@ public class ClubCustomRepositoryImpl implements ClubCustomRepository {
                 ))
                 .from(club)
                 .where(
-                        club.name.containsIgnoreCase(keyword)
-                                .or(club.summary.containsIgnoreCase(keyword))
-                                .or(club.content.containsIgnoreCase(keyword)),
+                        club.name.containsIgnoreCase(keyword),
                         cursorCondition(cursor, sort)
                 );
 
@@ -454,8 +452,6 @@ public class ClubCustomRepositoryImpl implements ClubCustomRepository {
                 .from(club)
                 .where(
                         club.name.containsIgnoreCase(keyword)
-                                .or(club.summary.containsIgnoreCase(keyword))
-                                .or(club.content.containsIgnoreCase(keyword))
                 )
                 .fetchOne();
     }


### PR DESCRIPTION
## ✨ 작업 내용
- 동아리 검색 기능을 이름 기반 검색으로 변경
- 기존 검색 범위(이름, 소개글, 내용)를 동아리 이름으로만 제한
- Swagger API 문서 업데이트 (검색 API description 수정)
- 부분 일치 검색 지원 (예: "축" 검색 시 "축구부" 검색 가능)

---

## 🔍 관련 이슈
- 해결한 이슈 번호: #205 
- 관련된 이슈 번호 (선택): #205 

---

## ✅ 체크리스트
- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요?
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항
> 리뷰어가 알아야 할 특이사항, 주의사항이 있다면 작성해주세요.