### PR TITLE
동아리 게시판 관리자 CRUD API 완성(feat/#316 -> develop)

### DIFF
--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminController.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminController.java
@@ -1,10 +1,29 @@
 package org.project.ttokttok.domain.clubboard.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.project.ttokttok.domain.clubboard.controller.dto.request.ClubBoardUpdateRequest;
+import org.project.ttokttok.domain.clubboard.controller.dto.request.CreateBoardRequest;
+import org.project.ttokttok.domain.clubboard.controller.dto.response.ClubBoardCreateResponse;
 import org.project.ttokttok.domain.clubboard.service.ClubBoardAdminService;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.project.ttokttok.domain.clubboard.service.dto.request.DeleteBoardServiceRequest;
+import org.project.ttokttok.global.annotation.auth.AuthUserInfo;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
+/**
+ * 동아리 게시판 관리 API 컨트롤러
+ * 동아리 관리자가 게시글을 생성, 수정, 삭제할 수 있는 API들을 제공합니다.
+ */
+@Tag(name = "[관리자] 동아리 게시판 관리", description = "동아리 관리자가 게시판 게시글을 관리하는 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin/clubs/{clubId}/boards")
@@ -12,8 +31,67 @@ public class ClubBoardAdminController {
 
     private final ClubBoardAdminService clubBoardAdminService;
 
-    // 게시글 생성
-    // 게시글 수정
-    // 게시글 삭제
+    @Operation(
+            summary = "게시글 생성",
+            description = "동아리 관리자가 게시판에 새 게시글을 작성합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "생성 성공"),
+            @ApiResponse(responseCode = "403", description = "해당 동아리의 관리자가 아님"),
+            @ApiResponse(responseCode = "404", description = "동아리를 찾을 수 없음")
+    })
+    @PostMapping
+    public ResponseEntity<ClubBoardCreateResponse> createBoard(
+            @Parameter(hidden = true) @AuthUserInfo String username,
+            @Parameter(description = "동아리 ID", required = true) @PathVariable String clubId,
+            @RequestBody @Valid CreateBoardRequest request
+    ) {
+        String boardId = clubBoardAdminService.createBoard(request.toServiceRequest(username, clubId));
 
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new ClubBoardCreateResponse(boardId));
+    }
+
+    @Operation(
+            summary = "게시글 수정",
+            description = "동아리 관리자가 기존 게시글의 제목/내용을 수정합니다. 생략하거나 null인 필드는 기존 값을 유지합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "403", description = "해당 동아리의 관리자가 아님"),
+            @ApiResponse(responseCode = "404", description = "동아리 또는 게시글을 찾을 수 없음")
+    })
+    @PatchMapping("/{boardId}")
+    public ResponseEntity<Map<String, String>> updateBoard(
+            @Parameter(hidden = true) @AuthUserInfo String username,
+            @Parameter(description = "동아리 ID", required = true) @PathVariable String clubId,
+            @Parameter(description = "게시글 ID", required = true) @PathVariable String boardId,
+            @RequestBody ClubBoardUpdateRequest request
+    ) {
+        clubBoardAdminService.updateBoard(request.toServiceRequest(username, clubId, boardId));
+
+        return ResponseEntity.ok()
+                .body(Map.of("message", "게시글이 수정되었습니다."));
+    }
+
+    @Operation(
+            summary = "게시글 삭제",
+            description = "동아리 관리자가 게시글을 삭제합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "해당 동아리의 관리자가 아님"),
+            @ApiResponse(responseCode = "404", description = "동아리 또는 게시글을 찾을 수 없음")
+    })
+    @DeleteMapping("/{boardId}")
+    public ResponseEntity<Map<String, String>> deleteBoard(
+            @Parameter(hidden = true) @AuthUserInfo String username,
+            @Parameter(description = "동아리 ID", required = true) @PathVariable String clubId,
+            @Parameter(description = "게시글 ID", required = true) @PathVariable String boardId
+    ) {
+        clubBoardAdminService.deleteBoard(new DeleteBoardServiceRequest(username, clubId, boardId));
+
+        return ResponseEntity.ok()
+                .body(Map.of("message", "게시글이 삭제되었습니다."));
+    }
 }

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/ClubBoardUpdateRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/ClubBoardUpdateRequest.java
@@ -1,0 +1,22 @@
+package org.project.ttokttok.domain.clubboard.controller.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.project.ttokttok.domain.clubboard.service.dto.request.ClubBoardUpdateServiceRequest;
+
+public record ClubBoardUpdateRequest(
+        @Schema(description = "선택적 필드 (생략 또는 null이면 기존 값 유지)", nullable = true, example = "값 또는 null")
+        String title,
+
+        @Schema(description = "선택적 필드 (생략 또는 null이면 기존 값 유지)", nullable = true, example = "값 또는 null")
+        String content
+) {
+    public ClubBoardUpdateServiceRequest toServiceRequest(String username, String clubId, String boardId) {
+        return ClubBoardUpdateServiceRequest.builder()
+                .username(username)
+                .clubId(clubId)
+                .boardId(boardId)
+                .title(title)
+                .content(content)
+                .build();
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/CreateBoardRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/CreateBoardRequest.java
@@ -1,0 +1,16 @@
+package org.project.ttokttok.domain.clubboard.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import org.project.ttokttok.domain.clubboard.service.dto.request.CreateBoardServiceRequest;
+
+public record CreateBoardRequest(
+        @NotBlank(message = "제목은 비어 있을 수 없습니다.")
+        String title,
+
+        @NotBlank(message = "내용은 비어 있을 수 없습니다.")
+        String content
+) {
+    public CreateBoardServiceRequest toServiceRequest(String username, String clubId) {
+        return new CreateBoardServiceRequest(username, clubId, title, content);
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/response/ClubBoardCreateResponse.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/response/ClubBoardCreateResponse.java
@@ -1,0 +1,6 @@
+package org.project.ttokttok.domain.clubboard.controller.dto.response;
+
+public record ClubBoardCreateResponse(
+        String boardId
+) {
+}

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/response/ClubBoardListResponse.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/response/ClubBoardListResponse.java
@@ -18,6 +18,7 @@ public record ClubBoardListResponse(
     public record ClubBoardSummary(
             String boardId,
             String title,
+            String content,
             String clubName,
             boolean hasImages,      // content에 이미지가 포함되어 있는지
             LocalDateTime createdAt // 프론트에서 "19시간 전" 형식으로 변환

--- a/src/main/java/org/project/ttokttok/domain/clubboard/domain/ClubBoard.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/domain/ClubBoard.java
@@ -44,6 +44,17 @@ public class ClubBoard extends BaseTimeEntity {
         this.club = club;
     }
 
+    public void update(String title, String content) {
+        if (title != null) {
+            validateTitle(title);
+            this.title = title;
+        }
+        if (content != null) {
+            validateContent(content);
+            this.content = content;
+        }
+    }
+
     // ------- 정적 메서드 -------
     public static ClubBoard create(String title, String content, Club club) {
         validateTitle(title);

--- a/src/main/java/org/project/ttokttok/domain/clubboard/service/ClubBoardAdminService.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/service/ClubBoardAdminService.java
@@ -2,15 +2,17 @@ package org.project.ttokttok.domain.clubboard.service;
 
 import lombok.RequiredArgsConstructor;
 import org.project.ttokttok.domain.club.domain.Club;
-import org.project.ttokttok.domain.club.exception.ClubNotFoundException;
 import org.project.ttokttok.domain.club.exception.NotClubAdminException;
 import org.project.ttokttok.domain.club.repository.ClubRepository;
 import org.project.ttokttok.domain.clubboard.domain.ClubBoard;
 import org.project.ttokttok.domain.clubboard.exception.ClubAdminNameNotMatchException;
 import org.project.ttokttok.domain.clubboard.exception.ClubBoardNotFoundException;
 import org.project.ttokttok.domain.clubboard.repository.ClubBoardRepository;
+import org.project.ttokttok.domain.clubboard.service.dto.request.ClubBoardUpdateServiceRequest;
 import org.project.ttokttok.domain.clubboard.service.dto.request.CreateBoardServiceRequest;
+import org.project.ttokttok.domain.clubboard.service.dto.request.DeleteBoardServiceRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -20,8 +22,9 @@ public class ClubBoardAdminService {
     private final ClubBoardRepository clubBoardRepository;
 
     // 게시글 생성
+    @Transactional
     public String createBoard(CreateBoardServiceRequest request) {
-        Club club = validateClubAdmin(request.adminName());
+        Club club = validateClubAdmin(request.adminName(), request.clubId());
 
         // 게시글 생성 로직
         ClubBoard clubBoard = ClubBoard.create(request.title(), request.content(), club);
@@ -30,24 +33,47 @@ public class ClubBoardAdminService {
                 .getId();
     }
 
+    // 게시글 수정 로직
+    @Transactional
+    public void updateBoard(ClubBoardUpdateServiceRequest request) {
+        Club club = validateClubAdmin(request.username(), request.clubId());
+
+        ClubBoard clubBoard = findClubBoardOfClub(request.boardId(), club.getId());
+
+        clubBoard.update(request.title(), request.content());
+    }
+
     // 게시글 삭제 로직
-    public void deleteBoard(String clubId, String boardId, String requestAdminName) {
-        Club club = validateClubAdmin(requestAdminName);
+    @Transactional
+    public void deleteBoard(DeleteBoardServiceRequest request) {
+        Club club = validateClubAdmin(request.adminName(), request.clubId());
 
-        ClubBoard clubBoard = clubBoardRepository.findById(boardId)
-                .orElseThrow(ClubBoardNotFoundException::new);
-
-        // 해당 게시글이 요청한 동아리의 게시글인지 추가 확인
-        if (!clubBoard.getClub().getId().equals(club.getId())) {
-            throw new ClubAdminNameNotMatchException();
-        }
+        ClubBoard clubBoard = findClubBoardOfClub(request.boardId(), club.getId());
 
         // 게시글 삭제 로직
         clubBoardRepository.delete(clubBoard);
     }
 
-    private Club validateClubAdmin(String username) {
-        return clubRepository.findByAdminUsername(username)
+    private ClubBoard findClubBoardOfClub(String boardId, String clubId) {
+        ClubBoard clubBoard = clubBoardRepository.findById(boardId)
+                .orElseThrow(ClubBoardNotFoundException::new);
+
+        // 해당 게시글이 요청한 동아리의 게시글인지 추가 확인
+        if (!clubBoard.getClub().getId().equals(clubId)) {
+            throw new ClubAdminNameNotMatchException();
+        }
+
+        return clubBoard;
+    }
+
+    private Club validateClubAdmin(String username, String requestClubId) {
+        Club club = clubRepository.findByAdminUsername(username)
                 .orElseThrow(NotClubAdminException::new);
+
+        if (!club.getId().equals(requestClubId)) {
+            throw new ClubAdminNameNotMatchException();
+        }
+
+        return club;
     }
 }

--- a/src/main/java/org/project/ttokttok/domain/clubboard/service/ClubBoardUserService.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/service/ClubBoardUserService.java
@@ -61,6 +61,7 @@ public class ClubBoardUserService {
         return new ClubBoardSummary(
                 board.getId(),
                 board.getTitle(),
+                board.getContent(),
                 board.getClub().getName(),
                 hasImages(board.getContent()),
                 board.getCreatedAt()

--- a/src/main/java/org/project/ttokttok/domain/clubboard/service/dto/request/ClubBoardUpdateServiceRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/service/dto/request/ClubBoardUpdateServiceRequest.java
@@ -1,0 +1,13 @@
+package org.project.ttokttok.domain.clubboard.service.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record ClubBoardUpdateServiceRequest(
+        String username,
+        String clubId,
+        String boardId,
+        String title,
+        String content
+) {
+}

--- a/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminControllerTest.java
@@ -1,0 +1,139 @@
+package org.project.ttokttok.domain.clubboard.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.admin.domain.Admin;
+import org.project.ttokttok.domain.admin.repository.AdminRepository;
+import org.project.ttokttok.domain.club.domain.Club;
+import org.project.ttokttok.domain.club.domain.enums.ClubUniv;
+import org.project.ttokttok.domain.club.repository.ClubRepository;
+import org.project.ttokttok.domain.clubboard.controller.dto.request.ClubBoardUpdateRequest;
+import org.project.ttokttok.domain.clubboard.controller.dto.request.CreateBoardRequest;
+import org.project.ttokttok.domain.clubboard.domain.ClubBoard;
+import org.project.ttokttok.domain.clubboard.repository.ClubBoardRepository;
+import org.project.ttokttok.global.entity.Role;
+import org.project.ttokttok.infrastructure.jwt.JwtFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ClubBoardAdminControllerTest {
+
+    @Autowired
+    private ClubRepository clubRepository;
+
+    @Autowired
+    private AdminRepository adminRepository;
+
+    @Autowired
+    private ClubBoardRepository clubBoardRepository;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtFactory jwtFactory;
+
+    private Club myClub;
+    private String myAccessToken;
+    private String otherAccessToken;
+
+    @BeforeEach
+    void setUp() {
+        Admin myAdmin = adminRepository.save(Admin.adminJoin("boardadmin1", "password123!", "boardadmin1@sangmyung.kr"));
+        Admin otherAdmin = adminRepository.save(Admin.adminJoin("boardadmin2", "password123!", "boardadmin2@sangmyung.kr"));
+
+        myClub = clubRepository.save(Club.builder()
+                .admin(myAdmin)
+                .clubName("게시판 테스트 동아리")
+                .clubUniv(ClubUniv.ENGINEERING)
+                .build());
+
+        clubRepository.save(Club.builder()
+                .admin(otherAdmin)
+                .clubName("다른 동아리")
+                .clubUniv(ClubUniv.DESIGN)
+                .build());
+
+        myAccessToken = jwtFactory.generateValidToken(myAdmin.getUsername(), Role.ROLE_ADMIN);
+        otherAccessToken = jwtFactory.generateValidToken(otherAdmin.getUsername(), Role.ROLE_ADMIN);
+    }
+
+    @Test
+    @DisplayName("createBoard(): 게시글 생성에 성공한다.")
+    void createBoard_success() throws Exception {
+        CreateBoardRequest request = new CreateBoardRequest("제목입니다", "본문입니다");
+
+        mockMvc.perform(post("/api/admin/clubs/{clubId}/boards", myClub.getId())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.boardId", notNullValue()));
+    }
+
+    @Test
+    @DisplayName("createBoard(): 다른 동아리 관리자가 요청하면 403이 발생한다.")
+    void createBoard_forbidden() throws Exception {
+        CreateBoardRequest request = new CreateBoardRequest("제목입니다", "본문입니다");
+
+        mockMvc.perform(post("/api/admin/clubs/{clubId}/boards", myClub.getId())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + otherAccessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("updateBoard(): 게시글 수정에 성공한다.")
+    void updateBoard_success() throws Exception {
+        ClubBoard board = clubBoardRepository.save(ClubBoard.create("원래 제목", "원래 내용", myClub));
+
+        ClubBoardUpdateRequest request = new ClubBoardUpdateRequest("수정된 제목", null);
+
+        mockMvc.perform(patch("/api/admin/clubs/{clubId}/boards/{boardId}", myClub.getId(), board.getId())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("deleteBoard(): 게시글 삭제에 성공한다.")
+    void deleteBoard_success() throws Exception {
+        ClubBoard board = clubBoardRepository.save(ClubBoard.create("삭제될 제목", "삭제될 내용", myClub));
+
+        mockMvc.perform(delete("/api/admin/clubs/{clubId}/boards/{boardId}", myClub.getId(), board.getId())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("deleteBoard(): 다른 동아리 관리자가 요청하면 403이 발생한다.")
+    void deleteBoard_forbidden() throws Exception {
+        ClubBoard board = clubBoardRepository.save(ClubBoard.create("삭제될 제목", "삭제될 내용", myClub));
+
+        mockMvc.perform(delete("/api/admin/clubs/{clubId}/boards/{boardId}", myClub.getId(), board.getId())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + otherAccessToken))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/clubboard/service/ClubBoardAdminServiceTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/service/ClubBoardAdminServiceTest.java
@@ -1,62 +1,201 @@
 package org.project.ttokttok.domain.clubboard.service;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.project.ttokttok.domain.club.domain.Club;
+import org.project.ttokttok.domain.club.exception.NotClubAdminException;
 import org.project.ttokttok.domain.club.repository.ClubRepository;
 import org.project.ttokttok.domain.clubboard.domain.ClubBoard;
+import org.project.ttokttok.domain.clubboard.exception.ClubAdminNameNotMatchException;
+import org.project.ttokttok.domain.clubboard.exception.ClubBoardNotFoundException;
 import org.project.ttokttok.domain.clubboard.repository.ClubBoardRepository;
+import org.project.ttokttok.domain.clubboard.service.dto.request.ClubBoardUpdateServiceRequest;
 import org.project.ttokttok.domain.clubboard.service.dto.request.CreateBoardServiceRequest;
+import org.project.ttokttok.domain.clubboard.service.dto.request.DeleteBoardServiceRequest;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ClubBoardAdminServiceTest {
 
-    @Mock
-    private ClubRepository clubRepository;
+    private final ClubRepository clubRepository = mock(ClubRepository.class);
+    private final ClubBoardRepository clubBoardRepository = mock(ClubBoardRepository.class);
+    private final ClubBoardAdminService clubBoardService =
+            new ClubBoardAdminService(clubRepository, clubBoardRepository);
 
-    @Mock
-    private ClubBoardRepository clubBoardRepository;
+    private Club mockClub(String clubId) {
+        Club club = mock(Club.class);
+        when(club.getId()).thenReturn(clubId);
+        return club;
+    }
 
-    @InjectMocks
-    private ClubBoardAdminService clubBoardService;
+    @Nested
+    @DisplayName("createBoard()")
+    class CreateBoard {
 
-    @Test
-    @DisplayName("createBoard(): 게시글 생성 성공")
-    void createBoardSuccess() {
-        // given
-        String clubId = "club123";
-        Club mockClub = mock(Club.class);
-        when(clubRepository.findByAdminUsername("admin")).thenReturn(Optional.of(mockClub));
-        CreateBoardServiceRequest request = new CreateBoardServiceRequest("admin", clubId, "title", "content");
+        @Test
+        @DisplayName("게시글 생성에 성공한다.")
+        void createBoardSuccess() {
+            Club club = mockClub("club123");
+            when(clubRepository.findByAdminUsername("admin")).thenReturn(Optional.of(club));
 
-        ClubBoard mockBoard = mock(ClubBoard.class);
-        when(mockBoard.getId()).thenReturn("board123");
-        when(clubBoardRepository.save(any(ClubBoard.class))).thenReturn(mockBoard);
+            ClubBoard savedBoard = mock(ClubBoard.class);
+            when(savedBoard.getId()).thenReturn("board123");
+            when(clubBoardRepository.save(any(ClubBoard.class))).thenReturn(savedBoard);
 
-        // AOP 대신 수동으로 ClubHolder 설정
-        
+            CreateBoardServiceRequest request = new CreateBoardServiceRequest("admin", "club123", "title", "content");
 
-        try {
-            // when
             String result = clubBoardService.createBoard(request);
 
-            // then
             assertThat(result).isEqualTo("board123");
             verify(clubBoardRepository).save(any(ClubBoard.class));
-        } finally {
-            
+        }
+
+        @Test
+        @DisplayName("요청한 clubId가 관리자의 동아리와 다르면 예외가 발생한다.")
+        void createBoardClubIdMismatch() {
+            Club club = mockClub("club123");
+            when(clubRepository.findByAdminUsername("admin")).thenReturn(Optional.of(club));
+
+            CreateBoardServiceRequest request = new CreateBoardServiceRequest("admin", "otherClub", "title", "content");
+
+            assertThatThrownBy(() -> clubBoardService.createBoard(request))
+                    .isInstanceOf(ClubAdminNameNotMatchException.class);
+
+            verify(clubBoardRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("요청자가 동아리 관리자가 아니면 예외가 발생한다.")
+        void createBoardNotAdmin() {
+            when(clubRepository.findByAdminUsername("stranger")).thenReturn(Optional.empty());
+
+            CreateBoardServiceRequest request = new CreateBoardServiceRequest("stranger", "club123", "title", "content");
+
+            assertThatThrownBy(() -> clubBoardService.createBoard(request))
+                    .isInstanceOf(NotClubAdminException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateBoard()")
+    class UpdateBoard {
+
+        @Test
+        @DisplayName("일부 필드만 보내도 수정에 성공한다.")
+        void updateBoardPartialSuccess() {
+            Club club = mockClub("club123");
+            when(clubRepository.findByAdminUsername("admin")).thenReturn(Optional.of(club));
+
+            ClubBoard board = mock(ClubBoard.class);
+            when(board.getClub()).thenReturn(club);
+            when(clubBoardRepository.findById("board123")).thenReturn(Optional.of(board));
+
+            ClubBoardUpdateServiceRequest request = ClubBoardUpdateServiceRequest.builder()
+                    .username("admin")
+                    .clubId("club123")
+                    .boardId("board123")
+                    .title("새 제목")
+                    .content(null)
+                    .build();
+
+            clubBoardService.updateBoard(request);
+
+            verify(board).update("새 제목", null);
+        }
+
+        @Test
+        @DisplayName("게시글이 존재하지 않으면 예외가 발생한다.")
+        void updateBoardNotFound() {
+            Club club = mockClub("club123");
+            when(clubRepository.findByAdminUsername("admin")).thenReturn(Optional.of(club));
+            when(clubBoardRepository.findById("missing")).thenReturn(Optional.empty());
+
+            ClubBoardUpdateServiceRequest request = ClubBoardUpdateServiceRequest.builder()
+                    .username("admin")
+                    .clubId("club123")
+                    .boardId("missing")
+                    .title("title")
+                    .content("content")
+                    .build();
+
+            assertThatThrownBy(() -> clubBoardService.updateBoard(request))
+                    .isInstanceOf(ClubBoardNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("게시글이 다른 동아리 소속이면 예외가 발생한다.")
+        void updateBoardClubMismatch() {
+            Club myClub = mockClub("club123");
+            Club otherClub = mockClub("otherClub");
+            when(clubRepository.findByAdminUsername("admin")).thenReturn(Optional.of(myClub));
+
+            ClubBoard board = mock(ClubBoard.class);
+            when(board.getClub()).thenReturn(otherClub);
+            when(clubBoardRepository.findById("board123")).thenReturn(Optional.of(board));
+
+            ClubBoardUpdateServiceRequest request = ClubBoardUpdateServiceRequest.builder()
+                    .username("admin")
+                    .clubId("club123")
+                    .boardId("board123")
+                    .title("title")
+                    .content("content")
+                    .build();
+
+            assertThatThrownBy(() -> clubBoardService.updateBoard(request))
+                    .isInstanceOf(ClubAdminNameNotMatchException.class);
+
+            verify(board, never()).update(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteBoard()")
+    class DeleteBoard {
+
+        @Test
+        @DisplayName("게시글 삭제에 성공한다.")
+        void deleteBoardSuccess() {
+            Club club = mockClub("club123");
+            when(clubRepository.findByAdminUsername("admin")).thenReturn(Optional.of(club));
+
+            ClubBoard board = mock(ClubBoard.class);
+            when(board.getClub()).thenReturn(club);
+            when(clubBoardRepository.findById("board123")).thenReturn(Optional.of(board));
+
+            DeleteBoardServiceRequest request = new DeleteBoardServiceRequest("admin", "club123", "board123");
+
+            clubBoardService.deleteBoard(request);
+
+            verify(clubBoardRepository).delete(board);
+        }
+
+        @Test
+        @DisplayName("게시글이 다른 동아리 소속이면 예외가 발생하고 삭제되지 않는다.")
+        void deleteBoardClubMismatch() {
+            Club myClub = mockClub("club123");
+            Club otherClub = mockClub("otherClub");
+            when(clubRepository.findByAdminUsername("admin")).thenReturn(Optional.of(myClub));
+
+            ClubBoard board = mock(ClubBoard.class);
+            when(board.getClub()).thenReturn(otherClub);
+            when(clubBoardRepository.findById("board123")).thenReturn(Optional.of(board));
+
+            DeleteBoardServiceRequest request = new DeleteBoardServiceRequest("admin", "club123", "board123");
+
+            assertThatThrownBy(() -> clubBoardService.deleteBoard(request))
+                    .isInstanceOf(ClubAdminNameNotMatchException.class);
+
+            verify(clubBoardRepository, never()).delete(any());
         }
     }
 }


### PR DESCRIPTION
## ✨ 작업 내용
- `ClubBoardAdminController`에 게시글 생성/수정/삭제 API 3종 연결 (기존엔 컨트롤러가 비어있어 라우팅 자체가 없었음)
- `ClubBoard`에 patch 스타일 `update(title, content)` 도메인 메서드 추가 — PATCH 방식 부분 수정, `JsonNullable` 대신 일반 nullable `String` 사용 (해당 필드들은 명시적 null 허용이 필요 없어서 더 단순한 방식 채택)
- `createBoard`가 path의 `clubId`를 전혀 검증하지 않던 버그 수정 (`deleteBoard`만 검증하던 비일관성 해소)
- 정의만 되고 쓰이지 않던 `DeleteBoardServiceRequest` DTO를 실제로 연결
- Figma(`동아리 상세-게시판`) 확인 결과 반영: 무한스크롤 목록 응답(`ClubBoardListResponse.ClubBoardSummary`)에 `content`(본문 전체) 필드 추가. 관리자용 목록 조회는 별도 엔드포인트 없이 기존 유저 라우트(`GET /api/clubs/{clubId}/boards`)를 재사용
- Swagger 문서: `ClubBoardAdminController`에 인라인 `@Operation`/`@ApiResponses` 작성 (같은 도메인의 `ClubBoardUserController` 컨벤션 유지)
- DB 변경 없음

---

## 🔍 관련 이슈
- 해결한 이슈 번호: #316

---

## ✅ 체크리스트
- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요? (`bash maintenance/verify.sh` green — clean build + 전체 테스트)
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항
- 신규/보강 테스트 13건 (`ClubBoardAdminServiceTest` 단위 테스트 8건, `ClubBoardAdminControllerTest` MockMvc 테스트 5건) 모두 green.
- 작업 중 별도로 발견한 이슈: `feat/#316` worktree를 새로 만들었을 때 `application*.yml`, `application-test.yml`, Firebase 서비스 계정 json, `db/seed`(mock 데이터 삽입용 SQL) 및 mock CSV들이 `.gitignore`에 걸려 있어 새 worktree에는 복사되지 않는다는 걸 확인했습니다 (참고: `db/migration`의 실제 스키마 마이그레이션 파일들은 git에 정상적으로 커밋되어 있어 문제 없었습니다). 특히 `application-test.yml`이 없으면 `spring.flyway.enabled=false` 오버라이드가 적용되지 않아 Flyway가 기본값(enabled)으로 동작해 스키마 생성 전에 마이그레이션을 시도하며 대량 실패가 발생합니다 — 이번엔 로컬에서 파일을 수동 복사해 우회했습니다. `git worktree`는 gitignore된 파일을 새 워크트리에 복사하지 않는 게 표준 동작이라, 팀 차원에서 `ship` 스킬(혹은 별도 스크립트)에 "새 worktree 생성 시 로컬 설정 파일 자동 복사" 단계를 추가하는 걸 권장합니다.
