### PR TITLE
[Chore] ship 스킬: worktree 생성 시 로컬 리소스 복사 단계 추가

### DIFF
--- a/.omc/skills/ship/SKILL.md
+++ b/.omc/skills/ship/SKILL.md
@@ -65,13 +65,24 @@ Every issue body must also cover the fields from [`maintenance/task.md`](../../.
    Immediately run `git branch --unset-upstream` inside the new worktree — `git worktree add -b <branch> origin/develop` auto-sets upstream tracking to `origin/develop`, and a bare `git push` would then target the protected `develop` branch instead of creating a new remote branch.
    Then call `EnterWorktree({ path: ".claude/worktrees/<prefix>-<issue-number>" })` to switch the session's cwd. If the tool reports the path is already the current working directory (this can happen if a prior Bash `cd` already moved the shell there), that's fine — no further action needed, just confirm with `pwd` / `git status --short --branch`.
 
+   **Immediately after creating the worktree, restore local-only resources.** `git worktree add` only populates git-tracked files — anything gitignored (`application*.yml`, the Firebase service-account `*.json` key, `db/seed/`, mock `*.csv` fixtures) exists solely on disk in whichever checkout created it, never in git history, so a brand-new worktree starts without them. Skipping this produces confusing, unrelated failures in step 5 (e.g. Flyway running with its default `enabled` instead of the `application-test.yml` override, cascading into dozens of Spring-context test failures that have nothing to do with the actual feature). Copy them in from the original checkout — find it via `git worktree list` (the entry that isn't the new one, usually the repo root) — before running `verify.sh`:
+   ```bash
+   SRC_ROOT="<original checkout root from `git worktree list`>"
+   NEW_ROOT=".claude/worktrees/<prefix>-<issue-number>"
+   git -C "$SRC_ROOT" status --porcelain --ignored=matching -- src | grep '^!!' | sed 's/^!! //' | while IFS= read -r f; do
+     mkdir -p "$NEW_ROOT/$(dirname "$f")"
+     cp -r "$SRC_ROOT/$f" "$NEW_ROOT/$f"
+   done
+   ```
+   Never edit `.gitignore` to make these trackable — they stay untracked by design (secrets/local fixtures). This step only mirrors the working-tree copy across so the new worktree can actually build and test; it changes nothing about what git tracks.
+
 4. **Implement (Change)** — follow `AGENTS.md` conventions. Use the per-type mini checklist in `maintenance/task.md` as the working checklist.
 
 5. **Verify**:
    ```bash
    bash maintenance/verify.sh
    ```
-   On failure, go back to step 4 and retry. **Cap at 3 verify attempts.** If still failing after 3, stop — do not commit/push/open a PR. Report the failure with the test report path (`build/reports/tests/test/index.html`) and leave the worktree in place for manual inspection.
+   On failure, go back to step 4 and retry. **Cap at 3 verify attempts.** If still failing after 3, stop — do not commit/push/open a PR. Report the failure with the test report path (`build/reports/tests/test/index.html`) and leave the worktree in place for manual inspection. If a failure looks unrelated to the actual change (widespread Spring-context/Flyway errors across unrelated domains), first double-check the local-resource copy above before spending a retry attempt.
 
 6. **Record** — append a dated section to `IMPLEMENTATION.md`, following its existing format (see prior entries: dated header, 주요 작업 내용, 기술적 세부 사항, 업데이트된 파일, 최종 확인 사항).
 


### PR DESCRIPTION
## ✨ 작업 내용
- `ship` 스킬(`.omc/skills/ship/SKILL.md`)의 "브랜치+worktree 생성" 단계에 로컬 전용 리소스 복사 서브스텝 추가
- `git worktree add`는 git-tracked 파일만 채우므로, gitignore된 `application*.yml`, Firebase 서비스 계정 json, `db/seed/`, mock csv가 새 worktree엔 없어 `verify.sh`가 코드와 무관하게(Flyway 기본 설정 충돌) 대량 실패하던 문제의 재발 방지책
- `.gitignore`는 변경하지 않음 (요청에 따라 그대로 유지)
- 문서/스킬 변경만 있음, DB 변경 없음

---

## 🔍 관련 이슈
- 해결한 이슈 번호: #318
- 관련된 이슈 번호 (선택): #316 (이 문제를 실제로 겪은 작업)

---

## ✅ 체크리스트
- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요? (`bash maintenance/verify.sh` green — 문서 변경이라 영향 없음, 확인 차 재실행)
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항
- `.gitignore`는 의도적으로 변경하지 않았습니다 — 해당 파일들은 여전히 로컬 전용/시크릿으로 유지되고, 이번 변경은 새 worktree에 "복사"만 해오는 절차를 스킬 문서에 추가한 것입니다.
