### PR TITLE
미흡한 테스트 커버리지 확보 (Jacoco 게이트 + 단위/E2E 백필) / (test/#22 -> develop)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.0'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'jacoco'
 }
 
 group = 'org.project.ttokttok'
@@ -85,4 +86,61 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
 }
+
+jacoco {
+	toolVersion = "0.8.12"
+}
+
+// 커버리지 측정에서 제외할 항목 (생성 코드/보일러플레이트/설정)
+def jacocoExcludes = [
+		'**/Q*.class',                 // QueryDSL 생성 클래스
+		'**/*Application*',            // 스프링 부트 진입점
+		'**/dto/**',                   // 요청/응답 DTO
+		'**/*Request*',
+		'**/*Response*',
+		'**/*QueryResponse*',
+		'**/docs/**',                  // Swagger 문서 인터페이스
+		'**/*Docs*',
+		'**/config/**',                // 설정 클래스
+		'**/*Config*',
+		'**/enums/**',                 // enum
+		'**/exception/**',             // 커스텀 예외(로직 없음)
+]
+
+jacocoTestReport {
+	dependsOn test
+	reports {
+		html.required = true
+		xml.required = true
+		csv.required = false
+	}
+	afterEvaluate {
+		classDirectories.setFrom(files(classDirectories.files.collect {
+			fileTree(dir: it, exclude: jacocoExcludes)
+		}))
+	}
+}
+
+jacocoTestCoverageVerification {
+	dependsOn test
+	afterEvaluate {
+		classDirectories.setFrom(files(classDirectories.files.collect {
+			fileTree(dir: it, exclude: jacocoExcludes)
+		}))
+	}
+	violationRules {
+		rule {
+			element = 'BUNDLE'
+			limit {
+				counter = 'LINE'
+				value = 'COVEREDRATIO'
+				minimum = 0.80
+			}
+		}
+	}
+}
+
+// 80% 라인 커버리지 하드 게이트: check(= build) 시 검증을 강제한다.
+check.dependsOn jacocoTestCoverageVerification

--- a/src/test/java/org/project/ttokttok/domain/applicant/controller/ApplicantAdminApiControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/applicant/controller/ApplicantAdminApiControllerTest.java
@@ -1,0 +1,170 @@
+package org.project.ttokttok.domain.applicant.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.applicant.domain.enums.Gender;
+import org.project.ttokttok.domain.applicant.domain.enums.Grade;
+import org.project.ttokttok.domain.applicant.domain.enums.StudentStatus;
+import org.project.ttokttok.domain.applicant.service.ApplicantAdminService;
+import org.project.ttokttok.domain.applicant.service.dto.request.ApplicantFinalizationRequest;
+import org.project.ttokttok.domain.applicant.service.dto.request.ApplicantPageServiceRequest;
+import org.project.ttokttok.domain.applicant.service.dto.request.ApplicantSearchServiceRequest;
+import org.project.ttokttok.domain.applicant.service.dto.request.ApplicantStatusServiceRequest;
+import org.project.ttokttok.domain.applicant.service.dto.request.StatusUpdateServiceRequest;
+import org.project.ttokttok.domain.applicant.service.dto.response.ApplicantDetailServiceResponse;
+import org.project.ttokttok.domain.applicant.service.dto.response.ApplicantFinalizeServiceResponse;
+import org.project.ttokttok.domain.applicant.service.dto.response.ApplicantPageServiceResponse;
+import org.project.ttokttok.global.annotationresolver.auth.AuthUserInfoResolver;
+import org.project.ttokttok.global.auth.jwt.service.TokenProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ApplicantAdminApiController.class)
+class ApplicantAdminApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ApplicantAdminService applicantAdminService;
+
+    @MockitoBean
+    private TokenProvider tokenProvider;
+
+    @MockitoBean
+    private AuthUserInfoResolver authUserInfoResolver;
+
+    private void mockAuthUser(String username) throws Exception {
+        given(authUserInfoResolver.supportsParameter(any())).willReturn(true);
+        given(authUserInfoResolver.resolveArgument(any(), any(), any(), any())).willReturn(username);
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("지원자 목록 조회 API를 호출하면 200을 반환한다")
+    void getApplicantsPage() throws Exception {
+        mockAuthUser("admin@sangmyung.kr");
+        given(applicantAdminService.getApplicantPage(any(ApplicantPageServiceRequest.class)))
+                .willReturn(ApplicantPageServiceResponse.toEmpty());
+
+        mockMvc.perform(get("/api/admin/applies").param("kind", "DOCUMENT"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("지원자 상세 조회 API를 호출하면 200과 지원자 정보를 반환한다")
+    void getApplicantDetail() throws Exception {
+        mockAuthUser("admin@sangmyung.kr");
+        ApplicantDetailServiceResponse detail = ApplicantDetailServiceResponse.of(
+                "홍길동", 22, "컴퓨터과학과", "hong@sangmyung.kr", "010-1234-5678",
+                StudentStatus.ENROLLED, Grade.FIRST_GRADE, Gender.MALE, List.of(), List.of()
+        );
+        given(applicantAdminService.getApplicantDetail(any(), any())).willReturn(detail);
+
+        mockMvc.perform(get("/api/admin/applies/{applicantId}", "applicant-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("홍길동"))
+                .andExpect(jsonPath("$.major").value("컴퓨터과학과"));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("지원자 검색 API를 호출하면 200을 반환한다")
+    void applicantPageSearch() throws Exception {
+        mockAuthUser("admin@sangmyung.kr");
+        given(applicantAdminService.searchApplicantByKeyword(any(ApplicantSearchServiceRequest.class)))
+                .willReturn(ApplicantPageServiceResponse.toEmpty());
+
+        mockMvc.perform(get("/api/admin/applies/search").param("name", "홍").param("kind", "DOCUMENT"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("합격자 목록 조회 API를 호출하면 200을 반환한다")
+    void getPassedApplicantsPage() throws Exception {
+        mockAuthUser("admin@sangmyung.kr");
+        given(applicantAdminService.getApplicantsByStatus(any(ApplicantStatusServiceRequest.class)))
+                .willReturn(ApplicantPageServiceResponse.toEmpty());
+
+        mockMvc.perform(get("/api/admin/applies/passed").param("kind", "DOCUMENT"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("불합격자 목록 조회 API를 호출하면 200을 반환한다")
+    void getFailedApplicantsPage() throws Exception {
+        mockAuthUser("admin@sangmyung.kr");
+        given(applicantAdminService.getApplicantsByStatus(any(ApplicantStatusServiceRequest.class)))
+                .willReturn(ApplicantPageServiceResponse.toEmpty());
+
+        mockMvc.perform(get("/api/admin/applies/failed").param("kind", "DOCUMENT"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("지원자 평가 상태 변경 API를 호출하면 200과 완료 메시지를 반환한다")
+    void updateApplicantEvaluation() throws Exception {
+        mockAuthUser("admin@sangmyung.kr");
+        doNothing().when(applicantAdminService).updateApplicantStatus(any(StatusUpdateServiceRequest.class));
+
+        mockMvc.perform(patch("/api/admin/applies/evaluations/{applicantId}", "applicant-1").with(csrf())
+                        .param("kind", "DOCUMENT")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"PASS\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("지원자 상태가 성공적으로 업데이트되었습니다."));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("지원자 상태를 확정하는 API를 호출하면 200과 확정 결과를 반환한다")
+    void finalizeApplicantsStatus() throws Exception {
+        mockAuthUser("admin@sangmyung.kr");
+        given(applicantAdminService.finalizeApplicantsStatus(any(ApplicantFinalizationRequest.class)))
+                .willReturn(ApplicantFinalizeServiceResponse.of(3, 5));
+
+        mockMvc.perform(put("/api/admin/applies/{clubId}/finalize", "club-1").with(csrf())
+                        .param("kind", "DOCUMENT"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("지원자에게 결과 메일 전송 API를 호출하면 200과 완료 메시지를 반환한다")
+    void sendEmailToApplicants() throws Exception {
+        mockAuthUser("admin@sangmyung.kr");
+        doNothing().when(applicantAdminService)
+                .sendResultMailToApplicants(any(), any(), any(), any());
+
+        String body = "{\"pass\":{\"title\":\"합격 안내\",\"body\":\"축하합니다\"},"
+                + "\"fail\":{\"title\":\"불합격 안내\",\"body\":\"감사합니다\"}}";
+
+        mockMvc.perform(post("/api/admin/applies/{clubId}/send-email", "club-1").with(csrf())
+                        .param("kind", "DOCUMENT")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("이메일 전송이 완료되었습니다."));
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/applicant/domain/ApplicantTest.java
+++ b/src/test/java/org/project/ttokttok/domain/applicant/domain/ApplicantTest.java
@@ -1,0 +1,280 @@
+package org.project.ttokttok.domain.applicant.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.applicant.domain.enums.ApplicantPhase;
+import org.project.ttokttok.domain.applicant.domain.enums.Gender;
+import org.project.ttokttok.domain.applicant.domain.enums.Grade;
+import org.project.ttokttok.domain.applicant.domain.enums.PhaseStatus;
+import org.project.ttokttok.domain.applicant.domain.enums.StudentStatus;
+import org.project.ttokttok.domain.applicant.domain.json.Answer;
+import org.project.ttokttok.domain.applicant.exception.InvalidPhaseTransitionException;
+import org.project.ttokttok.domain.applyform.domain.ApplyForm;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class ApplicantTest {
+
+    private Applicant createApplicant(ApplyForm applyForm) {
+        return Applicant.createApplicant(
+                "test@sangmyung.kr",
+                "홍길동",
+                21,
+                "소프트웨어학과",
+                "hong@gmail.com",
+                "010-1234-5678",
+                StudentStatus.ENROLLED,
+                Grade.SECOND_GRADE,
+                Gender.MALE,
+                applyForm
+        );
+    }
+
+    @Nested
+    @DisplayName("createApplicant() 테스트")
+    class CreateApplicantTest {
+
+        @Test
+        @DisplayName("지원자 정보로 Applicant를 생성하면 초기 단계는 DOCUMENT이다")
+        void createApplicant_Success() {
+            // given
+            ApplyForm applyForm = mock(ApplyForm.class);
+
+            // when
+            Applicant applicant = createApplicant(applyForm);
+
+            // then
+            assertThat(applicant.getName()).isEqualTo("홍길동");
+            assertThat(applicant.getCurrentPhase()).isEqualTo(ApplicantPhase.DOCUMENT);
+            assertThat(applicant.getDocumentPhase()).isNull();
+            assertThat(applicant.getInterviewPhase()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("submitDocument() 테스트")
+    class SubmitDocumentTest {
+
+        @Test
+        @DisplayName("서류를 제출하면 DocumentPhase가 생성되고 DOCUMENT 단계가 된다")
+        void submitDocument_Success() {
+            // given
+            Applicant applicant = createApplicant(mock(ApplyForm.class));
+            List<Answer> answers = List.of();
+
+            // when
+            applicant.submitDocument(answers);
+
+            // then
+            assertThat(applicant.getDocumentPhase()).isNotNull();
+            assertThat(applicant.isInDocumentPhase()).isTrue();
+        }
+
+        @Test
+        @DisplayName("이미 면접 단계인 지원자가 서류를 다시 제출하면 InvalidPhaseTransitionException이 발생한다")
+        void submitDocument_Fail_WhenAlreadyInInterviewPhase() {
+            // given
+            ApplyForm applyForm = mock(ApplyForm.class);
+            Applicant applicant = createApplicant(applyForm);
+            applicant.submitDocument(List.of());
+            applicant.updateToInterviewPhase(LocalDate.of(2026, 8, 1));
+
+            // when & then
+            assertThatThrownBy(() -> applicant.submitDocument(List.of()))
+                    .isInstanceOf(InvalidPhaseTransitionException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("서류 평가 결과 테스트")
+    class DocumentEvaluationTest {
+
+        @Test
+        @DisplayName("passDocumentEvaluation() 호출 시 서류 상태가 PASS가 된다")
+        void passDocumentEvaluation_Success() {
+            // given
+            Applicant applicant = createApplicant(mock(ApplyForm.class));
+            applicant.submitDocument(List.of());
+
+            // when
+            applicant.passDocumentEvaluation();
+
+            // then
+            assertThat(applicant.getDocumentPhase().getStatus()).isEqualTo(PhaseStatus.PASS);
+        }
+
+        @Test
+        @DisplayName("면접 단계가 없는 지원자는 failDocumentEvaluation() 호출 시 서류 상태가 FAIL이 된다")
+        void failDocumentEvaluation_Success() {
+            // given
+            ApplyForm applyForm = mock(ApplyForm.class);
+            given(applyForm.isHasInterview()).willReturn(false);
+            Applicant applicant = createApplicant(applyForm);
+            applicant.submitDocument(List.of());
+
+            // when
+            applicant.failDocumentEvaluation();
+
+            // then
+            assertThat(applicant.getDocumentPhase().getStatus()).isEqualTo(PhaseStatus.FAIL);
+        }
+
+        @Test
+        @DisplayName("이미 면접 단계에 존재하는 지원자는 failDocumentEvaluation() 호출 시 IllegalArgumentException이 발생한다")
+        void failDocumentEvaluation_Fail_WhenAlreadyInInterviewPhase() {
+            // given
+            ApplyForm applyForm = mock(ApplyForm.class);
+            given(applyForm.isHasInterview()).willReturn(true);
+            Applicant applicant = createApplicant(applyForm);
+            applicant.submitDocument(List.of());
+            applicant.updateToInterviewPhase(LocalDate.of(2026, 8, 1));
+
+            // when & then
+            assertThatThrownBy(applicant::failDocumentEvaluation)
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("이미 면접 단계에 존재하는 지원자입니다.");
+        }
+
+        @Test
+        @DisplayName("setDocumentEvaluating() 호출 시 서류 상태가 EVALUATING이 된다")
+        void setDocumentEvaluating_Success() {
+            // given
+            Applicant applicant = createApplicant(mock(ApplyForm.class));
+            applicant.submitDocument(List.of());
+            applicant.passDocumentEvaluation();
+
+            // when
+            applicant.setDocumentEvaluating();
+
+            // then
+            assertThat(applicant.getDocumentPhase().getStatus()).isEqualTo(PhaseStatus.EVALUATING);
+        }
+
+        @Test
+        @DisplayName("이미 면접 단계에 존재하는 지원자는 setDocumentEvaluating() 호출 시 IllegalArgumentException이 발생한다")
+        void setDocumentEvaluating_Fail_WhenAlreadyInInterviewPhase() {
+            // given
+            ApplyForm applyForm = mock(ApplyForm.class);
+            given(applyForm.isHasInterview()).willReturn(true);
+            Applicant applicant = createApplicant(applyForm);
+            applicant.submitDocument(List.of());
+            applicant.updateToInterviewPhase(LocalDate.of(2026, 8, 1));
+
+            // when & then
+            assertThatThrownBy(applicant::setDocumentEvaluating)
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("이미 면접 단계에 존재하는 지원자입니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("면접 단계 테스트")
+    class InterviewPhaseTransitionTest {
+
+        @Test
+        @DisplayName("updateToInterviewPhase() 호출 시 InterviewPhase가 생성되고 INTERVIEW 단계가 된다")
+        void updateToInterviewPhase_Success() {
+            // given
+            Applicant applicant = createApplicant(mock(ApplyForm.class));
+            LocalDate interviewDate = LocalDate.of(2026, 8, 1);
+
+            // when
+            applicant.updateToInterviewPhase(interviewDate);
+
+            // then
+            assertThat(applicant.getInterviewPhase()).isNotNull();
+            assertThat(applicant.getInterviewPhase().getInterviewDate()).isEqualTo(interviewDate);
+            assertThat(applicant.isInInterviewPhase()).isTrue();
+        }
+
+        @Test
+        @DisplayName("passInterview() 호출 시 면접 상태가 PASS가 된다")
+        void passInterview_Success() {
+            // given
+            Applicant applicant = createApplicant(mock(ApplyForm.class));
+            applicant.updateToInterviewPhase(LocalDate.of(2026, 8, 1));
+
+            // when
+            applicant.passInterview();
+
+            // then
+            assertThat(applicant.getInterviewPhase().getStatus()).isEqualTo(PhaseStatus.PASS);
+        }
+
+        @Test
+        @DisplayName("failInterview() 호출 시 면접 상태가 FAIL이 된다")
+        void failInterview_Success() {
+            // given
+            Applicant applicant = createApplicant(mock(ApplyForm.class));
+            applicant.updateToInterviewPhase(LocalDate.of(2026, 8, 1));
+
+            // when
+            applicant.failInterview();
+
+            // then
+            assertThat(applicant.getInterviewPhase().getStatus()).isEqualTo(PhaseStatus.FAIL);
+        }
+
+        @Test
+        @DisplayName("setInterviewEvaluating() 호출 시 면접 상태가 EVALUATING이 된다")
+        void setInterviewEvaluating_Success() {
+            // given
+            Applicant applicant = createApplicant(mock(ApplyForm.class));
+            applicant.updateToInterviewPhase(LocalDate.of(2026, 8, 1));
+            applicant.passInterview();
+
+            // when
+            applicant.setInterviewEvaluating();
+
+            // then
+            assertThat(applicant.getInterviewPhase().getStatus()).isEqualTo(PhaseStatus.EVALUATING);
+        }
+    }
+
+    @Nested
+    @DisplayName("편의 메서드 테스트")
+    class ConvenienceMethodTest {
+
+        @Test
+        @DisplayName("hasInterviewPhase()는 ApplyForm의 면접 전형 존재 여부를 그대로 반환한다")
+        void hasInterviewPhase_DelegatesToApplyForm() {
+            // given
+            ApplyForm applyFormWithInterview = mock(ApplyForm.class);
+            given(applyFormWithInterview.isHasInterview()).willReturn(true);
+            Applicant applicantWithInterview = createApplicant(applyFormWithInterview);
+
+            ApplyForm applyFormWithoutInterview = mock(ApplyForm.class);
+            given(applyFormWithoutInterview.isHasInterview()).willReturn(false);
+            Applicant applicantWithoutInterview = createApplicant(applyFormWithoutInterview);
+
+            // when & then
+            assertThat(applicantWithInterview.hasInterviewPhase()).isTrue();
+            assertThat(applicantWithoutInterview.hasInterviewPhase()).isFalse();
+        }
+
+        @Test
+        @DisplayName("isInDocumentPhase()와 isInInterviewPhase()는 currentPhase에 따라 결정된다")
+        void isInDocumentPhase_And_isInInterviewPhase() {
+            // given
+            Applicant applicant = createApplicant(mock(ApplyForm.class));
+
+            // then: 생성 직후는 DOCUMENT 단계
+            assertThat(applicant.isInDocumentPhase()).isTrue();
+            assertThat(applicant.isInInterviewPhase()).isFalse();
+
+            // when: 면접 단계로 전환
+            applicant.updateToInterviewPhase(LocalDate.of(2026, 8, 1));
+
+            // then
+            assertThat(applicant.isInDocumentPhase()).isFalse();
+            assertThat(applicant.isInInterviewPhase()).isTrue();
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/applicant/domain/DocumentPhaseTest.java
+++ b/src/test/java/org/project/ttokttok/domain/applicant/domain/DocumentPhaseTest.java
@@ -1,0 +1,149 @@
+package org.project.ttokttok.domain.applicant.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.applicant.domain.enums.PhaseStatus;
+import org.project.ttokttok.domain.applicant.domain.json.Answer;
+import org.project.ttokttok.domain.memo.domain.Memo;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class DocumentPhaseTest {
+
+    @Nested
+    @DisplayName("create() 테스트")
+    class CreateTest {
+
+        @Test
+        @DisplayName("지원자와 답변 목록으로 서류 단계를 생성하면 상태는 EVALUATING이다")
+        void create_Success() {
+            // given
+            Applicant applicant = mock(Applicant.class);
+            List<Answer> answers = List.of();
+
+            // when
+            DocumentPhase documentPhase = DocumentPhase.create(applicant, answers);
+
+            // then
+            assertThat(documentPhase.getApplicant()).isEqualTo(applicant);
+            assertThat(documentPhase.getAnswers()).isEqualTo(answers);
+            assertThat(documentPhase.getStatus()).isEqualTo(PhaseStatus.EVALUATING);
+            assertThat(documentPhase.getMemos()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("updateStatus() 테스트")
+    class UpdateStatusTest {
+
+        @Test
+        @DisplayName("상태를 변경할 수 있다")
+        void updateStatus_Success() {
+            // given
+            DocumentPhase documentPhase = DocumentPhase.create(mock(Applicant.class), List.of());
+
+            // when
+            documentPhase.updateStatus(PhaseStatus.PASS);
+
+            // then
+            assertThat(documentPhase.getStatus()).isEqualTo(PhaseStatus.PASS);
+        }
+    }
+
+    @Nested
+    @DisplayName("메모 관련 비즈니스 메서드 테스트")
+    class MemoTest {
+
+        @Test
+        @DisplayName("addMemo() 호출 시 메모가 추가되고 생성된 memoId가 반환된다")
+        void addMemo_Success() {
+            // given
+            DocumentPhase documentPhase = DocumentPhase.create(mock(Applicant.class), List.of());
+
+            // when
+            String memoId = documentPhase.addMemo("면접 태도가 좋았음");
+
+            // then
+            assertThat(memoId).isNotNull();
+            assertThat(documentPhase.getMemos()).hasSize(1);
+            assertThat(documentPhase.getMemos().get(0).getId()).isEqualTo(memoId);
+            assertThat(documentPhase.getMemos().get(0).getContent()).isEqualTo("면접 태도가 좋았음");
+        }
+
+        @Test
+        @DisplayName("updateMemo() 호출 시 해당 memoId의 메모 내용이 수정된다")
+        void updateMemo_Success() {
+            // given
+            DocumentPhase documentPhase = DocumentPhase.create(mock(Applicant.class), List.of());
+            String memoId = documentPhase.addMemo("원래 내용");
+
+            // when
+            documentPhase.updateMemo(memoId, "수정된 내용");
+
+            // then
+            Memo updated = documentPhase.getMemos().get(0);
+            assertThat(updated.getContent()).isEqualTo("수정된 내용");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 memoId로 updateMemo()를 호출해도 예외 없이 아무 일도 일어나지 않는다")
+        void updateMemo_NoOp_WhenMemoNotFound() {
+            // given
+            DocumentPhase documentPhase = DocumentPhase.create(mock(Applicant.class), List.of());
+            documentPhase.addMemo("원래 내용");
+
+            // when
+            documentPhase.updateMemo("존재하지-않는-id", "수정된 내용");
+
+            // then
+            assertThat(documentPhase.getMemos()).hasSize(1);
+            assertThat(documentPhase.getMemos().get(0).getContent()).isEqualTo("원래 내용");
+        }
+
+        @Test
+        @DisplayName("deleteMemo() 호출 시 해당 memoId의 메모가 삭제된다")
+        void deleteMemo_Success() {
+            // given
+            DocumentPhase documentPhase = DocumentPhase.create(mock(Applicant.class), List.of());
+            String memoId = documentPhase.addMemo("삭제될 메모");
+
+            // when
+            documentPhase.deleteMemo(memoId);
+
+            // then
+            assertThat(documentPhase.getMemos()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 memoId로 deleteMemo()를 호출해도 예외 없이 기존 메모는 유지된다")
+        void deleteMemo_NoOp_WhenMemoNotFound() {
+            // given
+            DocumentPhase documentPhase = DocumentPhase.create(mock(Applicant.class), List.of());
+            documentPhase.addMemo("유지될 메모");
+
+            // when
+            documentPhase.deleteMemo("존재하지-않는-id");
+
+            // then
+            assertThat(documentPhase.getMemos()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("getMemos()는 방어적 복사본을 반환하여 외부에서 수정해도 내부 상태에 영향을 주지 않는다")
+        void getMemos_ReturnsDefensiveCopy() {
+            // given
+            DocumentPhase documentPhase = DocumentPhase.create(mock(Applicant.class), List.of());
+            documentPhase.addMemo("메모");
+
+            // when
+            documentPhase.getMemos().clear();
+
+            // then
+            assertThat(documentPhase.getMemos()).hasSize(1);
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/applicant/domain/InterviewPhaseTest.java
+++ b/src/test/java/org/project/ttokttok/domain/applicant/domain/InterviewPhaseTest.java
@@ -1,0 +1,85 @@
+package org.project.ttokttok.domain.applicant.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.applicant.domain.enums.PhaseStatus;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class InterviewPhaseTest {
+
+    @Nested
+    @DisplayName("create() 테스트")
+    class CreateTest {
+
+        @Test
+        @DisplayName("지원자와 면접일로 면접 단계를 생성하면 상태는 EVALUATING이다")
+        void create_Success() {
+            // given
+            Applicant applicant = mock(Applicant.class);
+            LocalDate interviewDate = LocalDate.of(2026, 8, 1);
+
+            // when
+            InterviewPhase interviewPhase = InterviewPhase.create(applicant, interviewDate);
+
+            // then
+            assertThat(interviewPhase.getApplicant()).isEqualTo(applicant);
+            assertThat(interviewPhase.getInterviewDate()).isEqualTo(interviewDate);
+            assertThat(interviewPhase.getStatus()).isEqualTo(PhaseStatus.EVALUATING);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateStatus() 테스트")
+    class UpdateStatusTest {
+
+        @Test
+        @DisplayName("상태를 PASS로 변경할 수 있다")
+        void updateStatus_Pass() {
+            // given
+            InterviewPhase interviewPhase = InterviewPhase.create(mock(Applicant.class), LocalDate.of(2026, 8, 1));
+
+            // when
+            interviewPhase.updateStatus(PhaseStatus.PASS);
+
+            // then
+            assertThat(interviewPhase.getStatus()).isEqualTo(PhaseStatus.PASS);
+        }
+
+        @Test
+        @DisplayName("상태를 FAIL로 변경할 수 있다")
+        void updateStatus_Fail() {
+            // given
+            InterviewPhase interviewPhase = InterviewPhase.create(mock(Applicant.class), LocalDate.of(2026, 8, 1));
+
+            // when
+            interviewPhase.updateStatus(PhaseStatus.FAIL);
+
+            // then
+            assertThat(interviewPhase.getStatus()).isEqualTo(PhaseStatus.FAIL);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateInterviewDate() 테스트")
+    class UpdateInterviewDateTest {
+
+        @Test
+        @DisplayName("면접일을 변경할 수 있다")
+        void updateInterviewDate_Success() {
+            // given
+            InterviewPhase interviewPhase = InterviewPhase.create(mock(Applicant.class), LocalDate.of(2026, 8, 1));
+            LocalDate newDate = LocalDate.of(2026, 9, 15);
+
+            // when
+            interviewPhase.updateInterviewDate(newDate);
+
+            // then
+            assertThat(interviewPhase.getInterviewDate()).isEqualTo(newDate);
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/applicant/service/ApplicantAdminServiceTest.java
+++ b/src/test/java/org/project/ttokttok/domain/applicant/service/ApplicantAdminServiceTest.java
@@ -1,0 +1,820 @@
+package org.project.ttokttok.domain.applicant.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.domain.applicant.controller.dto.request.MailFormatRequest;
+import org.project.ttokttok.domain.applicant.domain.Applicant;
+import org.project.ttokttok.domain.applicant.domain.DocumentPhase;
+import org.project.ttokttok.domain.applicant.domain.InterviewPhase;
+import org.project.ttokttok.domain.applicant.domain.enums.Gender;
+import org.project.ttokttok.domain.applicant.domain.enums.Grade;
+import org.project.ttokttok.domain.applicant.domain.enums.PhaseStatus;
+import org.project.ttokttok.domain.applicant.domain.enums.StudentStatus;
+import org.project.ttokttok.domain.applicant.domain.json.Answer;
+import org.project.ttokttok.domain.applicant.exception.ApplicantNotFoundException;
+import org.project.ttokttok.domain.applicant.exception.UnAuthorizedApplicantAccessException;
+import org.project.ttokttok.domain.applicant.repository.ApplicantRepository;
+import org.project.ttokttok.domain.applicant.repository.dto.response.ApplicantPageQueryResponse;
+import org.project.ttokttok.domain.applicant.service.dto.request.ApplicantFinalizationRequest;
+import org.project.ttokttok.domain.applicant.service.dto.request.ApplicantPageServiceRequest;
+import org.project.ttokttok.domain.applicant.service.dto.request.ApplicantSearchServiceRequest;
+import org.project.ttokttok.domain.applicant.service.dto.request.ApplicantStatusServiceRequest;
+import org.project.ttokttok.domain.applicant.service.dto.request.SendResultMailServiceRequest;
+import org.project.ttokttok.domain.applicant.service.dto.request.StatusUpdateServiceRequest;
+import org.project.ttokttok.domain.applicant.service.dto.response.ApplicantFinalizeServiceResponse;
+import org.project.ttokttok.domain.applicant.service.dto.response.ApplicantPageServiceResponse;
+import org.project.ttokttok.domain.applyform.domain.ApplyForm;
+import org.project.ttokttok.domain.applyform.exception.ActiveApplyFormNotFoundException;
+import org.project.ttokttok.domain.applyform.repository.ApplyFormRepository;
+import org.project.ttokttok.domain.club.domain.Club;
+import org.project.ttokttok.domain.club.exception.NotClubAdminException;
+import org.project.ttokttok.domain.club.repository.ClubRepository;
+import org.project.ttokttok.domain.clubMember.repository.ClubMemberRepository;
+import org.project.ttokttok.infrastructure.email.service.EmailService;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.project.ttokttok.domain.applyform.domain.enums.ApplyFormStatus.ACTIVE;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicantAdminServiceTest {
+
+    @InjectMocks
+    private ApplicantAdminService applicantAdminService;
+
+    @Mock
+    private ApplicantRepository applicantRepository;
+
+    @Mock
+    private ApplyFormRepository applyFormRepository;
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private ClubMemberRepository clubMemberRepository;
+
+    @Mock
+    private EmailService emailService;
+
+    private static final String USERNAME = "adminUser";
+    private static final String CLUB_ID = "club-1";
+    private static final String APPLY_FORM_ID = "form-1";
+    private static final String APPLICANT_ID = "applicant-1";
+
+    @Nested
+    @DisplayName("getApplicantPage(): 지원자 페이지 조회")
+    class GetApplicantPageTest {
+
+        @Test
+        @DisplayName("활성 지원폼이 존재하면 지원자 페이지를 반환한다")
+        void getApplicantPage_success() {
+            // given
+            ApplicantPageServiceRequest request = ApplicantPageServiceRequest.of(
+                    USERNAME, "GRADE", false, 1, 7, "DOCUMENT");
+
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+
+            ApplyForm applyForm = mock(ApplyForm.class);
+            given(applyForm.getId()).willReturn(APPLY_FORM_ID);
+            given(applyForm.isHasInterview()).willReturn(true);
+            given(applyFormRepository.findTopByClubIdAndStatusOrderByCreatedAtDesc(CLUB_ID, ACTIVE))
+                    .willReturn(Optional.of(applyForm));
+
+            ApplicantPageQueryResponse queryResponse = ApplicantPageQueryResponse.builder()
+                    .currentPage(1)
+                    .totalPage(1)
+                    .totalCount(0)
+                    .applicants(List.of())
+                    .build();
+            given(applicantRepository.findApplicantsPageWithSortCriteria(
+                    "GRADE", false, 1, 7, APPLY_FORM_ID, "DOCUMENT"))
+                    .willReturn(queryResponse);
+
+            // when
+            ApplicantPageServiceResponse response = applicantAdminService.getApplicantPage(request);
+
+            // then
+            assertThat(response.hasInterview()).isTrue();
+            assertThat(response.currentPage()).isEqualTo(1);
+            assertThat(response.totalCount()).isEqualTo(0);
+            assertThat(response.applicants()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("활성 지원폼이 없으면 빈 응답을 반환한다")
+        void getApplicantPage_returnsEmpty_whenNoActiveApplyForm() {
+            // given
+            ApplicantPageServiceRequest request = ApplicantPageServiceRequest.of(
+                    USERNAME, "GRADE", false, 1, 7, "DOCUMENT");
+
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            given(applyFormRepository.findTopByClubIdAndStatusOrderByCreatedAtDesc(CLUB_ID, ACTIVE))
+                    .willReturn(Optional.empty());
+
+            // when
+            ApplicantPageServiceResponse response = applicantAdminService.getApplicantPage(request);
+
+            // then
+            assertThat(response.hasInterview()).isNull();
+            assertThat(response.applicants()).isEmpty();
+            verify(applicantRepository, never()).findApplicantsPageWithSortCriteria(
+                    anyString(), eq(false), eq(1), eq(7), anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("동아리 관리자가 아니면 NotClubAdminException이 발생한다")
+        void getApplicantPage_throwsNotClubAdminException_whenNotClubAdmin() {
+            // given
+            ApplicantPageServiceRequest request = ApplicantPageServiceRequest.of(
+                    USERNAME, "GRADE", false, 1, 7, "DOCUMENT");
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> applicantAdminService.getApplicantPage(request))
+                    .isInstanceOf(NotClubAdminException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getApplicantDetail(): 지원자 상세 조회")
+    class GetApplicantDetailTest {
+
+        @Test
+        @DisplayName("정상적으로 지원자 상세 정보를 조회한다")
+        void getApplicantDetail_success() {
+            // given
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+
+            ApplyForm applyForm = mock(ApplyForm.class);
+            given(applyForm.getClub()).willReturn(club);
+
+            List<Answer> answers = List.of(
+                    new Answer("질문1", null, null, true, List.of(), "답변1"));
+
+            DocumentPhase documentPhase = mock(DocumentPhase.class);
+            given(documentPhase.getAnswers()).willReturn(answers);
+            given(documentPhase.getMemos()).willReturn(List.of());
+
+            Applicant applicant = mock(Applicant.class);
+            given(applicant.getApplyForm()).willReturn(applyForm);
+            given(applicant.getDocumentPhase()).willReturn(documentPhase);
+            given(applicant.getName()).willReturn("홍길동");
+            given(applicant.getAge()).willReturn(22);
+            given(applicant.getMajor()).willReturn("컴퓨터공학과");
+            given(applicant.getEmail()).willReturn("hong@test.com");
+            given(applicant.getPhone()).willReturn("010-1234-5678");
+            given(applicant.getStudentStatus()).willReturn(StudentStatus.ENROLLED);
+            given(applicant.getGrade()).willReturn(Grade.FIRST_GRADE);
+            given(applicant.getGender()).willReturn(Gender.MALE);
+
+            given(applicantRepository.findByIdWithDocumentPhase(APPLICANT_ID))
+                    .willReturn(Optional.of(applicant));
+
+            // when
+            var response = applicantAdminService.getApplicantDetail(USERNAME, APPLICANT_ID);
+
+            // then
+            assertThat(response.name()).isEqualTo("홍길동");
+            assertThat(response.age()).isEqualTo(22);
+            assertThat(response.major()).isEqualTo("컴퓨터공학과");
+            assertThat(response.answers()).isEqualTo(answers);
+            assertThat(response.memos()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("서류 단계 정보가 없으면 답변과 메모는 빈 리스트를 반환한다")
+        void getApplicantDetail_returnsEmptyAnswersAndMemos_whenDocumentPhaseNull() {
+            // given
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+
+            ApplyForm applyForm = mock(ApplyForm.class);
+            given(applyForm.getClub()).willReturn(club);
+
+            Applicant applicant = mock(Applicant.class);
+            given(applicant.getApplyForm()).willReturn(applyForm);
+            given(applicant.getDocumentPhase()).willReturn(null);
+            given(applicant.getName()).willReturn("홍길동");
+            given(applicant.getAge()).willReturn(22);
+            given(applicant.getMajor()).willReturn("컴퓨터공학과");
+            given(applicant.getEmail()).willReturn("hong@test.com");
+            given(applicant.getPhone()).willReturn("010-1234-5678");
+            given(applicant.getStudentStatus()).willReturn(StudentStatus.ENROLLED);
+            given(applicant.getGrade()).willReturn(Grade.FIRST_GRADE);
+            given(applicant.getGender()).willReturn(Gender.MALE);
+
+            given(applicantRepository.findByIdWithDocumentPhase(APPLICANT_ID))
+                    .willReturn(Optional.of(applicant));
+
+            // when
+            var response = applicantAdminService.getApplicantDetail(USERNAME, APPLICANT_ID);
+
+            // then
+            assertThat(response.answers()).isEmpty();
+            assertThat(response.memos()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("지원자가 존재하지 않으면 ApplicantNotFoundException이 발생한다")
+        void getApplicantDetail_throwsApplicantNotFoundException() {
+            // given
+            Club club = mock(Club.class);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            given(applicantRepository.findByIdWithDocumentPhase(APPLICANT_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> applicantAdminService.getApplicantDetail(USERNAME, APPLICANT_ID))
+                    .isInstanceOf(ApplicantNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("지원자의 소속 동아리와 요청한 관리자의 동아리가 다르면 UnAuthorizedApplicantAccessException이 발생한다")
+        void getApplicantDetail_throwsUnAuthorizedApplicantAccessException() {
+            // given
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+
+            Club otherClub = mock(Club.class);
+            given(otherClub.getId()).willReturn("other-club");
+
+            ApplyForm applyForm = mock(ApplyForm.class);
+            given(applyForm.getClub()).willReturn(otherClub);
+
+            Applicant applicant = mock(Applicant.class);
+            given(applicant.getApplyForm()).willReturn(applyForm);
+
+            given(applicantRepository.findByIdWithDocumentPhase(APPLICANT_ID))
+                    .willReturn(Optional.of(applicant));
+
+            // when & then
+            assertThatThrownBy(() -> applicantAdminService.getApplicantDetail(USERNAME, APPLICANT_ID))
+                    .isInstanceOf(UnAuthorizedApplicantAccessException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("searchApplicantByKeyword(): 이름으로 지원자 검색")
+    class SearchApplicantByKeywordTest {
+
+        @Test
+        @DisplayName("정상적으로 검색 결과를 반환한다")
+        void searchApplicantByKeyword_success() {
+            // given
+            ApplicantSearchServiceRequest request = ApplicantSearchServiceRequest.of(
+                    USERNAME, "홍길동", "GRADE", false, 1, 7, "DOCUMENT");
+
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+
+            ApplyForm applyForm = mock(ApplyForm.class);
+            given(applyForm.getId()).willReturn(APPLY_FORM_ID);
+            given(applyForm.isHasInterview()).willReturn(false);
+            given(applyFormRepository.findTopByClubIdAndStatusOrderByCreatedAtDesc(CLUB_ID, ACTIVE))
+                    .willReturn(Optional.of(applyForm));
+
+            ApplicantPageQueryResponse queryResponse = ApplicantPageQueryResponse.builder()
+                    .currentPage(1)
+                    .totalPage(1)
+                    .totalCount(1)
+                    .applicants(List.of())
+                    .build();
+            given(applicantRepository.searchApplicantsByKeyword(
+                    "홍길동", "GRADE", false, 1, 7, APPLY_FORM_ID, "DOCUMENT"))
+                    .willReturn(queryResponse);
+
+            // when
+            ApplicantPageServiceResponse response = applicantAdminService.searchApplicantByKeyword(request);
+
+            // then
+            assertThat(response.hasInterview()).isFalse();
+            assertThat(response.totalCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("활성 지원폼이 없으면 빈 응답을 반환한다")
+        void searchApplicantByKeyword_returnsEmpty_whenNoActiveApplyForm() {
+            // given
+            ApplicantSearchServiceRequest request = ApplicantSearchServiceRequest.of(
+                    USERNAME, "홍길동", "GRADE", false, 1, 7, "DOCUMENT");
+
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            given(applyFormRepository.findTopByClubIdAndStatusOrderByCreatedAtDesc(CLUB_ID, ACTIVE))
+                    .willReturn(Optional.empty());
+
+            // when
+            ApplicantPageServiceResponse response = applicantAdminService.searchApplicantByKeyword(request);
+
+            // then
+            assertThat(response.applicants()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("동아리 관리자가 아니면 NotClubAdminException이 발생한다")
+        void searchApplicantByKeyword_throwsNotClubAdminException() {
+            // given
+            ApplicantSearchServiceRequest request = ApplicantSearchServiceRequest.of(
+                    USERNAME, "홍길동", "GRADE", false, 1, 7, "DOCUMENT");
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> applicantAdminService.searchApplicantByKeyword(request))
+                    .isInstanceOf(NotClubAdminException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getApplicantsByStatus(): 합격/불합격 지원자 조회")
+    class GetApplicantsByStatusTest {
+
+        @Test
+        @DisplayName("정상적으로 상태별 지원자 목록을 반환한다")
+        void getApplicantsByStatus_success() {
+            // given
+            ApplicantStatusServiceRequest request = ApplicantStatusServiceRequest.of(
+                    USERNAME, true, 1, 4, "DOCUMENT");
+
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+
+            ApplyForm applyForm = mock(ApplyForm.class);
+            given(applyForm.getId()).willReturn(APPLY_FORM_ID);
+            given(applyForm.isHasInterview()).willReturn(true);
+            given(applyFormRepository.findTopByClubIdAndStatusOrderByCreatedAtDesc(CLUB_ID, ACTIVE))
+                    .willReturn(Optional.of(applyForm));
+
+            ApplicantPageQueryResponse queryResponse = ApplicantPageQueryResponse.builder()
+                    .currentPage(1)
+                    .totalPage(1)
+                    .totalCount(2)
+                    .applicants(List.of())
+                    .build();
+            given(applicantRepository.findApplicantsByStatus(true, 1, 4, APPLY_FORM_ID, "DOCUMENT"))
+                    .willReturn(queryResponse);
+
+            // when
+            ApplicantPageServiceResponse response = applicantAdminService.getApplicantsByStatus(request);
+
+            // then
+            assertThat(response.totalCount()).isEqualTo(2);
+            assertThat(response.hasInterview()).isTrue();
+        }
+
+        @Test
+        @DisplayName("활성 지원폼이 없으면 빈 응답을 반환한다")
+        void getApplicantsByStatus_returnsEmpty_whenNoActiveApplyForm() {
+            // given
+            ApplicantStatusServiceRequest request = ApplicantStatusServiceRequest.of(
+                    USERNAME, false, 1, 4, "INTERVIEW");
+
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            given(applyFormRepository.findTopByClubIdAndStatusOrderByCreatedAtDesc(CLUB_ID, ACTIVE))
+                    .willReturn(Optional.empty());
+
+            // when
+            ApplicantPageServiceResponse response = applicantAdminService.getApplicantsByStatus(request);
+
+            // then
+            assertThat(response.applicants()).isEmpty();
+            verify(applicantRepository, never()).findApplicantsByStatus(
+                    anyBoolean(), eq(1), eq(4), anyString(), anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("updateApplicantStatus(): 지원자 전형 상태 변경")
+    class UpdateApplicantStatusTest {
+
+        private Applicant setUpApplicantWithMatchingClub(Club club) {
+            ApplyForm applyForm = mock(ApplyForm.class);
+            given(applyForm.getClub()).willReturn(club);
+
+            Applicant applicant = mock(Applicant.class);
+            given(applicant.getApplyForm()).willReturn(applyForm);
+            given(applicantRepository.findById(APPLICANT_ID)).willReturn(Optional.of(applicant));
+            return applicant;
+        }
+
+        @Test
+        @DisplayName("서류 전형 합격 처리를 한다")
+        void updateApplicantStatus_passDocument() {
+            // given
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            Applicant applicant = setUpApplicantWithMatchingClub(club);
+
+            StatusUpdateServiceRequest request = StatusUpdateServiceRequest.of(
+                    USERNAME, APPLICANT_ID, PhaseStatus.PASS, "DOCUMENT");
+
+            // when
+            applicantAdminService.updateApplicantStatus(request);
+
+            // then
+            verify(applicant).passDocumentEvaluation();
+        }
+
+        @Test
+        @DisplayName("서류 전형 불합격 처리를 한다")
+        void updateApplicantStatus_failDocument() {
+            // given
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            Applicant applicant = setUpApplicantWithMatchingClub(club);
+
+            StatusUpdateServiceRequest request = StatusUpdateServiceRequest.of(
+                    USERNAME, APPLICANT_ID, PhaseStatus.FAIL, "DOCUMENT");
+
+            // when
+            applicantAdminService.updateApplicantStatus(request);
+
+            // then
+            verify(applicant).failDocumentEvaluation();
+        }
+
+        @Test
+        @DisplayName("서류 전형 평가중 처리를 한다")
+        void updateApplicantStatus_evaluatingDocument() {
+            // given
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            Applicant applicant = setUpApplicantWithMatchingClub(club);
+
+            StatusUpdateServiceRequest request = StatusUpdateServiceRequest.of(
+                    USERNAME, APPLICANT_ID, PhaseStatus.EVALUATING, "DOCUMENT");
+
+            // when
+            applicantAdminService.updateApplicantStatus(request);
+
+            // then
+            verify(applicant).setDocumentEvaluating();
+        }
+
+        @Test
+        @DisplayName("면접 전형 합격 처리를 한다")
+        void updateApplicantStatus_passInterview() {
+            // given
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            Applicant applicant = setUpApplicantWithMatchingClub(club);
+
+            StatusUpdateServiceRequest request = StatusUpdateServiceRequest.of(
+                    USERNAME, APPLICANT_ID, PhaseStatus.PASS, "INTERVIEW");
+
+            // when
+            applicantAdminService.updateApplicantStatus(request);
+
+            // then
+            verify(applicant).passInterview();
+        }
+
+        @Test
+        @DisplayName("면접 전형 불합격 처리를 한다")
+        void updateApplicantStatus_failInterview() {
+            // given
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            Applicant applicant = setUpApplicantWithMatchingClub(club);
+
+            StatusUpdateServiceRequest request = StatusUpdateServiceRequest.of(
+                    USERNAME, APPLICANT_ID, PhaseStatus.FAIL, "INTERVIEW");
+
+            // when
+            applicantAdminService.updateApplicantStatus(request);
+
+            // then
+            verify(applicant).failInterview();
+        }
+
+        @Test
+        @DisplayName("면접 전형 평가중 처리를 한다")
+        void updateApplicantStatus_evaluatingInterview() {
+            // given
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            Applicant applicant = setUpApplicantWithMatchingClub(club);
+
+            StatusUpdateServiceRequest request = StatusUpdateServiceRequest.of(
+                    USERNAME, APPLICANT_ID, PhaseStatus.EVALUATING, "INTERVIEW");
+
+            // when
+            applicantAdminService.updateApplicantStatus(request);
+
+            // then
+            verify(applicant).setInterviewEvaluating();
+        }
+
+        @Test
+        @DisplayName("지원자가 존재하지 않으면 ApplicantNotFoundException이 발생한다")
+        void updateApplicantStatus_throwsApplicantNotFoundException() {
+            // given
+            Club club = mock(Club.class);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            given(applicantRepository.findById(APPLICANT_ID)).willReturn(Optional.empty());
+
+            StatusUpdateServiceRequest request = StatusUpdateServiceRequest.of(
+                    USERNAME, APPLICANT_ID, PhaseStatus.PASS, "DOCUMENT");
+
+            // when & then
+            assertThatThrownBy(() -> applicantAdminService.updateApplicantStatus(request))
+                    .isInstanceOf(ApplicantNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("지원자의 소속 동아리가 다르면 UnAuthorizedApplicantAccessException이 발생한다")
+        void updateApplicantStatus_throwsUnAuthorizedApplicantAccessException() {
+            // given
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+
+            Club otherClub = mock(Club.class);
+            given(otherClub.getId()).willReturn("other-club");
+
+            ApplyForm applyForm = mock(ApplyForm.class);
+            given(applyForm.getClub()).willReturn(otherClub);
+
+            Applicant applicant = mock(Applicant.class);
+            given(applicant.getApplyForm()).willReturn(applyForm);
+            given(applicantRepository.findById(APPLICANT_ID)).willReturn(Optional.of(applicant));
+
+            StatusUpdateServiceRequest request = StatusUpdateServiceRequest.of(
+                    USERNAME, APPLICANT_ID, PhaseStatus.PASS, "DOCUMENT");
+
+            // when & then
+            assertThatThrownBy(() -> applicantAdminService.updateApplicantStatus(request))
+                    .isInstanceOf(UnAuthorizedApplicantAccessException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("finalizeApplicantsStatus(): 전형 최종 마감 처리")
+    class FinalizeApplicantsStatusTest {
+
+        @Test
+        @DisplayName("서류 전형 마감 시, 면접이 있는 지원폼이면 합격자를 면접 단계로 이동시킨다")
+        void finalizeApplicantsStatus_document_movesToInterviewPhase() {
+            // given
+            ApplicantFinalizationRequest request = ApplicantFinalizationRequest.of(USERNAME, CLUB_ID, "DOCUMENT");
+
+            Club club = mock(Club.class);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+
+            LocalDate interviewStartDate = LocalDate.of(2026, 8, 1);
+            ApplyForm applyForm = mock(ApplyForm.class);
+            given(applyForm.getId()).willReturn(APPLY_FORM_ID);
+            given(applyForm.isHasInterview()).willReturn(true);
+            given(applyForm.getInterviewStartDate()).willReturn(interviewStartDate);
+            given(applyFormRepository.findByClubIdAndStatus(CLUB_ID, ACTIVE)).willReturn(Optional.of(applyForm));
+
+            Applicant passedApplicant = mock(Applicant.class);
+            given(passedApplicant.isInDocumentPhase()).willReturn(true);
+            DocumentPhase passedDocumentPhase = mock(DocumentPhase.class);
+            given(passedDocumentPhase.getStatus()).willReturn(PhaseStatus.PASS);
+            given(passedApplicant.getDocumentPhase()).willReturn(passedDocumentPhase);
+            given(passedApplicant.isInInterviewPhase()).willReturn(false);
+
+            Applicant failedApplicant = mock(Applicant.class);
+            given(failedApplicant.isInDocumentPhase()).willReturn(true);
+            DocumentPhase failedDocumentPhase = mock(DocumentPhase.class);
+            given(failedDocumentPhase.getStatus()).willReturn(PhaseStatus.FAIL);
+            given(failedApplicant.getDocumentPhase()).willReturn(failedDocumentPhase);
+
+            given(applicantRepository.findByApplyFormId(APPLY_FORM_ID))
+                    .willReturn(List.of(passedApplicant, failedApplicant));
+
+            // when
+            ApplicantFinalizeServiceResponse response = applicantAdminService.finalizeApplicantsStatus(request);
+
+            // then
+            assertThat(response.passedCount()).isEqualTo(1);
+            assertThat(response.totalFinalizedCount()).isEqualTo(2);
+            verify(passedApplicant).updateToInterviewPhase(interviewStartDate);
+            verify(clubMemberRepository, never()).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("면접 전형 마감 시, 합격자를 동아리 부원으로 등록한다")
+        void finalizeApplicantsStatus_interview_savesClubMembers() {
+            // given
+            ApplicantFinalizationRequest request = ApplicantFinalizationRequest.of(USERNAME, CLUB_ID, "INTERVIEW");
+
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+
+            ApplyForm applyForm = mock(ApplyForm.class);
+            given(applyForm.getId()).willReturn(APPLY_FORM_ID);
+            given(applyFormRepository.findByClubIdAndStatus(CLUB_ID, ACTIVE)).willReturn(Optional.of(applyForm));
+
+            Applicant passedApplicant = mock(Applicant.class);
+            given(passedApplicant.isInInterviewPhase()).willReturn(true);
+            given(passedApplicant.hasInterviewPhase()).willReturn(true);
+            InterviewPhase interviewPhase = mock(InterviewPhase.class);
+            given(interviewPhase.getStatus()).willReturn(PhaseStatus.PASS);
+            given(passedApplicant.getInterviewPhase()).willReturn(interviewPhase);
+            given(passedApplicant.getName()).willReturn("홍길동");
+            given(passedApplicant.getGrade()).willReturn(Grade.FIRST_GRADE);
+            given(passedApplicant.getMajor()).willReturn("컴퓨터공학과");
+            given(passedApplicant.getEmail()).willReturn("hong@test.com");
+            given(passedApplicant.getPhone()).willReturn("010-1234-5678");
+            given(passedApplicant.getGender()).willReturn(Gender.MALE);
+
+            given(applicantRepository.findByApplyFormId(APPLY_FORM_ID)).willReturn(List.of(passedApplicant));
+            given(clubMemberRepository.existsByClubIdAndEmail(CLUB_ID, "hong@test.com")).willReturn(false);
+
+            // when
+            ApplicantFinalizeServiceResponse response = applicantAdminService.finalizeApplicantsStatus(request);
+
+            // then
+            assertThat(response.passedCount()).isEqualTo(1);
+            verify(clubMemberRepository).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("이미 부원으로 등록된 지원자는 다시 등록하지 않는다")
+        void finalizeApplicantsStatus_skipsAlreadyRegisteredMember() {
+            // given
+            ApplicantFinalizationRequest request = ApplicantFinalizationRequest.of(USERNAME, CLUB_ID, "INTERVIEW");
+
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+
+            ApplyForm applyForm = mock(ApplyForm.class);
+            given(applyForm.getId()).willReturn(APPLY_FORM_ID);
+            given(applyFormRepository.findByClubIdAndStatus(CLUB_ID, ACTIVE)).willReturn(Optional.of(applyForm));
+
+            Applicant passedApplicant = mock(Applicant.class);
+            given(passedApplicant.isInInterviewPhase()).willReturn(true);
+            given(passedApplicant.hasInterviewPhase()).willReturn(true);
+            InterviewPhase interviewPhase = mock(InterviewPhase.class);
+            given(interviewPhase.getStatus()).willReturn(PhaseStatus.PASS);
+            given(passedApplicant.getInterviewPhase()).willReturn(interviewPhase);
+            given(passedApplicant.getEmail()).willReturn("hong@test.com");
+
+            given(applicantRepository.findByApplyFormId(APPLY_FORM_ID)).willReturn(List.of(passedApplicant));
+            given(clubMemberRepository.existsByClubIdAndEmail(CLUB_ID, "hong@test.com")).willReturn(true);
+
+            // when
+            applicantAdminService.finalizeApplicantsStatus(request);
+
+            // then
+            verify(clubMemberRepository, never()).saveAll(anyList());
+        }
+
+        @Test
+        @DisplayName("활성 지원폼이 없으면 ActiveApplyFormNotFoundException이 발생한다")
+        void finalizeApplicantsStatus_throwsActiveApplyFormNotFoundException() {
+            // given
+            ApplicantFinalizationRequest request = ApplicantFinalizationRequest.of(USERNAME, CLUB_ID, "DOCUMENT");
+
+            Club club = mock(Club.class);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            given(applyFormRepository.findByClubIdAndStatus(CLUB_ID, ACTIVE)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> applicantAdminService.finalizeApplicantsStatus(request))
+                    .isInstanceOf(ActiveApplyFormNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("동아리 관리자가 아니면 NotClubAdminException이 발생한다")
+        void finalizeApplicantsStatus_throwsNotClubAdminException() {
+            // given
+            ApplicantFinalizationRequest request = ApplicantFinalizationRequest.of(USERNAME, CLUB_ID, "DOCUMENT");
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> applicantAdminService.finalizeApplicantsStatus(request))
+                    .isInstanceOf(NotClubAdminException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("sendResultMailToApplicants(): 합불 결과 메일 발송")
+    class SendResultMailToApplicantsTest {
+
+        @Test
+        @DisplayName("합격자와 불합격자 각각에게 결과 메일을 발송한다")
+        void sendResultMailToApplicants_success() {
+            // given
+            MailFormatRequest pass = new MailFormatRequest("합격 안내", "축하합니다.");
+            MailFormatRequest fail = new MailFormatRequest("불합격 안내", "아쉽습니다.");
+            SendResultMailServiceRequest request = SendResultMailServiceRequest.builder()
+                    .pass(pass)
+                    .fail(fail)
+                    .build();
+
+            Club club = mock(Club.class);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+
+            ApplyForm applyForm = mock(ApplyForm.class);
+            given(applyForm.getId()).willReturn(APPLY_FORM_ID);
+            given(applyFormRepository.findByClubIdAndStatus(CLUB_ID, ACTIVE)).willReturn(Optional.of(applyForm));
+
+            Applicant passedApplicant = mock(Applicant.class);
+            given(passedApplicant.isInDocumentPhase()).willReturn(true);
+            DocumentPhase passedPhase = mock(DocumentPhase.class);
+            given(passedPhase.getStatus()).willReturn(PhaseStatus.PASS);
+            given(passedApplicant.getDocumentPhase()).willReturn(passedPhase);
+            given(passedApplicant.getEmail()).willReturn("passed@test.com");
+
+            Applicant failedApplicant = mock(Applicant.class);
+            given(failedApplicant.isInDocumentPhase()).willReturn(true);
+            DocumentPhase failedPhase = mock(DocumentPhase.class);
+            given(failedPhase.getStatus()).willReturn(PhaseStatus.FAIL);
+            given(failedApplicant.getDocumentPhase()).willReturn(failedPhase);
+            given(failedApplicant.getEmail()).willReturn("failed@test.com");
+
+            given(applicantRepository.findByApplyFormId(APPLY_FORM_ID))
+                    .willReturn(List.of(passedApplicant, failedApplicant));
+
+            // when
+            applicantAdminService.sendResultMailToApplicants(request, USERNAME, CLUB_ID, "DOCUMENT");
+
+            // then
+            verify(emailService, times(1)).sendResultMail(List.of("passed@test.com"), pass);
+            verify(emailService, times(1)).sendResultMail(List.of("failed@test.com"), fail);
+        }
+
+        @Test
+        @DisplayName("활성 지원폼이 없으면 ActiveApplyFormNotFoundException이 발생한다")
+        void sendResultMailToApplicants_throwsActiveApplyFormNotFoundException() {
+            // given
+            MailFormatRequest pass = new MailFormatRequest("합격 안내", "축하합니다.");
+            MailFormatRequest fail = new MailFormatRequest("불합격 안내", "아쉽습니다.");
+            SendResultMailServiceRequest request = SendResultMailServiceRequest.builder()
+                    .pass(pass)
+                    .fail(fail)
+                    .build();
+
+            Club club = mock(Club.class);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            given(applyFormRepository.findByClubIdAndStatus(CLUB_ID, ACTIVE)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() ->
+                    applicantAdminService.sendResultMailToApplicants(request, USERNAME, CLUB_ID, "DOCUMENT"))
+                    .isInstanceOf(ActiveApplyFormNotFoundException.class);
+            verify(emailService, never()).sendResultMail(anyList(), any());
+        }
+
+        @Test
+        @DisplayName("동아리 관리자가 아니면 NotClubAdminException이 발생한다")
+        void sendResultMailToApplicants_throwsNotClubAdminException() {
+            // given
+            MailFormatRequest pass = new MailFormatRequest("합격 안내", "축하합니다.");
+            MailFormatRequest fail = new MailFormatRequest("불합격 안내", "아쉽습니다.");
+            SendResultMailServiceRequest request = SendResultMailServiceRequest.builder()
+                    .pass(pass)
+                    .fail(fail)
+                    .build();
+
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() ->
+                    applicantAdminService.sendResultMailToApplicants(request, USERNAME, CLUB_ID, "DOCUMENT"))
+                    .isInstanceOf(NotClubAdminException.class);
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/applicant/service/ApplicantUserServiceTest.java
+++ b/src/test/java/org/project/ttokttok/domain/applicant/service/ApplicantUserServiceTest.java
@@ -1,0 +1,420 @@
+package org.project.ttokttok.domain.applicant.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.domain.applicant.controller.dto.request.AnswerRequest;
+import org.project.ttokttok.domain.applicant.controller.dto.request.ApplyFormRequest;
+import org.project.ttokttok.domain.applicant.domain.Applicant;
+import org.project.ttokttok.domain.applicant.domain.enums.ApplicantPhase;
+import org.project.ttokttok.domain.applicant.domain.enums.Gender;
+import org.project.ttokttok.domain.applicant.domain.enums.Grade;
+import org.project.ttokttok.domain.applicant.domain.enums.StudentStatus;
+import org.project.ttokttok.domain.applicant.exception.AlreadyApplicantExistsException;
+import org.project.ttokttok.domain.applicant.exception.AnswerRequestNotMatchException;
+import org.project.ttokttok.domain.applicant.exception.ListSizeNotMatchException;
+import org.project.ttokttok.domain.applicant.exception.QuestionParseFailException;
+import org.project.ttokttok.domain.applicant.repository.ApplicantRepository;
+import org.project.ttokttok.domain.applicant.repository.dto.UserApplicationHistoryQueryResponse;
+import org.project.ttokttok.domain.applyform.domain.ApplyForm;
+import org.project.ttokttok.domain.applyform.domain.enums.QuestionType;
+import org.project.ttokttok.domain.applyform.domain.json.Question;
+import org.project.ttokttok.domain.applyform.exception.ApplyFormNotFoundException;
+import org.project.ttokttok.domain.applyform.repository.ApplyFormRepository;
+import org.project.ttokttok.domain.club.domain.enums.ClubCategory;
+import org.project.ttokttok.domain.club.domain.enums.ClubType;
+import org.project.ttokttok.domain.club.service.dto.response.ClubListServiceResponse;
+import org.project.ttokttok.domain.temp.applicant.domain.TempApplicant;
+import org.project.ttokttok.domain.temp.applicant.repository.TempApplicantRepository;
+import org.project.ttokttok.domain.user.exception.UserNotFoundException;
+import org.project.ttokttok.domain.user.repository.UserRepository;
+import org.project.ttokttok.infrastructure.s3.service.S3Service;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.project.ttokttok.domain.applyform.domain.enums.ApplyFormStatus.ACTIVE;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicantUserServiceTest {
+
+    @InjectMocks
+    private ApplicantUserService applicantUserService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ApplicantRepository applicantRepository;
+
+    @Mock
+    private ApplyFormRepository applyFormRepository;
+
+    @Mock
+    private TempApplicantRepository tempApplicantRepository;
+
+    @Mock
+    private S3Service s3Service;
+
+    private static final String EMAIL = "user@sangmyung.kr";
+    private static final String CLUB_ID = "club-1";
+    private static final String FORM_ID = "form-1";
+    private static final String APPLICANT_ID = "applicant-1";
+
+    private ApplyFormRequest createApplyFormRequest(List<AnswerRequest> answers) {
+        return new ApplyFormRequest(
+                "홍길동",
+                22,
+                "컴퓨터공학과",
+                "hong@test.com",
+                "010-1234-5678",
+                StudentStatus.ENROLLED,
+                Grade.FIRST_GRADE,
+                Gender.MALE,
+                FORM_ID,
+                answers
+        );
+    }
+
+    @Nested
+    @DisplayName("apply(): 지원서 제출")
+    class ApplyTest {
+
+        @Test
+        @DisplayName("파일 질문이 없는 경우 정상적으로 지원서를 제출한다")
+        void apply_success_withoutFileQuestion() {
+            // given
+            Question question = new Question("q1", "질문1", null, QuestionType.SHORT_ANSWER, true, List.of());
+            ApplyForm form = mock(ApplyForm.class);
+            given(form.getId()).willReturn(FORM_ID);
+            given(form.getFormJson()).willReturn(List.of(question));
+
+            ApplyFormRequest request = createApplyFormRequest(List.of(new AnswerRequest("q1", "답변1")));
+
+            given(userRepository.existsByEmail(EMAIL)).willReturn(true);
+            given(applyFormRepository.findByClubIdAndStatus(CLUB_ID, ACTIVE)).willReturn(Optional.of(form));
+            given(applicantRepository.existsByUserEmailAndApplyFormId(EMAIL, FORM_ID)).willReturn(false);
+            given(tempApplicantRepository.findByUserEmailAndFormId(EMAIL, FORM_ID)).willReturn(Optional.empty());
+
+            Applicant savedApplicant = mock(Applicant.class);
+            given(savedApplicant.getId()).willReturn(APPLICANT_ID);
+            given(applicantRepository.save(any(Applicant.class))).willReturn(savedApplicant);
+
+            // when
+            String result = applicantUserService.apply(EMAIL, request, null, null, CLUB_ID);
+
+            // then
+            assertThat(result).isEqualTo(APPLICANT_ID);
+            verify(applicantRepository).save(any(Applicant.class));
+            verify(s3Service, never()).uploadFile(any(), anyString());
+        }
+
+        @Test
+        @DisplayName("파일 질문이 있는 경우 S3에 파일을 업로드하고 지원서를 제출한다")
+        void apply_success_withFileUpload() {
+            // given
+            Question question = new Question("q2", "파일질문", null, QuestionType.FILE, true, List.of());
+            ApplyForm form = mock(ApplyForm.class);
+            given(form.getId()).willReturn(FORM_ID);
+            given(form.getFormJson()).willReturn(List.of(question));
+
+            ApplyFormRequest request = createApplyFormRequest(List.of(new AnswerRequest("q2", null)));
+
+            MultipartFile file = new MockMultipartFile("q2", "resume.pdf", "application/pdf", "content".getBytes());
+
+            given(userRepository.existsByEmail(EMAIL)).willReturn(true);
+            given(applyFormRepository.findByClubIdAndStatus(CLUB_ID, ACTIVE)).willReturn(Optional.of(form));
+            given(applicantRepository.existsByUserEmailAndApplyFormId(EMAIL, FORM_ID)).willReturn(false);
+            given(tempApplicantRepository.findByUserEmailAndFormId(EMAIL, FORM_ID)).willReturn(Optional.empty());
+            given(s3Service.uploadFile(file, "applicant/" + EMAIL + "/")).willReturn("https://s3/resume.pdf");
+
+            Applicant savedApplicant = mock(Applicant.class);
+            given(savedApplicant.getId()).willReturn(APPLICANT_ID);
+            given(applicantRepository.save(any(Applicant.class))).willReturn(savedApplicant);
+
+            // when
+            String result = applicantUserService.apply(EMAIL, request, List.of("q2"), List.of(file), CLUB_ID);
+
+            // then
+            assertThat(result).isEqualTo(APPLICANT_ID);
+            verify(s3Service, times(1)).uploadFile(file, "applicant/" + EMAIL + "/");
+        }
+
+        @Test
+        @DisplayName("동일한 지원폼에 이미 임시 지원폼이 존재하면 삭제한다")
+        void apply_deletesTempApplicant_whenExists() {
+            // given
+            Question question = new Question("q1", "질문1", null, QuestionType.SHORT_ANSWER, true, List.of());
+            ApplyForm form = mock(ApplyForm.class);
+            given(form.getId()).willReturn(FORM_ID);
+            given(form.getFormJson()).willReturn(List.of(question));
+
+            ApplyFormRequest request = createApplyFormRequest(List.of(new AnswerRequest("q1", "답변1")));
+
+            given(userRepository.existsByEmail(EMAIL)).willReturn(true);
+            given(applyFormRepository.findByClubIdAndStatus(CLUB_ID, ACTIVE)).willReturn(Optional.of(form));
+            given(applicantRepository.existsByUserEmailAndApplyFormId(EMAIL, FORM_ID)).willReturn(false);
+
+            TempApplicant tempApplicant = mock(TempApplicant.class);
+            given(tempApplicantRepository.findByUserEmailAndFormId(EMAIL, FORM_ID))
+                    .willReturn(Optional.of(tempApplicant));
+
+            Applicant savedApplicant = mock(Applicant.class);
+            given(savedApplicant.getId()).willReturn(APPLICANT_ID);
+            given(applicantRepository.save(any(Applicant.class))).willReturn(savedApplicant);
+
+            // when
+            applicantUserService.apply(EMAIL, request, null, null, CLUB_ID);
+
+            // then
+            verify(tempApplicantRepository).delete(tempApplicant);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 사용자면 UserNotFoundException이 발생한다")
+        void apply_throwsUserNotFoundException_whenUserDoesNotExist() {
+            // given
+            ApplyFormRequest request = createApplyFormRequest(List.of());
+            given(userRepository.existsByEmail(EMAIL)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> applicantUserService.apply(EMAIL, request, null, null, CLUB_ID))
+                    .isInstanceOf(UserNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("활성화된 지원폼이 없으면 ApplyFormNotFoundException이 발생한다")
+        void apply_throwsApplyFormNotFoundException_whenNoActiveForm() {
+            // given
+            ApplyFormRequest request = createApplyFormRequest(List.of());
+            given(userRepository.existsByEmail(EMAIL)).willReturn(true);
+            given(applyFormRepository.findByClubIdAndStatus(CLUB_ID, ACTIVE)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> applicantUserService.apply(EMAIL, request, null, null, CLUB_ID))
+                    .isInstanceOf(ApplyFormNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("이미 지원한 이력이 있으면 AlreadyApplicantExistsException이 발생한다")
+        void apply_throwsAlreadyApplicantExistsException_whenDuplicateApply() {
+            // given
+            ApplyForm form = mock(ApplyForm.class);
+            given(form.getId()).willReturn(FORM_ID);
+
+            ApplyFormRequest request = createApplyFormRequest(List.of());
+            given(userRepository.existsByEmail(EMAIL)).willReturn(true);
+            given(applyFormRepository.findByClubIdAndStatus(CLUB_ID, ACTIVE)).willReturn(Optional.of(form));
+            given(applicantRepository.existsByUserEmailAndApplyFormId(EMAIL, FORM_ID)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> applicantUserService.apply(EMAIL, request, null, null, CLUB_ID))
+                    .isInstanceOf(AlreadyApplicantExistsException.class);
+        }
+
+        @Test
+        @DisplayName("필수 파일 질문에 파일이 없으면 AnswerRequestNotMatchException이 발생한다")
+        void apply_throwsAnswerRequestNotMatchException_whenRequiredFileQuestionMissing() {
+            // given
+            Question fileQuestion = new Question("q2", "파일질문", null, QuestionType.FILE, true, List.of());
+            ApplyForm form = mock(ApplyForm.class);
+            given(form.getId()).willReturn(FORM_ID);
+            given(form.getFormJson()).willReturn(List.of(fileQuestion));
+
+            ApplyFormRequest request = createApplyFormRequest(List.of());
+            given(userRepository.existsByEmail(EMAIL)).willReturn(true);
+            given(applyFormRepository.findByClubIdAndStatus(CLUB_ID, ACTIVE)).willReturn(Optional.of(form));
+            given(applicantRepository.existsByUserEmailAndApplyFormId(EMAIL, FORM_ID)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> applicantUserService.apply(EMAIL, request, null, null, CLUB_ID))
+                    .isInstanceOf(AnswerRequestNotMatchException.class);
+        }
+
+        @Test
+        @DisplayName("파일 질문 개수와 파일 개수가 일치하지 않으면 ListSizeNotMatchException이 발생한다")
+        void apply_throwsListSizeNotMatchException_whenFileCountMismatch() {
+            // given
+            Question fileQuestion1 = new Question("q2", "파일질문1", null, QuestionType.FILE, true, List.of());
+            Question fileQuestion2 = new Question("q3", "파일질문2", null, QuestionType.FILE, true, List.of());
+            ApplyForm form = mock(ApplyForm.class);
+            given(form.getId()).willReturn(FORM_ID);
+            given(form.getFormJson()).willReturn(List.of(fileQuestion1, fileQuestion2));
+
+            ApplyFormRequest request = createApplyFormRequest(List.of());
+            MultipartFile file = new MockMultipartFile("q2", "resume.pdf", "application/pdf", "content".getBytes());
+
+            given(userRepository.existsByEmail(EMAIL)).willReturn(true);
+            given(applyFormRepository.findByClubIdAndStatus(CLUB_ID, ACTIVE)).willReturn(Optional.of(form));
+            given(applicantRepository.existsByUserEmailAndApplyFormId(EMAIL, FORM_ID)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> applicantUserService.apply(
+                    EMAIL, request, List.of("q2", "q3"), List.of(file), CLUB_ID))
+                    .isInstanceOf(ListSizeNotMatchException.class);
+        }
+
+        @Test
+        @DisplayName("답변의 질문 ID가 지원폼에 존재하지 않으면 QuestionParseFailException이 발생한다")
+        void apply_throwsQuestionParseFailException_whenQuestionIdNotFound() {
+            // given
+            Question question = new Question("q1", "질문1", null, QuestionType.SHORT_ANSWER, true, List.of());
+            ApplyForm form = mock(ApplyForm.class);
+            given(form.getId()).willReturn(FORM_ID);
+            given(form.getFormJson()).willReturn(List.of(question));
+
+            ApplyFormRequest request = createApplyFormRequest(List.of(new AnswerRequest("존재하지-않는-id", "답변")));
+
+            given(userRepository.existsByEmail(EMAIL)).willReturn(true);
+            given(applyFormRepository.findByClubIdAndStatus(CLUB_ID, ACTIVE)).willReturn(Optional.of(form));
+            given(applicantRepository.existsByUserEmailAndApplyFormId(EMAIL, FORM_ID)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> applicantUserService.apply(EMAIL, request, null, null, CLUB_ID))
+                    .isInstanceOf(QuestionParseFailException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getUserApplicationHistory(): 사용자 지원내역 조회")
+    class GetUserApplicationHistoryTest {
+
+        private UserApplicationHistoryQueryResponse createResponse(String applicantId, LocalDate applyEndDate) {
+            return new UserApplicationHistoryQueryResponse(
+                    applicantId,
+                    "club-" + applicantId,
+                    "동아리 " + applicantId,
+                    ClubType.CENTRAL,
+                    ClubCategory.ACADEMIC,
+                    "",
+                    "한줄 소개",
+                    null,
+                    3,
+                    true,
+                    false,
+                    ApplicantPhase.DOCUMENT,
+                    LocalDateTime.now(),
+                    applyEndDate
+            );
+        }
+
+        @Test
+        @DisplayName("조회 결과가 size보다 많으면 hasNext가 true이고 다음 커서를 반환한다")
+        void getUserApplicationHistory_hasNext_true() {
+            // given
+            int size = 2;
+            given(userRepository.existsByEmail(EMAIL)).willReturn(true);
+            given(applicantRepository.getUserApplicationHistory(EMAIL, size, null, "latest"))
+                    .willReturn(List.of(
+                            createResponse("a1", null),
+                            createResponse("a2", null),
+                            createResponse("a3", null)
+                    ));
+
+            // when
+            ClubListServiceResponse response = applicantUserService.getUserApplicationHistory(
+                    EMAIL, size, null, "latest");
+
+            // then
+            assertThat(response.clubs()).hasSize(2);
+            assertThat(response.hasNext()).isTrue();
+            assertThat(response.nextCursor()).isEqualTo("a2");
+        }
+
+        @Test
+        @DisplayName("조회 결과가 size 이하면 hasNext가 false이고 다음 커서가 없다")
+        void getUserApplicationHistory_hasNext_false() {
+            // given
+            int size = 2;
+            given(userRepository.existsByEmail(EMAIL)).willReturn(true);
+            given(applicantRepository.getUserApplicationHistory(EMAIL, size, null, "latest"))
+                    .willReturn(List.of(createResponse("a1", null)));
+
+            // when
+            ClubListServiceResponse response = applicantUserService.getUserApplicationHistory(
+                    EMAIL, size, null, "latest");
+
+            // then
+            assertThat(response.clubs()).hasSize(1);
+            assertThat(response.hasNext()).isFalse();
+            assertThat(response.nextCursor()).isNull();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 사용자면 UserNotFoundException이 발생한다")
+        void getUserApplicationHistory_throwsUserNotFoundException() {
+            // given
+            given(userRepository.existsByEmail(EMAIL)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> applicantUserService.getUserApplicationHistory(EMAIL, 10, null, "latest"))
+                    .isInstanceOf(UserNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("마감일이 일주일 이내면 마감 임박으로 표시한다")
+        void getUserApplicationHistory_marksDeadlineImminent_withinAWeek() {
+            // given
+            given(userRepository.existsByEmail(EMAIL)).willReturn(true);
+            given(applicantRepository.getUserApplicationHistory(eq(EMAIL), eq(10), eq((String) null), eq("latest")))
+                    .willReturn(List.of(createResponse("a1", LocalDate.now().plusDays(3))));
+
+            // when
+            ClubListServiceResponse response = applicantUserService.getUserApplicationHistory(
+                    EMAIL, 10, null, "latest");
+
+            // then
+            assertThat(response.clubs().get(0).isDeadlineImminent()).isTrue();
+        }
+
+        @Test
+        @DisplayName("마감일이 일주일 이상 남았으면 마감 임박이 아니다")
+        void getUserApplicationHistory_doesNotMarkDeadlineImminent_whenFarAway() {
+            // given
+            given(userRepository.existsByEmail(EMAIL)).willReturn(true);
+            given(applicantRepository.getUserApplicationHistory(eq(EMAIL), eq(10), eq((String) null), eq("latest")))
+                    .willReturn(List.of(createResponse("a1", LocalDate.now().plusDays(10))));
+
+            // when
+            ClubListServiceResponse response = applicantUserService.getUserApplicationHistory(
+                    EMAIL, 10, null, "latest");
+
+            // then
+            assertThat(response.clubs().get(0).isDeadlineImminent()).isFalse();
+        }
+
+        @Test
+        @DisplayName("마감일 정보가 없으면 마감 임박이 아니다")
+        void getUserApplicationHistory_doesNotMarkDeadlineImminent_whenApplyEndDateNull() {
+            // given
+            given(userRepository.existsByEmail(EMAIL)).willReturn(true);
+            given(applicantRepository.getUserApplicationHistory(eq(EMAIL), eq(10), eq((String) null), eq("latest")))
+                    .willReturn(List.of(createResponse("a1", null)));
+
+            // when
+            ClubListServiceResponse response = applicantUserService.getUserApplicationHistory(
+                    EMAIL, 10, null, "latest");
+
+            // then
+            assertThat(response.clubs().get(0).isDeadlineImminent()).isFalse();
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/applyform/controller/ApplyFormAdminApiControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/applyform/controller/ApplyFormAdminApiControllerTest.java
@@ -1,0 +1,204 @@
+package org.project.ttokttok.domain.applyform.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.applyform.domain.enums.QuestionType;
+import org.project.ttokttok.domain.applyform.domain.json.Question;
+import org.project.ttokttok.domain.applyform.service.ApplyFormAdminService;
+import org.project.ttokttok.domain.applyform.service.dto.request.ApplyFormCreateServiceRequest;
+import org.project.ttokttok.domain.applyform.service.dto.request.ApplyFormUpdateServiceRequest;
+import org.project.ttokttok.domain.applyform.service.dto.response.ApplyFormDetailServiceResponse;
+import org.project.ttokttok.global.annotationresolver.auth.AuthUserInfoResolver;
+import org.project.ttokttok.global.auth.jwt.service.TokenProvider;
+import org.project.ttokttok.global.config.JsonConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ApplyFormAdminApiController.class)
+@Import(JsonConfig.class)
+class ApplyFormAdminApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ApplyFormAdminService applyFormAdminService;
+
+    @MockitoBean
+    private TokenProvider tokenProvider;
+
+    @MockitoBean
+    private AuthUserInfoResolver authUserInfoResolver;
+
+    private void mockAuthUser(String username) throws Exception {
+        given(authUserInfoResolver.supportsParameter(any())).willReturn(true);
+        given(authUserInfoResolver.resolveArgument(any(), any(), any(), any())).willReturn(username);
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("지원폼 생성 API를 호출하면 201과 생성된 formId를 반환한다")
+    void createApplyForm_ShouldReturnCreated() throws Exception {
+        // given
+        mockAuthUser("admin@sangmyung.kr");
+        given(applyFormAdminService.createApplyForm(any(ApplyFormCreateServiceRequest.class)))
+                .willReturn("form-1");
+
+        String requestBody = """
+                {
+                  "hasInterview": true,
+                  "recruitStartDate": "2026-07-01",
+                  "recruitEndDate": "2026-07-31",
+                  "applicableGrades": [1, 2],
+                  "maxApplyCount": 1,
+                  "interviewStartDate": "2026-08-01",
+                  "interviewEndDate": "2026-08-05",
+                  "title": "동아리 지원폼",
+                  "subTitle": "2026년 상반기 모집",
+                  "questions": [
+                    {
+                      "title": "이름",
+                      "subTitle": null,
+                      "questionType": "SHORT_ANSWER",
+                      "isEssential": true,
+                      "content": []
+                    }
+                  ]
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(post("/api/admin/forms/clubs/{clubId}", "club-1")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.formId").value("form-1"));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("지원폼 생성 시 제목이 비어있으면 400을 반환한다")
+    void createApplyForm_ShouldReturnBadRequest_WhenTitleBlank() throws Exception {
+        // given
+        mockAuthUser("admin@sangmyung.kr");
+
+        String requestBody = """
+                {
+                  "hasInterview": false,
+                  "recruitStartDate": "2026-07-01",
+                  "recruitEndDate": "2026-07-31",
+                  "applicableGrades": [1],
+                  "maxApplyCount": 1,
+                  "title": "",
+                  "subTitle": null,
+                  "questions": []
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(post("/api/admin/forms/clubs/{clubId}", "club-1")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("지원폼 상세 조회 API를 호출한다")
+    void getApplyFormsByClubId_ShouldReturnOk() throws Exception {
+        // given
+        mockAuthUser("admin@sangmyung.kr");
+
+        List<Question> questions = List.of(
+                new Question("q1", "이름", null, QuestionType.SHORT_ANSWER, true, null)
+        );
+        ApplyFormDetailServiceResponse serviceResponse = ApplyFormDetailServiceResponse.of(
+                "form-1", "동아리 지원폼", "부제목", questions, List.of()
+        );
+        given(applyFormAdminService.getApplyFormDetail("admin@sangmyung.kr", "club-1"))
+                .willReturn(serviceResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/admin/forms/{clubId}", "club-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.formId").value("form-1"))
+                .andExpect(jsonPath("$.title").value("동아리 지원폼"));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("지원폼 수정 API를 호출하면 성공 메시지를 반환한다")
+    void updateApplyForm_ShouldReturnOk() throws Exception {
+        // given
+        mockAuthUser("admin@sangmyung.kr");
+
+        String requestBody = """
+                {
+                  "title": "새로운 제목"
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(patch("/api/admin/forms/{formId}", "form-1")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("지원 폼이 성공적으로 수정되었습니다."));
+
+        org.mockito.Mockito.verify(applyFormAdminService)
+                .updateApplyForm(any(ApplyFormUpdateServiceRequest.class));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("이전 지원폼 질문 조회 API를 호출한다")
+    void getPreviousQuestions_ShouldReturnOk() throws Exception {
+        // given
+        mockAuthUser("admin@sangmyung.kr");
+        List<Question> questions = List.of(
+                new Question("q1", "이름", null, QuestionType.SHORT_ANSWER, true, null)
+        );
+        given(applyFormAdminService.getPreviousApplyFormQuestions("admin@sangmyung.kr", "form-1"))
+                .willReturn(questions);
+
+        // when & then
+        mockMvc.perform(get("/api/admin/forms/before/{formId}", "form-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.beforeQuestions.length()").value(1))
+                .andExpect(jsonPath("$.beforeQuestions[0].questionId").value("q1"));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("지원자 평가 종료 API를 호출하면 성공 메시지를 반환한다")
+    void finishEvaluating_ShouldReturnOk() throws Exception {
+        // given
+        mockAuthUser("admin@sangmyung.kr");
+
+        // when & then
+        mockMvc.perform(post("/api/admin/forms/finish/{formId}", "form-1")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("지원자 평가 종료가 성공적으로 완료되었습니다."));
+
+        org.mockito.Mockito.verify(applyFormAdminService)
+                .finishEvaluation("admin@sangmyung.kr", "form-1");
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/applyform/controller/ApplyFormUserControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/applyform/controller/ApplyFormUserControllerTest.java
@@ -1,0 +1,76 @@
+package org.project.ttokttok.domain.applyform.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.applyform.domain.enums.QuestionType;
+import org.project.ttokttok.domain.applyform.domain.json.Question;
+import org.project.ttokttok.domain.applyform.exception.ActiveApplyFormNotFoundException;
+import org.project.ttokttok.domain.applyform.service.ApplyFormUserService;
+import org.project.ttokttok.domain.applyform.service.dto.response.ActiveApplyFormServiceResponse;
+import org.project.ttokttok.global.annotationresolver.auth.AuthUserInfoResolver;
+import org.project.ttokttok.global.auth.jwt.service.TokenProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ApplyFormUserController.class)
+class ApplyFormUserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ApplyFormUserService applyFormUserService;
+
+    @MockitoBean
+    private TokenProvider tokenProvider;
+
+    @MockitoBean
+    private AuthUserInfoResolver authUserInfoResolver;
+
+    @Test
+    @WithMockUser
+    @DisplayName("활성화된 지원폼 조회 API를 호출하면 200과 지원폼 정보를 반환한다")
+    void getActiveApplyForm_ShouldReturnOk() throws Exception {
+        // given
+        String clubId = "club-1";
+        List<Question> questions = List.of(
+                new Question("q1", "이름", null, QuestionType.SHORT_ANSWER, true, null)
+        );
+        ActiveApplyFormServiceResponse serviceResponse = ActiveApplyFormServiceResponse.of(
+                "form-1", "동아리 지원폼", "부제목", questions
+        );
+        given(applyFormUserService.getActiveApplyForm(clubId)).willReturn(serviceResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/forms/{clubId}", clubId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.formId").value("form-1"))
+                .andExpect(jsonPath("$.title").value("동아리 지원폼"))
+                .andExpect(jsonPath("$.subTitle").value("부제목"))
+                .andExpect(jsonPath("$.questions.length()").value(1));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("활성화된 지원폼이 없으면 404를 반환한다")
+    void getActiveApplyForm_ShouldReturnNotFound() throws Exception {
+        // given
+        String clubId = "club-1";
+        given(applyFormUserService.getActiveApplyForm(clubId))
+                .willThrow(new ActiveApplyFormNotFoundException());
+
+        // when & then
+        mockMvc.perform(get("/api/forms/{clubId}", clubId))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/applyform/domain/ApplyFormTest.java
+++ b/src/test/java/org/project/ttokttok/domain/applyform/domain/ApplyFormTest.java
@@ -1,0 +1,251 @@
+package org.project.ttokttok.domain.applyform.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.applyform.domain.enums.ApplicableGrade;
+import org.project.ttokttok.domain.applyform.domain.enums.ApplyFormStatus;
+import org.project.ttokttok.domain.applyform.domain.enums.QuestionType;
+import org.project.ttokttok.domain.applyform.domain.json.Question;
+import org.project.ttokttok.domain.club.domain.Club;
+
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class ApplyFormTest {
+
+    private final Club club = mock(Club.class);
+
+    private ApplyForm createDefaultApplyForm() {
+        return ApplyForm.createApplyForm(
+                club,
+                true,
+                LocalDate.of(2026, 7, 1),
+                LocalDate.of(2026, 7, 31),
+                LocalDate.of(2026, 8, 1),
+                LocalDate.of(2026, 8, 5),
+                1,
+                new HashSet<>(Set.of(ApplicableGrade.FIRST_GRADE, ApplicableGrade.SECOND_GRADE)),
+                "동아리 지원폼",
+                "부제목",
+                List.of(new Question("q1", "이름", null, QuestionType.SHORT_ANSWER, true, null))
+        );
+    }
+
+    @Nested
+    @DisplayName("createApplyForm(): 지원폼 생성 테스트")
+    class CreateApplyFormTest {
+
+        @Test
+        @DisplayName("모든 값을 정상적으로 전달하면 지원폼이 생성된다")
+        void createApplyForm_Success() {
+            // when
+            ApplyForm applyForm = createDefaultApplyForm();
+
+            // then
+            assertThat(applyForm.getClub()).isEqualTo(club);
+            assertThat(applyForm.isHasInterview()).isTrue();
+            assertThat(applyForm.getApplyStartDate()).isEqualTo(LocalDate.of(2026, 7, 1));
+            assertThat(applyForm.getApplyEndDate()).isEqualTo(LocalDate.of(2026, 7, 31));
+            assertThat(applyForm.getMaxApplyCount()).isEqualTo(1);
+            assertThat(applyForm.getGrades()).containsExactlyInAnyOrder(
+                    ApplicableGrade.FIRST_GRADE, ApplicableGrade.SECOND_GRADE
+            );
+            assertThat(applyForm.getTitle()).isEqualTo("동아리 지원폼");
+            assertThat(applyForm.getSubTitle()).isEqualTo("부제목");
+            assertThat(applyForm.getFormJson()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("생성 직후 상태는 ACTIVE이고 모집중 상태이다")
+        void createApplyForm_DefaultStatus() {
+            // when
+            ApplyForm applyForm = createDefaultApplyForm();
+
+            // then
+            assertThat(applyForm.getStatus()).isEqualTo(ApplyFormStatus.ACTIVE);
+            assertThat(applyForm.isRecruiting()).isTrue();
+        }
+
+        @Test
+        @DisplayName("학년 정보가 null이면 빈 학년 목록으로 생성된다")
+        void createApplyForm_NullGrades() {
+            // when
+            ApplyForm applyForm = ApplyForm.createApplyForm(
+                    club, false,
+                    LocalDate.of(2026, 7, 1), LocalDate.of(2026, 7, 31),
+                    null, null,
+                    1, null,
+                    "제목", "부제목", List.of()
+            );
+
+            // then
+            assertThat(applyForm.getGrades()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("updateApplyInfo(): 지원 정보 수정 테스트")
+    class UpdateApplyInfoTest {
+
+        @Test
+        @DisplayName("전달된 값으로 지원 정보를 수정한다")
+        void updateApplyInfo_Success() {
+            // given
+            ApplyForm applyForm = createDefaultApplyForm();
+
+            // when
+            applyForm.updateApplyInfo(
+                    LocalDate.of(2026, 9, 1),
+                    LocalDate.of(2026, 9, 30),
+                    5,
+                    Set.of(ApplicableGrade.THIRD_GRADE)
+            );
+
+            // then
+            assertThat(applyForm.getApplyStartDate()).isEqualTo(LocalDate.of(2026, 9, 1));
+            assertThat(applyForm.getApplyEndDate()).isEqualTo(LocalDate.of(2026, 9, 30));
+            assertThat(applyForm.getMaxApplyCount()).isEqualTo(5);
+            assertThat(applyForm.getGrades()).containsExactly(ApplicableGrade.THIRD_GRADE);
+        }
+
+        @Test
+        @DisplayName("null이 전달된 필드는 기존 값을 유지한다")
+        void updateApplyInfo_NullValues_KeepsOriginal() {
+            // given
+            ApplyForm applyForm = createDefaultApplyForm();
+            LocalDate originalStart = applyForm.getApplyStartDate();
+            LocalDate originalEnd = applyForm.getApplyEndDate();
+            Integer originalMaxApplyCount = applyForm.getMaxApplyCount();
+
+            // when
+            applyForm.updateApplyInfo(null, null, null, null);
+
+            // then
+            assertThat(applyForm.getApplyStartDate()).isEqualTo(originalStart);
+            assertThat(applyForm.getApplyEndDate()).isEqualTo(originalEnd);
+            assertThat(applyForm.getMaxApplyCount()).isEqualTo(originalMaxApplyCount);
+            assertThat(applyForm.getGrades()).containsExactlyInAnyOrder(
+                    ApplicableGrade.FIRST_GRADE, ApplicableGrade.SECOND_GRADE
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("updateFormContent(): 지원폼 내용 수정 테스트")
+    class UpdateFormContentTest {
+
+        @Test
+        @DisplayName("전달된 값으로 제목, 부제목, 질문을 수정한다")
+        void updateFormContent_Success() {
+            // given
+            ApplyForm applyForm = createDefaultApplyForm();
+            List<Question> newQuestions = List.of(
+                    new Question("q2", "전공", null, QuestionType.SHORT_ANSWER, false, null)
+            );
+
+            // when
+            applyForm.updateFormContent("새로운 제목", "새로운 부제목", newQuestions);
+
+            // then
+            assertThat(applyForm.getTitle()).isEqualTo("새로운 제목");
+            assertThat(applyForm.getSubTitle()).isEqualTo("새로운 부제목");
+            assertThat(applyForm.getFormJson()).isEqualTo(newQuestions);
+        }
+
+        @Test
+        @DisplayName("null이 전달된 필드는 기존 값을 유지한다")
+        void updateFormContent_NullValues_KeepsOriginal() {
+            // given
+            ApplyForm applyForm = createDefaultApplyForm();
+            String originalTitle = applyForm.getTitle();
+            String originalSubTitle = applyForm.getSubTitle();
+            List<Question> originalFormJson = applyForm.getFormJson();
+
+            // when
+            applyForm.updateFormContent(null, null, null);
+
+            // then
+            assertThat(applyForm.getTitle()).isEqualTo(originalTitle);
+            assertThat(applyForm.getSubTitle()).isEqualTo(originalSubTitle);
+            assertThat(applyForm.getFormJson()).isEqualTo(originalFormJson);
+        }
+    }
+
+    @Nested
+    @DisplayName("상태/모집 여부 변경 테스트")
+    class StatusToggleTest {
+
+        @Test
+        @DisplayName("updateFormStatus(): ACTIVE 상태를 호출하면 INACTIVE로 바뀐다")
+        void updateFormStatus_ActiveToInactive() {
+            // given
+            ApplyForm applyForm = createDefaultApplyForm();
+            assertThat(applyForm.getStatus()).isEqualTo(ApplyFormStatus.ACTIVE);
+
+            // when
+            applyForm.updateFormStatus();
+
+            // then
+            assertThat(applyForm.getStatus()).isEqualTo(ApplyFormStatus.INACTIVE);
+        }
+
+        @Test
+        @DisplayName("updateFormStatus(): 다시 호출하면 ACTIVE로 되돌아간다")
+        void updateFormStatus_TogglesBack() {
+            // given
+            ApplyForm applyForm = createDefaultApplyForm();
+
+            // when
+            applyForm.updateFormStatus();
+            applyForm.updateFormStatus();
+
+            // then
+            assertThat(applyForm.getStatus()).isEqualTo(ApplyFormStatus.ACTIVE);
+        }
+
+        @Test
+        @DisplayName("toggleRecruiting(): 모집 상태를 반전시킨다")
+        void toggleRecruiting_Success() {
+            // given
+            ApplyForm applyForm = createDefaultApplyForm();
+            assertThat(applyForm.isRecruiting()).isTrue();
+
+            // when
+            applyForm.toggleRecruiting();
+
+            // then
+            assertThat(applyForm.isRecruiting()).isFalse();
+
+            // when
+            applyForm.toggleRecruiting();
+
+            // then
+            assertThat(applyForm.isRecruiting()).isTrue();
+        }
+
+        @Test
+        @DisplayName("endRecruiting(): 모집 상태를 false로 고정한다")
+        void endRecruiting_Success() {
+            // given
+            ApplyForm applyForm = createDefaultApplyForm();
+
+            // when
+            applyForm.endRecruiting();
+
+            // then
+            assertThat(applyForm.isRecruiting()).isFalse();
+
+            // when - 이미 false인 상태에서 다시 호출해도 false를 유지한다
+            applyForm.endRecruiting();
+
+            // then
+            assertThat(applyForm.isRecruiting()).isFalse();
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/applyform/scheduler/ApplyFormSchedulerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/applyform/scheduler/ApplyFormSchedulerTest.java
@@ -1,0 +1,72 @@
+package org.project.ttokttok.domain.applyform.scheduler;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.domain.applyform.domain.ApplyForm;
+import org.project.ttokttok.domain.applyform.repository.ApplyFormRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ApplyFormSchedulerTest {
+
+    @Mock
+    private ApplyFormRepository applyFormRepository;
+
+    @InjectMocks
+    private ApplyFormScheduler applyFormScheduler;
+
+    @Test
+    @DisplayName("updateExpiredApplyFormsStatus(): 마감된 지원폼들의 모집 상태를 종료시킨다")
+    void updateExpiredApplyFormsStatus_EndsRecruitingForExpiredForms() {
+        // given
+        ApplyForm expiredForm1 = mock(ApplyForm.class);
+        ApplyForm expiredForm2 = mock(ApplyForm.class);
+        given(applyFormRepository.findExpiredApplyForms(any(LocalDate.class)))
+                .willReturn(List.of(expiredForm1, expiredForm2));
+
+        // when
+        applyFormScheduler.updateExpiredApplyFormsStatus();
+
+        // then
+        verify(expiredForm1, times(1)).endRecruiting();
+        verify(expiredForm2, times(1)).endRecruiting();
+    }
+
+    @Test
+    @DisplayName("updateExpiredApplyFormsStatus(): 마감된 지원폼이 없으면 아무 것도 변경하지 않는다")
+    void updateExpiredApplyFormsStatus_NoExpiredForms_DoesNothing() {
+        // given
+        given(applyFormRepository.findExpiredApplyForms(any(LocalDate.class)))
+                .willReturn(List.of());
+
+        // when
+        applyFormScheduler.updateExpiredApplyFormsStatus();
+
+        // then
+        verify(applyFormRepository, times(1)).findExpiredApplyForms(any(LocalDate.class));
+        verifyNoMoreInteractions(applyFormRepository);
+    }
+
+    @Test
+    @DisplayName("updateExpiredApplyFormsStatus(): 조회 중 예외가 발생해도 스케줄러는 예외를 전파하지 않는다")
+    void updateExpiredApplyFormsStatus_ExceptionIsSwallowed() {
+        // given
+        given(applyFormRepository.findExpiredApplyForms(any(LocalDate.class)))
+                .willThrow(new RuntimeException("DB 오류"));
+
+        // when, then
+        assertThatCode(() -> applyFormScheduler.updateExpiredApplyFormsStatus())
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/applyform/service/ApplyFormUserServiceTest.java
+++ b/src/test/java/org/project/ttokttok/domain/applyform/service/ApplyFormUserServiceTest.java
@@ -1,0 +1,95 @@
+package org.project.ttokttok.domain.applyform.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.domain.applyform.domain.ApplyForm;
+import org.project.ttokttok.domain.applyform.domain.enums.ApplyFormStatus;
+import org.project.ttokttok.domain.applyform.domain.enums.QuestionType;
+import org.project.ttokttok.domain.applyform.domain.json.Question;
+import org.project.ttokttok.domain.applyform.exception.ActiveApplyFormNotFoundException;
+import org.project.ttokttok.domain.applyform.repository.ApplyFormRepository;
+import org.project.ttokttok.domain.applyform.service.dto.response.ActiveApplyFormServiceResponse;
+import org.project.ttokttok.domain.club.exception.ClubNotFoundException;
+import org.project.ttokttok.domain.club.repository.ClubRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ApplyFormUserServiceTest {
+
+    @Mock
+    private ApplyFormRepository applyFormRepository;
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @InjectMocks
+    private ApplyFormUserService applyFormUserService;
+
+    @Test
+    @DisplayName("getActiveApplyForm(): 활성화된 지원폼을 정상적으로 조회한다")
+    void getActiveApplyForm_Success() {
+        // given
+        String clubId = "club-1";
+        List<Question> questions = List.of(
+                new Question("q1", "이름", null, QuestionType.SHORT_ANSWER, true, null)
+        );
+
+        ApplyForm applyForm = mock(ApplyForm.class);
+        given(applyForm.getId()).willReturn("form-1");
+        given(applyForm.getTitle()).willReturn("동아리 지원폼");
+        given(applyForm.getSubTitle()).willReturn("2026년 상반기 모집");
+        given(applyForm.getFormJson()).willReturn(questions);
+
+        given(clubRepository.existsById(clubId)).willReturn(true);
+        given(applyFormRepository.findByClubIdAndStatus(clubId, ApplyFormStatus.ACTIVE))
+                .willReturn(Optional.of(applyForm));
+
+        // when
+        ActiveApplyFormServiceResponse response = applyFormUserService.getActiveApplyForm(clubId);
+
+        // then
+        assertThat(response.formId()).isEqualTo("form-1");
+        assertThat(response.title()).isEqualTo("동아리 지원폼");
+        assertThat(response.subTitle()).isEqualTo("2026년 상반기 모집");
+        assertThat(response.questions()).isEqualTo(questions);
+    }
+
+    @Test
+    @DisplayName("getActiveApplyForm(): 동아리가 존재하지 않으면 ClubNotFoundException이 발생한다")
+    void getActiveApplyForm_ClubNotFound() {
+        // given
+        String clubId = "non-existent-club";
+        given(clubRepository.existsById(clubId)).willReturn(false);
+
+        // when, then
+        assertThatThrownBy(() -> applyFormUserService.getActiveApplyForm(clubId))
+                .isInstanceOf(ClubNotFoundException.class);
+
+        verify(applyFormRepository, never()).findByClubIdAndStatus(anyString(), any());
+    }
+
+    @Test
+    @DisplayName("getActiveApplyForm(): 활성화된 지원폼이 없으면 ActiveApplyFormNotFoundException이 발생한다")
+    void getActiveApplyForm_ActiveFormNotFound() {
+        // given
+        String clubId = "club-1";
+        given(clubRepository.existsById(clubId)).willReturn(true);
+        given(applyFormRepository.findByClubIdAndStatus(clubId, ApplyFormStatus.ACTIVE))
+                .willReturn(Optional.empty());
+
+        // when, then
+        assertThatThrownBy(() -> applyFormUserService.getActiveApplyForm(clubId))
+                .isInstanceOf(ActiveApplyFormNotFoundException.class);
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/club/controller/ClubUserApiControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/club/controller/ClubUserApiControllerTest.java
@@ -1,0 +1,146 @@
+package org.project.ttokttok.domain.club.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.club.domain.enums.ClubCategory;
+import org.project.ttokttok.domain.club.domain.enums.ClubType;
+import org.project.ttokttok.domain.club.service.ClubUserService;
+import org.project.ttokttok.domain.club.service.dto.response.ClubDetailServiceResponse;
+import org.project.ttokttok.domain.club.service.dto.response.ClubListServiceResponse;
+import org.project.ttokttok.global.annotationresolver.auth.AuthUserInfoResolver;
+import org.project.ttokttok.global.auth.jwt.service.TokenProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ClubUserApiController.class)
+class ClubUserApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ClubUserService clubUserService;
+
+    @MockitoBean
+    private TokenProvider tokenProvider;
+
+    @MockitoBean
+    private AuthUserInfoResolver authUserInfoResolver;
+
+    private static final String USER_EMAIL = "test@sangmyung.kr";
+    private static final String CLUB_ID = "club-1";
+
+    private void givenAuthenticatedUser() throws Exception {
+        given(authUserInfoResolver.supportsParameter(any())).willReturn(true);
+        given(authUserInfoResolver.resolveArgument(any(), any(), any(), any())).willReturn(USER_EMAIL);
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("동아리 상세 조회 API를 호출한다")
+    void getClubIntroduction() throws Exception {
+        givenAuthenticatedUser();
+
+        ClubDetailServiceResponse response = ClubDetailServiceResponse.builder()
+                .name("테스트 동아리")
+                .clubType(ClubType.CENTRAL)
+                .clubCategory(ClubCategory.ACADEMIC)
+                .customCategory("")
+                .bookmarked(true)
+                .recruiting(true)
+                .isDeadlineImminent(false)
+                .summary("한줄 소개")
+                .profileImageUrl(null)
+                .clubMemberCount(5)
+                .applyStartDate(null)
+                .applyDeadLine(null)
+                .grades(Collections.emptySet())
+                .maxApplyCount(10)
+                .content("소개 내용")
+                .build();
+        given(clubUserService.getClubIntroduction(USER_EMAIL, CLUB_ID)).willReturn(response);
+
+        mockMvc.perform(get("/api/clubs/{clubId}/content", CLUB_ID)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("테스트 동아리"))
+                .andExpect(jsonPath("$.bookmarked").value(true))
+                .andExpect(jsonPath("$.clubMemberCount").value(5));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("동아리 목록 조회 API를 호출한다")
+    void getClubList() throws Exception {
+        givenAuthenticatedUser();
+
+        ClubListServiceResponse response = new ClubListServiceResponse(List.of(), 0, 0L, false, null);
+        given(clubUserService.getClubList(any(), any(), any(), any(), any(), org.mockito.ArgumentMatchers.eq(20),
+                any(), org.mockito.ArgumentMatchers.eq("latest"), org.mockito.ArgumentMatchers.eq(USER_EMAIL)))
+                .willReturn(response);
+
+        mockMvc.perform(get("/api/clubs")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.clubs").isArray())
+                .andExpect(jsonPath("$.hasNext").value(false));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("메인 배너 인기 동아리 조회 API를 호출한다")
+    void getBannerPopularClubs() throws Exception {
+        givenAuthenticatedUser();
+
+        ClubListServiceResponse response = new ClubListServiceResponse(List.of(), 0, 0L, false, null);
+        given(clubUserService.getAllPopularClubs(USER_EMAIL)).willReturn(response);
+
+        mockMvc.perform(get("/api/clubs/banner/popular")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.clubs").isArray());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("필터 옵션 조회 API를 호출한다")
+    void getFilterOptions() throws Exception {
+        mockMvc.perform(get("/api/clubs/filter-options")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.types").isArray())
+                .andExpect(jsonPath("$.recruitingOptions").isArray())
+                .andExpect(jsonPath("$.universities").isArray());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("동아리 검색 API를 호출한다")
+    void searchClubs() throws Exception {
+        givenAuthenticatedUser();
+
+        ClubListServiceResponse response = new ClubListServiceResponse(List.of(), 0, 3L, false, null);
+        given(clubUserService.searchClubs(org.mockito.ArgumentMatchers.eq("코딩"), org.mockito.ArgumentMatchers.eq("latest"),
+                any(), org.mockito.ArgumentMatchers.eq(20), org.mockito.ArgumentMatchers.eq(USER_EMAIL)))
+                .willReturn(response);
+
+        mockMvc.perform(get("/api/clubs/search")
+                        .param("keyword", "코딩")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalCount").value(3));
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/club/domain/ClubTest.java
+++ b/src/test/java/org/project/ttokttok/domain/club/domain/ClubTest.java
@@ -1,0 +1,135 @@
+package org.project.ttokttok.domain.club.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openapitools.jackson.nullable.JsonNullable;
+import org.project.ttokttok.domain.admin.domain.Admin;
+import org.project.ttokttok.domain.club.domain.enums.ClubCategory;
+import org.project.ttokttok.domain.club.domain.enums.ClubType;
+import org.project.ttokttok.domain.club.domain.enums.ClubUniv;
+import org.project.ttokttok.domain.club.service.dto.request.ClubPatchRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class ClubTest {
+
+    private Club createClub() {
+        Admin admin = mock(Admin.class);
+        return Club.builder()
+                .admin(admin)
+                .clubName("테스트 동아리")
+                .clubUniv(ClubUniv.ENGINEERING)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("생성")
+    class Create {
+
+        @Test
+        @DisplayName("동아리를 생성하면 기본값들이 설정된다.")
+        void createSuccess() {
+            Club club = createClub();
+
+            assertThat(club.getName()).isEqualTo("테스트 동아리");
+            assertThat(club.getClubUniv()).isEqualTo(ClubUniv.ENGINEERING);
+            assertThat(club.getProfileImageUrl()).isNull();
+            assertThat(club.getSummary()).isEqualTo("아직 동아리 소개가 없어요 🙂");
+            assertThat(club.getClubType()).isEqualTo(ClubType.CENTRAL);
+            assertThat(club.getClubCategory()).isEqualTo(ClubCategory.ACADEMIC);
+            assertThat(club.getCustomCategory()).isEqualTo("");
+            assertThat(club.getContent()).isEqualTo("동아리 소개가 아직 작성되지 않았어요!");
+            assertThat(club.getViewCount()).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("updateViewCount()")
+    class UpdateViewCount {
+
+        @Test
+        @DisplayName("호출할 때마다 조회수가 1씩 증가한다.")
+        void increasesByOneEachCall() {
+            Club club = createClub();
+
+            club.updateViewCount();
+            assertThat(club.getViewCount()).isEqualTo(1L);
+
+            club.updateViewCount();
+            club.updateViewCount();
+            assertThat(club.getViewCount()).isEqualTo(3L);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateProfileImgUrl()")
+    class UpdateProfileImgUrl {
+
+        @Test
+        @DisplayName("프로필 이미지 URL을 변경할 수 있다.")
+        void updatesUrl() {
+            Club club = createClub();
+
+            club.updateProfileImgUrl("https://example.com/image.png");
+
+            assertThat(club.getProfileImageUrl()).isEqualTo("https://example.com/image.png");
+        }
+    }
+
+    @Nested
+    @DisplayName("updateFrom()")
+    class UpdateFrom {
+
+        @Test
+        @DisplayName("값이 채워진 필드만 부분 수정된다.")
+        void partialUpdate() {
+            Club club = createClub();
+
+            ClubPatchRequest request = new ClubPatchRequest(
+                    JsonNullable.of("새 이름"),
+                    JsonNullable.undefined(),
+                    JsonNullable.of(ClubCategory.SPORTS),
+                    JsonNullable.undefined(),
+                    JsonNullable.undefined(),
+                    JsonNullable.undefined(),
+                    JsonNullable.undefined()
+            );
+
+            club.updateFrom(request);
+
+            assertThat(club.getName()).isEqualTo("새 이름");
+            assertThat(club.getClubCategory()).isEqualTo(ClubCategory.SPORTS);
+            // 전달되지 않은 필드는 기존 값 유지
+            assertThat(club.getClubType()).isEqualTo(ClubType.CENTRAL);
+            assertThat(club.getSummary()).isEqualTo("아직 동아리 소개가 없어요 🙂");
+        }
+
+        @Test
+        @DisplayName("모든 필드가 채워지면 전체가 수정된다.")
+        void updatesAllFields() {
+            Club club = createClub();
+
+            ClubPatchRequest request = new ClubPatchRequest(
+                    JsonNullable.of("전체수정동아리"),
+                    JsonNullable.of(ClubType.UNION),
+                    JsonNullable.of(ClubCategory.CULTURE),
+                    JsonNullable.of(ClubUniv.DESIGN),
+                    JsonNullable.of("커스텀분류"),
+                    JsonNullable.of("새 한줄소개"),
+                    JsonNullable.of("새 소개 내용")
+            );
+
+            club.updateFrom(request);
+
+            assertThat(club.getName()).isEqualTo("전체수정동아리");
+            assertThat(club.getClubType()).isEqualTo(ClubType.UNION);
+            assertThat(club.getClubCategory()).isEqualTo(ClubCategory.CULTURE);
+            assertThat(club.getClubUniv()).isEqualTo(ClubUniv.DESIGN);
+            assertThat(club.getCustomCategory()).isEqualTo("커스텀분류");
+            assertThat(club.getSummary()).isEqualTo("새 한줄소개");
+            assertThat(club.getContent()).isEqualTo("새 소개 내용");
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/club/repository/ClubCustomRepositoryImplCoverageTest.java
+++ b/src/test/java/org/project/ttokttok/domain/club/repository/ClubCustomRepositoryImplCoverageTest.java
@@ -1,0 +1,82 @@
+package org.project.ttokttok.domain.club.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.applyform.domain.enums.ApplicableGrade;
+import org.project.ttokttok.domain.club.domain.enums.ClubCategory;
+import org.project.ttokttok.domain.club.domain.enums.ClubType;
+import org.project.ttokttok.domain.club.domain.enums.ClubUniv;
+import org.project.ttokttok.domain.club.repository.dto.ClubCardQueryResponse;
+import org.project.ttokttok.support.RepositoryTestSupport;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * ClubCustomRepositoryImpl 의 QueryDSL 쿼리들이 정상적으로 조립/실행되는지 검증한다.
+ * (빈 DB 기준으로 쿼리 실행 경로 및 정렬/필터 분기를 커버한다)
+ */
+@DisplayName("ClubCustomRepositoryImpl - 쿼리 실행 커버리지")
+class ClubCustomRepositoryImplCoverageTest implements RepositoryTestSupport {
+
+    @Autowired
+    private ClubRepository clubRepository;
+
+    private static final String USER = "user@sangmyung.kr";
+
+    @Test
+    @DisplayName("getClubList는 다양한 필터/정렬 조합에서 빈 결과를 반환한다")
+    void getClubList_variousFilters() {
+        for (String sort : List.of("latest", "popular", "member_count")) {
+            List<ClubCardQueryResponse> result = clubRepository.getClubList(
+                    ClubCategory.ACADEMIC, ClubType.CENTRAL, ClubUniv.ENGINEERING, true,
+                    List.of(ApplicableGrade.FIRST_GRADE), 10, null, sort, USER
+            );
+            assertThat(result).isNotNull();
+        }
+        // 필터 없음 + 커서 있음 분기
+        assertThat(clubRepository.getClubList(
+                null, null, null, null, List.of(), 10, "cursor-1", "latest", null
+        )).isNotNull();
+    }
+
+    @Test
+    @DisplayName("getAllPopularClubs는 빈 결과를 반환한다")
+    void getAllPopularClubs() {
+        assertThat(clubRepository.getAllPopularClubs(USER, 7.0)).isNotNull();
+        assertThat(clubRepository.getAllPopularClubs(null, 7.0)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("getPopularClubsWithFilters는 다양한 정렬에서 빈 결과를 반환한다")
+    void getPopularClubsWithFilters() {
+        for (String sort : List.of("latest", "popular", "member_count")) {
+            assertThat(clubRepository.getPopularClubsWithFilters(10, null, sort, USER, 7.0)).isNotNull();
+        }
+        assertThat(clubRepository.getPopularClubsWithFilters(10, "cursor-1", "popular", null, 7.0)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("searchByKeyword는 다양한 정렬에서 빈 결과를 반환한다")
+    void searchByKeyword() {
+        for (String sort : List.of("latest", "popular", "member_count")) {
+            assertThat(clubRepository.searchByKeyword("코딩", 10, null, sort, USER)).isNotNull();
+        }
+        assertThat(clubRepository.searchByKeyword("코딩", 10, "cursor-1", "latest", null)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("countByKeyword는 빈 DB에서 0을 반환한다")
+    void countByKeyword() {
+        assertThat(clubRepository.countByKeyword("코딩")).isZero();
+    }
+
+    @Test
+    @DisplayName("getClubIntroduction/getAdminClubIntro는 존재하지 않는 동아리에 대해 null을 반환한다")
+    void getIntroductions_emptyDb() {
+        assertThat(clubRepository.getClubIntroduction("no-club", USER)).isNull();
+        assertThat(clubRepository.getAdminClubIntro("no-club")).isNull();
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/club/service/ClubAdminServiceBehaviorTest.java
+++ b/src/test/java/org/project/ttokttok/domain/club/service/ClubAdminServiceBehaviorTest.java
@@ -1,0 +1,207 @@
+package org.project.ttokttok.domain.club.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.domain.applyform.domain.ApplyForm;
+import org.project.ttokttok.domain.applyform.exception.ApplyFormNotFoundException;
+import org.project.ttokttok.domain.applyform.repository.ApplyFormRepository;
+import org.project.ttokttok.domain.club.domain.Club;
+import org.project.ttokttok.domain.club.exception.ClubNotFoundException;
+import org.project.ttokttok.domain.club.exception.FileIsNotImageException;
+import org.project.ttokttok.domain.club.exception.NotClubAdminException;
+import org.project.ttokttok.domain.club.repository.ClubRepository;
+import org.project.ttokttok.domain.club.service.dto.request.MarkdownImageUpdateRequest;
+import org.project.ttokttok.domain.notification.fcm.repository.FCMTokenRepository;
+import org.project.ttokttok.infrastructure.firebase.service.FCMService;
+import org.project.ttokttok.infrastructure.firebase.service.dto.FCMRequest;
+import org.project.ttokttok.infrastructure.s3.service.S3Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ClubAdminService - 동아리 관리 동작")
+class ClubAdminServiceBehaviorTest {
+
+    @Mock private ClubRepository clubRepository;
+    @Mock private ApplyFormRepository applyFormRepository;
+    @Mock private FCMTokenRepository fcmTokenRepository;
+    @Mock private S3Service s3Service;
+    @Mock private FCMService fcmService;
+
+    @InjectMocks private ClubAdminService clubAdminService;
+
+    private static final String USERNAME = "admin@sangmyung.kr";
+    private static final String CLUB_ID = "club-1";
+
+    @Nested
+    @DisplayName("updateMarkdownImage()")
+    class UpdateMarkdownImage {
+
+        @Test
+        @DisplayName("이미지 파일이면 S3에 업로드하고 키를 반환한다")
+        void success() {
+            Club club = mock(Club.class);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            MultipartFile file = mock(MultipartFile.class);
+            given(file.getContentType()).willReturn("image/png");
+            given(s3Service.uploadFile(any(), anyString())).willReturn("s3-key");
+
+            String result = clubAdminService.updateMarkdownImage(
+                    USERNAME, MarkdownImageUpdateRequest.of(USERNAME, CLUB_ID, file));
+
+            org.assertj.core.api.Assertions.assertThat(result).isEqualTo("s3-key");
+        }
+
+        @Test
+        @DisplayName("이미지가 아닌 파일이면 FileIsNotImageException을 던진다")
+        void throwsWhenNotImage() {
+            Club club = mock(Club.class);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            MultipartFile file = mock(MultipartFile.class);
+            given(file.getContentType()).willReturn("application/pdf");
+
+            assertThatThrownBy(() -> clubAdminService.updateMarkdownImage(
+                    USERNAME, MarkdownImageUpdateRequest.of(USERNAME, CLUB_ID, file)))
+                    .isInstanceOf(FileIsNotImageException.class);
+        }
+
+        @Test
+        @DisplayName("동아리 관리자가 아니면 NotClubAdminException을 던진다")
+        void throwsWhenNotAdmin() {
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.empty());
+            MultipartFile file = mock(MultipartFile.class);
+
+            assertThatThrownBy(() -> clubAdminService.updateMarkdownImage(
+                    USERNAME, MarkdownImageUpdateRequest.of(USERNAME, CLUB_ID, file)))
+                    .isInstanceOf(NotClubAdminException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getClubContent()")
+    class GetClubContent {
+
+        @Test
+        @DisplayName("존재하지 않는 동아리면 ClubNotFoundException을 던진다")
+        void throwsWhenNotFound() {
+            given(clubRepository.existsById(CLUB_ID)).willReturn(false);
+
+            assertThatThrownBy(() -> clubAdminService.getClubContent(CLUB_ID))
+                    .isInstanceOf(ClubNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateContent()")
+    class UpdateContent {
+
+        @Test
+        @DisplayName("프로필 이미지가 있으면 S3 업로드 후 URL을 갱신한다")
+        void updatesProfileImage() {
+            Club club = mock(Club.class);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            given(club.getProfileImageUrl()).willReturn(null);
+            MultipartFile profile = mock(MultipartFile.class);
+            given(s3Service.uploadFile(any(), anyString())).willReturn("new-key");
+
+            clubAdminService.updateContent(USERNAME, CLUB_ID, null, Optional.of(profile));
+
+            verify(club).updateProfileImgUrl("new-key");
+        }
+
+        @Test
+        @DisplayName("동아리 관리자가 아니면 NotClubAdminException을 던진다")
+        void throwsWhenNotAdmin() {
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                    clubAdminService.updateContent(USERNAME, CLUB_ID, null, Optional.empty()))
+                    .isInstanceOf(NotClubAdminException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("toggleRecruitment()")
+    class ToggleRecruitment {
+
+        @Test
+        @DisplayName("모집중이 아니던 활성 폼을 켜면 모집 재개 알림을 발송한다")
+        void togglesAndSendsNotificationWhenStartRecruiting() {
+            Club club = mock(Club.class);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            given(club.getId()).willReturn(CLUB_ID);
+            given(club.getName()).willReturn("떡떡동아리");
+
+            ApplyForm form = mock(ApplyForm.class);
+            given(applyFormRepository.findByClubIdAndStatus(any(), any())).willReturn(Optional.of(form));
+            given(form.isRecruiting()).willReturn(false, true); // 토글 전 false, 토글 후 true
+            given(fcmTokenRepository.findTokensByClubId(CLUB_ID)).willReturn(List.of("token-1"));
+
+            clubAdminService.toggleRecruitment(USERNAME, CLUB_ID);
+
+            verify(form).toggleRecruiting();
+            verify(fcmService).sendNotification(any(FCMRequest.class));
+        }
+
+        @Test
+        @DisplayName("이미 모집중이던 폼을 끄면 알림을 보내지 않는다")
+        void togglesOffWithoutNotification() {
+            Club club = mock(Club.class);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+
+            ApplyForm form = mock(ApplyForm.class);
+            given(applyFormRepository.findByClubIdAndStatus(any(), any())).willReturn(Optional.of(form));
+            given(form.isRecruiting()).willReturn(true, false);
+
+            clubAdminService.toggleRecruitment(USERNAME, CLUB_ID);
+
+            verify(form).toggleRecruiting();
+            verify(fcmService, never()).sendNotification(any());
+        }
+
+        @Test
+        @DisplayName("활성 폼이 없으면 최신 폼을 활성화한다")
+        void activatesLatestWhenNoActiveForm() {
+            Club club = mock(Club.class);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            given(applyFormRepository.findByClubIdAndStatus(any(), any())).willReturn(Optional.empty());
+
+            ApplyForm latest = mock(ApplyForm.class);
+            given(applyFormRepository.findTopByClubIdOrderByCreatedAtDesc(CLUB_ID))
+                    .willReturn(Optional.of(latest));
+            given(latest.isRecruiting()).willReturn(false);
+
+            clubAdminService.toggleRecruitment(USERNAME, CLUB_ID);
+
+            verify(latest).updateFormStatus();
+        }
+
+        @Test
+        @DisplayName("활성 폼도 없고 최신 폼도 없으면 ApplyFormNotFoundException을 던진다")
+        void throwsWhenNoFormAtAll() {
+            Club club = mock(Club.class);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            given(applyFormRepository.findByClubIdAndStatus(any(), any())).willReturn(Optional.empty());
+            given(applyFormRepository.findTopByClubIdOrderByCreatedAtDesc(CLUB_ID))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> clubAdminService.toggleRecruitment(USERNAME, CLUB_ID))
+                    .isInstanceOf(ApplyFormNotFoundException.class);
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/club/service/ClubUserServiceListTest.java
+++ b/src/test/java/org/project/ttokttok/domain/club/service/ClubUserServiceListTest.java
@@ -1,0 +1,145 @@
+package org.project.ttokttok.domain.club.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.domain.club.domain.enums.ClubCategory;
+import org.project.ttokttok.domain.club.domain.enums.ClubType;
+import org.project.ttokttok.domain.club.repository.ClubRepository;
+import org.project.ttokttok.domain.club.repository.dto.ClubCardQueryResponse;
+import org.project.ttokttok.domain.club.service.dto.response.ClubListServiceResponse;
+import org.project.ttokttok.global.config.ClubPopularityConfig;
+import org.project.ttokttok.infrastructure.s3.service.S3Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ClubUserService - 목록/인기/검색 조회")
+class ClubUserServiceListTest {
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private S3Service s3Service;
+
+    @Mock
+    private ClubPopularityConfig popularityConfig;
+
+    @InjectMocks
+    private ClubUserService clubUserService;
+
+    private static final String USER = "user@sangmyung.kr";
+
+    private ClubCardQueryResponse card(String id, LocalDate deadline) {
+        return new ClubCardQueryResponse(
+                id, "동아리" + id, ClubType.CENTRAL, ClubCategory.ACADEMIC,
+                null, "요약", "http://img", 10, true, false, deadline
+        );
+    }
+
+    @Test
+    @DisplayName("동아리 목록 조회 시 size보다 많으면 hasNext=true, nextCursor가 설정된다")
+    void getClubList_hasNext() {
+        // given: size=2인데 3개 반환 -> hasNext true, 마지막 잘림
+        given(clubRepository.getClubList(any(), any(), any(), any(), any(), anyInt(), any(), anyString(), anyString()))
+                .willReturn(List.of(
+                        card("1", LocalDate.now().plusDays(3)),   // 마감 임박
+                        card("2", null),
+                        card("3", null)
+                ));
+
+        // when
+        ClubListServiceResponse response = clubUserService.getClubList(
+                ClubCategory.ACADEMIC, ClubType.CENTRAL, null, true, List.of(), 2, null, "latest", USER
+        );
+
+        // then
+        assertThat(response.hasNext()).isTrue();
+        assertThat(response.clubs()).hasSize(2);
+        assertThat(response.nextCursor()).isEqualTo("2");
+        assertThat(response.clubs().get(0).isDeadlineImminent()).isTrue();
+        assertThat(response.clubs().get(1).isDeadlineImminent()).isFalse();
+    }
+
+    @Test
+    @DisplayName("동아리 목록 조회 시 size 이하면 hasNext=false, nextCursor는 null이다")
+    void getClubList_noNext() {
+        given(clubRepository.getClubList(any(), any(), any(), any(), any(), anyInt(), any(), anyString(), anyString()))
+                .willReturn(List.of(card("1", null)));
+
+        ClubListServiceResponse response = clubUserService.getClubList(
+                null, null, null, null, List.of(), 5, null, "latest", USER
+        );
+
+        assertThat(response.hasNext()).isFalse();
+        assertThat(response.nextCursor()).isNull();
+        assertThat(response.clubs()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("마감일이 8일 이후면 마감 임박이 아니다")
+    void getClubList_notImminentWhenFar() {
+        given(clubRepository.getClubList(any(), any(), any(), any(), any(), anyInt(), any(), anyString(), anyString()))
+                .willReturn(List.of(card("1", LocalDate.now().plusDays(8))));
+
+        ClubListServiceResponse response = clubUserService.getClubList(
+                null, null, null, null, List.of(), 5, null, "latest", USER
+        );
+
+        assertThat(response.clubs().get(0).isDeadlineImminent()).isFalse();
+    }
+
+    @Test
+    @DisplayName("전체 인기 동아리 목록을 조회한다")
+    void getAllPopularClubs() {
+        given(popularityConfig.getMinScore()).willReturn(7.0);
+        given(clubRepository.getAllPopularClubs(eq(USER), eq(7.0)))
+                .willReturn(List.of(card("1", null), card("2", null)));
+
+        ClubListServiceResponse response = clubUserService.getAllPopularClubs(USER);
+
+        assertThat(response.clubs()).hasSize(2);
+        assertThat(response.hasNext()).isFalse();
+    }
+
+    @Test
+    @DisplayName("필터가 있는 인기 동아리 목록을 무한스크롤 조회한다")
+    void getPopularClubsWithFilters_hasNext() {
+        given(popularityConfig.getMinScore()).willReturn(7.0);
+        given(clubRepository.getPopularClubsWithFilters(anyInt(), any(), anyString(), anyString(), eq(7.0)))
+                .willReturn(List.of(card("1", null), card("2", null), card("3", null)));
+
+        ClubListServiceResponse response = clubUserService.getPopularClubsWithFilters(2, null, "popular", USER);
+
+        assertThat(response.hasNext()).isTrue();
+        assertThat(response.clubs()).hasSize(2);
+        assertThat(response.nextCursor()).isEqualTo("2");
+    }
+
+    @Test
+    @DisplayName("키워드로 동아리를 검색하면 총 개수와 결과를 반환한다")
+    void searchClubs() {
+        given(clubRepository.countByKeyword("코딩")).willReturn(5L);
+        given(clubRepository.searchByKeyword(eq("코딩"), anyInt(), any(), anyString(), anyString()))
+                .willReturn(List.of(card("1", null), card("2", null), card("3", null)));
+
+        ClubListServiceResponse response = clubUserService.searchClubs("코딩", "member_count", null, 2, USER);
+
+        assertThat(response.totalCount()).isEqualTo(5L);
+        assertThat(response.hasNext()).isTrue();
+        assertThat(response.clubs()).hasSize(2);
+        assertThat(response.nextCursor()).isEqualTo("2");
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/clubMember/controller/ClubMemberApiControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubMember/controller/ClubMemberApiControllerTest.java
@@ -1,0 +1,211 @@
+package org.project.ttokttok.domain.clubMember.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.applicant.domain.enums.Grade;
+import org.project.ttokttok.domain.clubMember.domain.MemberRole;
+import org.project.ttokttok.domain.clubMember.service.ClubMemberService;
+import org.project.ttokttok.domain.clubMember.service.dto.request.ChangeRoleServiceRequest;
+import org.project.ttokttok.domain.clubMember.service.dto.request.ClubMemberSearchRequest;
+import org.project.ttokttok.domain.clubMember.service.dto.request.DeleteMemberServiceRequest;
+import org.project.ttokttok.domain.clubMember.service.dto.response.ClubMemberCountServiceResponse;
+import org.project.ttokttok.domain.clubMember.service.dto.response.ClubMemberPageServiceResponse;
+import org.project.ttokttok.domain.clubMember.service.dto.response.ClubMemberSearchServiceResponse;
+import org.project.ttokttok.domain.clubMember.service.dto.response.ExcelServiceResponse;
+import org.project.ttokttok.global.annotationresolver.auth.AuthUserInfoResolver;
+import org.project.ttokttok.global.auth.jwt.service.TokenProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ClubMemberApiController.class)
+class ClubMemberApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ClubMemberService clubMemberService;
+
+    @MockitoBean
+    private TokenProvider tokenProvider;
+
+    @MockitoBean
+    private AuthUserInfoResolver authUserInfoResolver;
+
+    private static final String USERNAME = "clubadmin1";
+    private static final String CLUB_ID = "club-1";
+
+    private void stubAuthUserInfo() throws Exception {
+        given(authUserInfoResolver.supportsParameter(any())).willReturn(true);
+        given(authUserInfoResolver.resolveArgument(any(), any(), any(), any())).willReturn(USERNAME);
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("동아리 부원 목록을 페이지 단위로 조회한다")
+    void getClubMembers() throws Exception {
+        // given
+        stubAuthUserInfo();
+        ClubMemberPageServiceResponse response = ClubMemberPageServiceResponse.builder()
+                .currentPage(1)
+                .totalPage(1)
+                .totalCount(0)
+                .clubMembers(List.of())
+                .build();
+        given(clubMemberService.getClubMembers(eq(USERNAME), eq(CLUB_ID), any())).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/admin/members/{clubId}", CLUB_ID)
+                        .param("page", "1")
+                        .param("size", "5")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.currentPage").value(1))
+                .andExpect(jsonPath("$.totalPage").value(1))
+                .andExpect(jsonPath("$.totalCount").value(0));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("동아리 부원 총 수를 조회한다")
+    void getClubMemberCount() throws Exception {
+        // given
+        stubAuthUserInfo();
+        ClubMemberCountServiceResponse response = ClubMemberCountServiceResponse.builder()
+                .totalCount(4)
+                .firstGradeCount(1)
+                .secondGradeCount(1)
+                .thirdGradeCount(1)
+                .fourthGradeCount(1)
+                .build();
+        given(clubMemberService.getClubMembersCount(CLUB_ID, USERNAME)).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/admin/members/{clubId}/total-count", CLUB_ID)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalCount").value(4))
+                .andExpect(jsonPath("$.firstGradeCount").value(1));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("부원의 역할을 변경한다")
+    void changeRole() throws Exception {
+        // given
+        stubAuthUserInfo();
+        String memberId = "member-1";
+
+        // when & then
+        mockMvc.perform(patch("/api/admin/members/{clubId}/{memberId}/role", CLUB_ID, memberId)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"role\":\"EXECUTIVE\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("부원 역할 변경 완료: " + memberId));
+
+        verify(clubMemberService, times(1)).changeRole(eq(USERNAME), any(ChangeRoleServiceRequest.class));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("부원을 삭제한다")
+    void deleteMember() throws Exception {
+        // given
+        stubAuthUserInfo();
+        String memberId = "member-1";
+
+        // when & then
+        mockMvc.perform(delete("/api/admin/members/{clubId}/{memberId}", CLUB_ID, memberId)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("부원 삭제 완료: " + memberId));
+
+        verify(clubMemberService, times(1)).deleteMember(eq(USERNAME), any(DeleteMemberServiceRequest.class));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("부원 목록을 엑셀 파일로 다운로드한다")
+    void downloadMembersExcel() throws Exception {
+        // given
+        stubAuthUserInfo();
+        byte[] excelBytes = {1, 2, 3};
+        given(clubMemberService.downloadMembersAsExcel(CLUB_ID, USERNAME))
+                .willReturn(new ExcelServiceResponse("테스트동아리", excelBytes));
+
+        // when & then
+        mockMvc.perform(get("/api/admin/members/{clubId}/download", CLUB_ID))
+                .andExpect(status().isOk())
+                .andExpect(header().exists("Content-Disposition"));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("키워드로 부원을 검색한다")
+    void searchMembers() throws Exception {
+        // given
+        stubAuthUserInfo();
+        List<ClubMemberSearchServiceResponse> serviceResponses = List.of(
+                ClubMemberSearchServiceResponse.of("member-1", Grade.FIRST_GRADE, "홍길동", "컴퓨터공학과", MemberRole.MEMBER)
+        );
+        given(clubMemberService.clubMemberSearch(eq(USERNAME), any(ClubMemberSearchRequest.class)))
+                .willReturn(serviceResponses);
+
+        // when & then
+        mockMvc.perform(get("/api/admin/members/{clubId}/search", CLUB_ID)
+                        .param("keyword", "홍")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.clubMembers[0].name").value("홍길동"));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("동아리에 부원을 추가한다")
+    void addMembers() throws Exception {
+        // given
+        stubAuthUserInfo();
+        given(clubMemberService.addMember(eq(USERNAME), eq(CLUB_ID), any(), eq("MEMBER")))
+                .willReturn("new-member-id");
+
+        String requestBody = """
+                {
+                    "studentNum": 60201234,
+                    "name": "홍길동",
+                    "major": "컴퓨터공학과",
+                    "grade": "FIRST_GRADE",
+                    "email": "test1@sangmyung.kr",
+                    "phoneNumber": "010-1111-1111",
+                    "gender": "MALE"
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(post("/api/admin/members/{clubId}/add", CLUB_ID)
+                        .with(csrf())
+                        .param("role", "MEMBER")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.memberId").value("new-member-id"));
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/clubMember/domain/ClubMemberTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubMember/domain/ClubMemberTest.java
@@ -1,0 +1,142 @@
+package org.project.ttokttok.domain.clubMember.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.applicant.domain.enums.Gender;
+import org.project.ttokttok.domain.applicant.domain.enums.Grade;
+import org.project.ttokttok.domain.club.domain.Club;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class ClubMemberTest {
+
+    @Nested
+    @DisplayName("create() 팩토리 메서드 테스트")
+    class CreateTest {
+
+        @Test
+        @DisplayName("모든 값을 지정하면 그대로 반영된 부원이 생성된다")
+        void create_success() {
+            // given
+            Club club = mock(Club.class);
+
+            // when
+            ClubMember member = ClubMember.create(
+                    club,
+                    "홍길동",
+                    MemberRole.EXECUTIVE,
+                    Grade.SECOND_GRADE,
+                    "컴퓨터공학과",
+                    "test1@sangmyung.kr",
+                    "010-1111-1111",
+                    Gender.MALE
+            );
+
+            // then
+            assertThat(member.getClub()).isEqualTo(club);
+            assertThat(member.getMemberName()).isEqualTo("홍길동");
+            assertThat(member.getRole()).isEqualTo(MemberRole.EXECUTIVE);
+            assertThat(member.getGrade()).isEqualTo(Grade.SECOND_GRADE);
+            assertThat(member.getMajor()).isEqualTo("컴퓨터공학과");
+            assertThat(member.getEmail()).isEqualTo("test1@sangmyung.kr");
+            assertThat(member.getPhoneNumber()).isEqualTo("010-1111-1111");
+            assertThat(member.getGender()).isEqualTo(Gender.MALE);
+        }
+
+        @Test
+        @DisplayName("role이 null이면 기본값 MEMBER로 생성된다")
+        void create_nullRole_defaultsToMember() {
+            // given
+            Club club = mock(Club.class);
+
+            // when
+            ClubMember member = ClubMember.create(
+                    club,
+                    "홍길동",
+                    null,
+                    Grade.SECOND_GRADE,
+                    "컴퓨터공학과",
+                    "test1@sangmyung.kr",
+                    "010-1111-1111",
+                    Gender.MALE
+            );
+
+            // then
+            assertThat(member.getRole()).isEqualTo(MemberRole.MEMBER);
+        }
+
+        @Test
+        @DisplayName("grade가 null이면 기본값 FIRST_GRADE로 생성된다")
+        void create_nullGrade_defaultsToFirstGrade() {
+            // given
+            Club club = mock(Club.class);
+
+            // when
+            ClubMember member = ClubMember.create(
+                    club,
+                    "홍길동",
+                    MemberRole.MEMBER,
+                    null,
+                    "컴퓨터공학과",
+                    "test1@sangmyung.kr",
+                    "010-1111-1111",
+                    Gender.MALE
+            );
+
+            // then
+            assertThat(member.getGrade()).isEqualTo(Grade.FIRST_GRADE);
+        }
+
+        @Test
+        @DisplayName("major가 null이면 기본값 N/A로 생성된다")
+        void create_nullMajor_defaultsToNA() {
+            // given
+            Club club = mock(Club.class);
+
+            // when
+            ClubMember member = ClubMember.create(
+                    club,
+                    "홍길동",
+                    MemberRole.MEMBER,
+                    Grade.FIRST_GRADE,
+                    null,
+                    "test1@sangmyung.kr",
+                    "010-1111-1111",
+                    Gender.MALE
+            );
+
+            // then
+            assertThat(member.getMajor()).isEqualTo("N/A");
+        }
+    }
+
+    @Nested
+    @DisplayName("changeRole() 메서드 테스트")
+    class ChangeRoleTest {
+
+        @Test
+        @DisplayName("부원의 역할을 변경할 수 있다")
+        void changeRole_success() {
+            // given
+            Club club = mock(Club.class);
+            ClubMember member = ClubMember.create(
+                    club,
+                    "홍길동",
+                    MemberRole.MEMBER,
+                    Grade.FIRST_GRADE,
+                    "컴퓨터공학과",
+                    "test1@sangmyung.kr",
+                    "010-1111-1111",
+                    Gender.MALE
+            );
+
+            // when
+            member.changeRole(MemberRole.PRESIDENT);
+
+            // then
+            assertThat(member.getRole()).isEqualTo(MemberRole.PRESIDENT);
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/clubMember/domain/MemberRoleTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubMember/domain/MemberRoleTest.java
@@ -1,0 +1,24 @@
+package org.project.ttokttok.domain.clubMember.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberRoleTest {
+
+    @Test
+    @DisplayName("각 역할은 올바른 한글 이름을 가진다")
+    void memberRoleName_success() {
+        assertThat(MemberRole.PRESIDENT.getMemberRoleName()).isEqualTo("회장");
+        assertThat(MemberRole.VICE_PRESIDENT.getMemberRoleName()).isEqualTo("부회장");
+        assertThat(MemberRole.EXECUTIVE.getMemberRoleName()).isEqualTo("임원진");
+        assertThat(MemberRole.MEMBER.getMemberRoleName()).isEqualTo("부원");
+    }
+
+    @Test
+    @DisplayName("MemberRole은 4개의 상수를 가진다")
+    void memberRole_hasFourValues() {
+        assertThat(MemberRole.values()).hasSize(4);
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/clubMember/repository/ClubMemberCustomRepositoryImplTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubMember/repository/ClubMemberCustomRepositoryImplTest.java
@@ -1,0 +1,266 @@
+package org.project.ttokttok.domain.clubMember.repository;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.admin.domain.Admin;
+import org.project.ttokttok.domain.admin.repository.AdminRepository;
+import org.project.ttokttok.domain.applicant.domain.enums.Gender;
+import org.project.ttokttok.domain.applicant.domain.enums.Grade;
+import org.project.ttokttok.domain.club.domain.Club;
+import org.project.ttokttok.domain.club.domain.enums.ClubUniv;
+import org.project.ttokttok.domain.club.repository.ClubRepository;
+import org.project.ttokttok.domain.clubMember.domain.ClubMember;
+import org.project.ttokttok.domain.clubMember.domain.MemberRole;
+import org.project.ttokttok.domain.clubMember.repository.dto.ClubMemberCountQueryResponse;
+import org.project.ttokttok.domain.clubMember.repository.dto.ClubMemberPageQueryResponse;
+import org.project.ttokttok.domain.clubMember.service.dto.response.ClubMemberInExcelResponse;
+import org.project.ttokttok.support.RepositoryTestSupport;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ClubMemberCustomRepositoryImplTest implements RepositoryTestSupport {
+
+    @Autowired
+    private ClubMemberRepository clubMemberRepository;
+
+    @Autowired
+    private ClubRepository clubRepository;
+
+    @Autowired
+    private AdminRepository adminRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private Club club1;
+    private Club club2;
+
+    private ClubMember president; // club1, PRESIDENT, FIRST_GRADE
+    private ClubMember executive; // club1, EXECUTIVE, SECOND_GRADE
+    private ClubMember member1;   // club1, MEMBER, THIRD_GRADE
+    private ClubMember member2;   // club1, MEMBER, FIRST_GRADE
+    private ClubMember otherClubMember; // club2, MEMBER
+
+    @BeforeEach
+    void setUp() {
+        Admin admin1 = adminRepository.save(Admin.adminJoin("testadmin1", "password123!", "admin1@sangmyung.kr"));
+        Admin admin2 = adminRepository.save(Admin.adminJoin("testadmin2", "password123!", "admin2@sangmyung.kr"));
+
+        club1 = clubRepository.save(Club.builder()
+                .admin(admin1)
+                .clubName("테스트 동아리 1")
+                .clubUniv(ClubUniv.ENGINEERING)
+                .build());
+
+        club2 = clubRepository.save(Club.builder()
+                .admin(admin2)
+                .clubName("테스트 동아리 2")
+                .clubUniv(ClubUniv.DESIGN)
+                .build());
+
+        president = clubMemberRepository.save(ClubMember.create(
+                club1, "박대표", MemberRole.PRESIDENT, Grade.FIRST_GRADE,
+                "경영학과", "president@sangmyung.kr", "010-1111-0001", Gender.MALE));
+
+        executive = clubMemberRepository.save(ClubMember.create(
+                club1, "이임원", MemberRole.EXECUTIVE, Grade.SECOND_GRADE,
+                "전자공학과", "executive@sangmyung.kr", "010-1111-0002", Gender.FEMALE));
+
+        member1 = clubMemberRepository.save(ClubMember.create(
+                club1, "김철수", MemberRole.MEMBER, Grade.THIRD_GRADE,
+                "컴퓨터공학과", "member1@sangmyung.kr", "010-1111-0003", Gender.MALE));
+
+        member2 = clubMemberRepository.save(ClubMember.create(
+                club1, "최부원", MemberRole.MEMBER, Grade.FIRST_GRADE,
+                "화학공학과", "member2@sangmyung.kr", "010-1111-0004", Gender.FEMALE));
+
+        otherClubMember = clubMemberRepository.save(ClubMember.create(
+                club2, "정회원", MemberRole.MEMBER, Grade.FIRST_GRADE,
+                "디자인학과", "other@sangmyung.kr", "010-1111-0005", Gender.MALE));
+
+        em.flush();
+        em.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        clubMemberRepository.deleteAllInBatch();
+        clubRepository.deleteAllInBatch();
+        adminRepository.deleteAllInBatch();
+    }
+
+    @Nested
+    @DisplayName("findClubMemberPageByClubId 메서드")
+    class FindClubMemberPageByClubIdTest {
+
+        @Test
+        @DisplayName("역할(PRESIDENT>EXECUTIVE>MEMBER) 순, 학년 순으로 정렬된 첫 페이지를 반환한다")
+        void findClubMemberPageByClubId_firstPage() {
+            // when
+            ClubMemberPageQueryResponse result =
+                    clubMemberRepository.findClubMemberPageByClubId(club1.getId(), 1, 2);
+
+            // then
+            assertThat(result.currentPage()).isEqualTo(1);
+            assertThat(result.totalCount()).isEqualTo(4);
+            assertThat(result.totalPage()).isEqualTo(2);
+            assertThat(result.clubMembers()).hasSize(2);
+            assertThat(result.clubMembers().get(0).getId()).isEqualTo(president.getId());
+            assertThat(result.clubMembers().get(1).getId()).isEqualTo(executive.getId());
+        }
+
+        @Test
+        @DisplayName("두 번째 페이지는 학년 오름차순으로 MEMBER들을 반환한다")
+        void findClubMemberPageByClubId_secondPage() {
+            // when
+            ClubMemberPageQueryResponse result =
+                    clubMemberRepository.findClubMemberPageByClubId(club1.getId(), 2, 2);
+
+            // then
+            assertThat(result.currentPage()).isEqualTo(2);
+            assertThat(result.clubMembers()).hasSize(2);
+            assertThat(result.clubMembers().get(0).getId()).isEqualTo(member2.getId()); // FIRST_GRADE
+            assertThat(result.clubMembers().get(1).getId()).isEqualTo(member1.getId()); // THIRD_GRADE
+        }
+
+        @Test
+        @DisplayName("다른 동아리의 부원은 결과에 포함되지 않는다")
+        void findClubMemberPageByClubId_excludesOtherClub() {
+            // when
+            ClubMemberPageQueryResponse result =
+                    clubMemberRepository.findClubMemberPageByClubId(club2.getId(), 1, 10);
+
+            // then
+            assertThat(result.totalCount()).isEqualTo(1);
+            assertThat(result.clubMembers()).hasSize(1);
+            assertThat(result.clubMembers().get(0).getId()).isEqualTo(otherClubMember.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("countClubMembersByClubId 메서드")
+    class CountClubMembersByClubIdTest {
+
+        @Test
+        @DisplayName("동아리의 학년별 부원 수와 총 부원 수를 반환한다")
+        void countClubMembersByClubId_success() {
+            // when
+            ClubMemberCountQueryResponse result = clubMemberRepository.countClubMembersByClubId(club1.getId());
+
+            // then
+            assertThat(result.totalCount()).isEqualTo(4);
+            assertThat(result.firstGradeCount()).isEqualTo(2); // president, member2
+            assertThat(result.secondGradeCount()).isEqualTo(1); // executive
+            assertThat(result.thirdGradeCount()).isEqualTo(1); // member1
+            assertThat(result.fourthGradeCount()).isEqualTo(0);
+        }
+    }
+
+    @Nested
+    @DisplayName("findByClubIdAndKeyword 메서드")
+    class FindByClubIdAndKeywordTest {
+
+        @Test
+        @DisplayName("이름에 키워드가 포함된 부원을 조회한다")
+        void findByClubIdAndKeyword_found() {
+            // when
+            List<ClubMember> result = clubMemberRepository.findByClubIdAndKeyword(club1.getId(), "철수");
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getId()).isEqualTo(member1.getId());
+        }
+
+        @Test
+        @DisplayName("일치하는 이름이 없으면 빈 리스트를 반환한다")
+        void findByClubIdAndKeyword_notFound() {
+            // when
+            List<ClubMember> result = clubMemberRepository.findByClubIdAndKeyword(club1.getId(), "존재하지않음");
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByClubId 메서드")
+    class FindByClubIdTest {
+
+        @Test
+        @DisplayName("동아리의 모든 부원을 엑셀 응답 형태로 조회한다")
+        void findByClubId_success() {
+            // when
+            List<ClubMemberInExcelResponse> result = clubMemberRepository.findByClubId(club1.getId());
+
+            // then
+            assertThat(result).hasSize(4);
+            assertThat(result)
+                    .anySatisfy(response -> {
+                        assertThat(response.name()).isEqualTo("김철수");
+                        assertThat(response.grade()).isEqualTo(Grade.THIRD_GRADE);
+                        assertThat(response.major()).isEqualTo("컴퓨터공학과");
+                        assertThat(response.role()).isEqualTo(MemberRole.MEMBER);
+                    });
+        }
+    }
+
+    @Nested
+    @DisplayName("findByClubIdAndRole 메서드")
+    class FindByClubIdAndRoleTest {
+
+        @Test
+        @DisplayName("동아리의 회장을 조회한다")
+        void findByClubIdAndRole_found() {
+            // when
+            Optional<ClubMember> result = clubMemberRepository.findByClubIdAndRole(club1.getId(), MemberRole.PRESIDENT);
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get().getId()).isEqualTo(president.getId());
+        }
+
+        @Test
+        @DisplayName("동아리에 부회장이 없으면 빈 값을 반환한다")
+        void findByClubIdAndRole_notFound() {
+            // when
+            Optional<ClubMember> result =
+                    clubMemberRepository.findByClubIdAndRole(club1.getId(), MemberRole.VICE_PRESIDENT);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByClubIdAndEmail 메서드")
+    class ExistsByClubIdAndEmailTest {
+
+        @Test
+        @DisplayName("동아리에 해당 이메일의 부원이 존재하면 true를 반환한다")
+        void existsByClubIdAndEmail_true() {
+            // when
+            boolean exists = clubMemberRepository.existsByClubIdAndEmail(club1.getId(), "member1@sangmyung.kr");
+
+            // then
+            assertThat(exists).isTrue();
+        }
+
+        @Test
+        @DisplayName("동아리에 해당 이메일의 부원이 없으면 false를 반환한다")
+        void existsByClubIdAndEmail_false() {
+            // when
+            boolean exists = clubMemberRepository.existsByClubIdAndEmail(club1.getId(), "notexist@sangmyung.kr");
+
+            // then
+            assertThat(exists).isFalse();
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/clubMember/service/ClubMemberServiceTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubMember/service/ClubMemberServiceTest.java
@@ -1,0 +1,492 @@
+package org.project.ttokttok.domain.clubMember.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.domain.admin.domain.Admin;
+import org.project.ttokttok.domain.applicant.domain.enums.Gender;
+import org.project.ttokttok.domain.applicant.domain.enums.Grade;
+import org.project.ttokttok.domain.club.domain.Club;
+import org.project.ttokttok.domain.club.exception.ClubNotFoundException;
+import org.project.ttokttok.domain.club.exception.NotClubAdminException;
+import org.project.ttokttok.domain.club.repository.ClubRepository;
+import org.project.ttokttok.domain.clubMember.domain.ClubMember;
+import org.project.ttokttok.domain.clubMember.domain.MemberRole;
+import org.project.ttokttok.domain.clubMember.exception.AlreadyClubMemberException;
+import org.project.ttokttok.domain.clubMember.exception.ClubMemberNotFoundException;
+import org.project.ttokttok.domain.clubMember.exception.DuplicateRoleException;
+import org.project.ttokttok.domain.clubMember.exception.ExcelFileCreateFailException;
+import org.project.ttokttok.domain.clubMember.repository.ClubMemberRepository;
+import org.project.ttokttok.domain.clubMember.repository.dto.ClubMemberCountQueryResponse;
+import org.project.ttokttok.domain.clubMember.repository.dto.ClubMemberPageQueryResponse;
+import org.project.ttokttok.domain.clubMember.service.dto.request.ChangeRoleServiceRequest;
+import org.project.ttokttok.domain.clubMember.service.dto.request.ClubMemberPageRequest;
+import org.project.ttokttok.domain.clubMember.service.dto.request.ClubMemberSearchRequest;
+import org.project.ttokttok.domain.clubMember.service.dto.request.ClubMemberServiceRequest;
+import org.project.ttokttok.domain.clubMember.service.dto.request.DeleteMemberServiceRequest;
+import org.project.ttokttok.domain.clubMember.service.dto.response.ClubMemberCountServiceResponse;
+import org.project.ttokttok.domain.clubMember.service.dto.response.ClubMemberInExcelResponse;
+import org.project.ttokttok.domain.clubMember.service.dto.response.ClubMemberPageServiceResponse;
+import org.project.ttokttok.domain.clubMember.service.dto.response.ClubMemberSearchServiceResponse;
+import org.project.ttokttok.domain.clubMember.service.dto.response.ExcelServiceResponse;
+import org.project.ttokttok.global.excel.ExcelService;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+import static org.project.ttokttok.domain.clubMember.domain.MemberRole.*;
+
+@ExtendWith(MockitoExtension.class)
+class ClubMemberServiceTest {
+
+    @Mock
+    private ClubMemberRepository clubMemberRepository;
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private ExcelService excelService;
+
+    @InjectMocks
+    private ClubMemberService clubMemberService;
+
+    private static final String USERNAME = "clubadmin1";
+    private static final String CLUB_ID = "club-1";
+
+    private Club createClub(String adminUsername) {
+        Admin admin = mock(Admin.class);
+        lenient().when(admin.getUsername()).thenReturn(adminUsername);
+
+        Club club = mock(Club.class);
+        lenient().when(club.getId()).thenReturn(CLUB_ID);
+        lenient().when(club.getName()).thenReturn("테스트동아리");
+        lenient().when(club.getAdmin()).thenReturn(admin);
+        return club;
+    }
+
+    private ClubMember createMember(MemberRole role) {
+        Club club = mock(Club.class);
+        return ClubMember.create(
+                club,
+                "홍길동",
+                role,
+                Grade.FIRST_GRADE,
+                "컴퓨터공학과",
+                "test1@sangmyung.kr",
+                "010-1111-1111",
+                Gender.MALE
+        );
+    }
+
+    @Nested
+    @DisplayName("getClubMembers 메서드")
+    class GetClubMembersTest {
+
+        @Test
+        @DisplayName("동아리 관리자가 부원 목록을 페이지 단위로 조회한다")
+        void getClubMembers_success() {
+            // given
+            Club club = createClub(USERNAME);
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+
+            ClubMemberPageRequest request = new ClubMemberPageRequest(USERNAME, 1, 5);
+            ClubMemberPageQueryResponse queryResponse = ClubMemberPageQueryResponse.builder()
+                    .currentPage(1)
+                    .totalPage(1)
+                    .totalCount(1)
+                    .clubMembers(List.of(createMember(MEMBER)))
+                    .build();
+
+            given(clubMemberRepository.findClubMemberPageByClubId(CLUB_ID, 1, 5))
+                    .willReturn(queryResponse);
+
+            // when
+            ClubMemberPageServiceResponse result = clubMemberService.getClubMembers(USERNAME, CLUB_ID, request);
+
+            // then
+            assertThat(result.currentPage()).isEqualTo(1);
+            assertThat(result.totalPage()).isEqualTo(1);
+            assertThat(result.totalCount()).isEqualTo(1);
+            assertThat(result.clubMembers()).hasSize(1);
+            assertThat(result.clubMembers().get(0).name()).isEqualTo("홍길동");
+            assertThat(result.clubMembers().get(0).role()).isEqualTo(MEMBER);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 동아리를 조회하면 ClubNotFoundException이 발생한다")
+        void getClubMembers_clubNotFound() {
+            // given
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.empty());
+            ClubMemberPageRequest request = new ClubMemberPageRequest(USERNAME, 1, 5);
+
+            // when & then
+            assertThatThrownBy(() -> clubMemberService.getClubMembers(USERNAME, CLUB_ID, request))
+                    .isInstanceOf(ClubNotFoundException.class);
+
+            verify(clubMemberRepository, never()).findClubMemberPageByClubId(anyString(), anyInt(), anyInt());
+        }
+
+        @Test
+        @DisplayName("동아리 관리자가 아니면 NotClubAdminException이 발생한다")
+        void getClubMembers_notClubAdmin() {
+            // given
+            Club club = createClub("otheradmin1");
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            ClubMemberPageRequest request = new ClubMemberPageRequest(USERNAME, 1, 5);
+
+            // when & then
+            assertThatThrownBy(() -> clubMemberService.getClubMembers(USERNAME, CLUB_ID, request))
+                    .isInstanceOf(NotClubAdminException.class);
+
+            verify(clubMemberRepository, never()).findClubMemberPageByClubId(anyString(), anyInt(), anyInt());
+        }
+    }
+
+    @Nested
+    @DisplayName("changeRole 메서드")
+    class ChangeRoleTest {
+
+        @Test
+        @DisplayName("부원의 역할을 변경한다")
+        void changeRole_success() {
+            // given
+            Club club = createClub(USERNAME);
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+
+            ClubMember member = mock(ClubMember.class);
+            given(clubMemberRepository.findById("member-1")).willReturn(Optional.of(member));
+
+            ChangeRoleServiceRequest request = ChangeRoleServiceRequest.of(USERNAME, CLUB_ID, "member-1", MEMBER);
+
+            // when
+            clubMemberService.changeRole(USERNAME, request);
+
+            // then
+            verify(member, times(1)).changeRole(MEMBER);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 부원의 역할을 변경하면 ClubMemberNotFoundException이 발생한다")
+        void changeRole_memberNotFound() {
+            // given
+            Club club = createClub(USERNAME);
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            given(clubMemberRepository.findById("member-1")).willReturn(Optional.empty());
+
+            ChangeRoleServiceRequest request = ChangeRoleServiceRequest.of(USERNAME, CLUB_ID, "member-1", MEMBER);
+
+            // when & then
+            assertThatThrownBy(() -> clubMemberService.changeRole(USERNAME, request))
+                    .isInstanceOf(ClubMemberNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("이미 회장이 존재하는 동아리에서 다른 부원을 회장으로 변경하면 DuplicateRoleException이 발생한다")
+        void changeRole_duplicatePresident() {
+            // given
+            Club club = createClub(USERNAME);
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+
+            ClubMember member = mock(ClubMember.class);
+            given(member.getId()).willReturn("member-1");
+            given(clubMemberRepository.findById("member-1")).willReturn(Optional.of(member));
+
+            ClubMember existingPresident = mock(ClubMember.class);
+            given(existingPresident.getId()).willReturn("member-2");
+            given(clubMemberRepository.findByClubIdAndRole(CLUB_ID, PRESIDENT))
+                    .willReturn(Optional.of(existingPresident));
+
+            ChangeRoleServiceRequest request = ChangeRoleServiceRequest.of(USERNAME, CLUB_ID, "member-1", PRESIDENT);
+
+            // when & then
+            assertThatThrownBy(() -> clubMemberService.changeRole(USERNAME, request))
+                    .isInstanceOf(DuplicateRoleException.class);
+
+            verify(member, never()).changeRole(any());
+        }
+
+        @Test
+        @DisplayName("본인이 이미 회장인 부원을 다시 회장으로 변경해도 중복 예외가 발생하지 않는다")
+        void changeRole_samePresident_noException() {
+            // given
+            Club club = createClub(USERNAME);
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+
+            ClubMember member = mock(ClubMember.class);
+            given(member.getId()).willReturn("member-1");
+            given(clubMemberRepository.findById("member-1")).willReturn(Optional.of(member));
+
+            given(clubMemberRepository.findByClubIdAndRole(CLUB_ID, PRESIDENT))
+                    .willReturn(Optional.of(member));
+
+            ChangeRoleServiceRequest request = ChangeRoleServiceRequest.of(USERNAME, CLUB_ID, "member-1", PRESIDENT);
+
+            // when
+            clubMemberService.changeRole(USERNAME, request);
+
+            // then
+            verify(member, times(1)).changeRole(PRESIDENT);
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteMember 메서드")
+    class DeleteMemberTest {
+
+        @Test
+        @DisplayName("부원을 삭제한다")
+        void deleteMember_success() {
+            // given
+            Club club = createClub(USERNAME);
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+
+            ClubMember member = mock(ClubMember.class);
+            given(clubMemberRepository.findById("member-1")).willReturn(Optional.of(member));
+
+            DeleteMemberServiceRequest request = DeleteMemberServiceRequest.of(USERNAME, CLUB_ID, "member-1");
+
+            // when
+            clubMemberService.deleteMember(USERNAME, request);
+
+            // then
+            verify(clubMemberRepository, times(1)).delete(member);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 부원을 삭제하면 ClubMemberNotFoundException이 발생한다")
+        void deleteMember_memberNotFound() {
+            // given
+            Club club = createClub(USERNAME);
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            given(clubMemberRepository.findById("member-1")).willReturn(Optional.empty());
+
+            DeleteMemberServiceRequest request = DeleteMemberServiceRequest.of(USERNAME, CLUB_ID, "member-1");
+
+            // when & then
+            assertThatThrownBy(() -> clubMemberService.deleteMember(USERNAME, request))
+                    .isInstanceOf(ClubMemberNotFoundException.class);
+
+            verify(clubMemberRepository, never()).delete(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("downloadMembersAsExcel 메서드")
+    class DownloadMembersAsExcelTest {
+
+        @Test
+        @DisplayName("부원 목록을 엑셀 파일로 생성한다")
+        void downloadMembersAsExcel_success() throws IOException {
+            // given
+            Club club = createClub(USERNAME);
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+
+            List<ClubMemberInExcelResponse> excelTargets =
+                    List.of(new ClubMemberInExcelResponse(Grade.FIRST_GRADE, "홍길동", "컴퓨터공학과", MEMBER));
+            given(clubMemberRepository.findByClubId(CLUB_ID)).willReturn(excelTargets);
+
+            given(clubRepository.findByName("테스트동아리")).willReturn(Optional.of(club));
+
+            byte[] excelBytes = {1, 2, 3};
+            given(excelService.createMemberExcel("테스트동아리", excelTargets)).willReturn(excelBytes);
+
+            // when
+            ExcelServiceResponse result = clubMemberService.downloadMembersAsExcel(CLUB_ID, USERNAME);
+
+            // then
+            assertThat(result.clubName()).isEqualTo("테스트동아리");
+            assertThat(result.excelData()).isEqualTo(excelBytes);
+        }
+
+        @Test
+        @DisplayName("엑셀 생성 중 IOException이 발생하면 ExcelFileCreateFailException이 발생한다")
+        void downloadMembersAsExcel_ioException() throws IOException {
+            // given
+            Club club = createClub(USERNAME);
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            given(clubMemberRepository.findByClubId(CLUB_ID)).willReturn(List.of());
+            given(clubRepository.findByName("테스트동아리")).willReturn(Optional.of(club));
+            given(excelService.createMemberExcel(anyString(), any())).willThrow(new IOException("엑셀 생성 실패"));
+
+            // when & then
+            assertThatThrownBy(() -> clubMemberService.downloadMembersAsExcel(CLUB_ID, USERNAME))
+                    .isInstanceOf(ExcelFileCreateFailException.class);
+        }
+
+        @Test
+        @DisplayName("엑셀 생성 대상 동아리 이름을 찾지 못하면 ClubNotFoundException이 발생한다")
+        void downloadMembersAsExcel_clubNameNotFound() {
+            // given
+            Club club = createClub(USERNAME);
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+            given(clubMemberRepository.findByClubId(CLUB_ID)).willReturn(List.of());
+            given(clubRepository.findByName("테스트동아리")).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> clubMemberService.downloadMembersAsExcel(CLUB_ID, USERNAME))
+                    .isInstanceOf(ClubNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("clubMemberSearch 메서드")
+    class ClubMemberSearchTest {
+
+        @Test
+        @DisplayName("이름 키워드로 부원을 검색한다")
+        void clubMemberSearch_success() {
+            // given
+            Club club = createClub(USERNAME);
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+
+            ClubMember member = createMember(EXECUTIVE);
+            given(clubMemberRepository.findByClubIdAndKeyword(CLUB_ID, "홍")).willReturn(List.of(member));
+
+            ClubMemberSearchRequest request = ClubMemberSearchRequest.of(USERNAME, CLUB_ID, "홍");
+
+            // when
+            List<ClubMemberSearchServiceResponse> result = clubMemberService.clubMemberSearch(USERNAME, request);
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).name()).isEqualTo("홍길동");
+            assertThat(result.get(0).grade()).isEqualTo(Grade.FIRST_GRADE);
+            assertThat(result.get(0).major()).isEqualTo("컴퓨터공학과");
+            assertThat(result.get(0).role()).isEqualTo(EXECUTIVE);
+        }
+    }
+
+    @Nested
+    @DisplayName("getClubMembersCount 메서드")
+    class GetClubMembersCountTest {
+
+        @Test
+        @DisplayName("학년별 부원 수를 조회한다")
+        void getClubMembersCount_success() {
+            // given
+            Club club = createClub(USERNAME);
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+
+            ClubMemberCountQueryResponse queryResponse = ClubMemberCountQueryResponse.builder()
+                    .totalCount(4)
+                    .firstGradeCount(1)
+                    .secondGradeCount(1)
+                    .thirdGradeCount(1)
+                    .fourthGradeCount(1)
+                    .build();
+            given(clubMemberRepository.countClubMembersByClubId(CLUB_ID)).willReturn(queryResponse);
+
+            // when
+            ClubMemberCountServiceResponse result = clubMemberService.getClubMembersCount(CLUB_ID, USERNAME);
+
+            // then
+            assertThat(result.totalCount()).isEqualTo(4);
+            assertThat(result.firstGradeCount()).isEqualTo(1);
+            assertThat(result.secondGradeCount()).isEqualTo(1);
+            assertThat(result.thirdGradeCount()).isEqualTo(1);
+            assertThat(result.fourthGradeCount()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("addMember 메서드")
+    class AddMemberTest {
+
+        private ClubMemberServiceRequest createAddRequest() {
+            return ClubMemberServiceRequest.builder()
+                    .studentNum(60201234L)
+                    .name("홍길동")
+                    .major("컴퓨터공학과")
+                    .grade(Grade.FIRST_GRADE)
+                    .phoneNumber("010-1111-1111")
+                    .gender(Gender.MALE)
+                    .build();
+        }
+
+        @Test
+        @DisplayName("role이 EXECUTIVE이면 임원진으로 부원을 추가한다")
+        void addMember_executive() {
+            // given
+            Club club = createClub(USERNAME);
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+
+            given(clubMemberRepository.existsByClubIdAndEmail(CLUB_ID, "60201234@sangmyung.kr"))
+                    .willReturn(false);
+
+            ClubMember saved = mock(ClubMember.class);
+            given(saved.getId()).willReturn("new-member-id");
+            given(clubMemberRepository.save(any(ClubMember.class))).willReturn(saved);
+
+            // when
+            String memberId = clubMemberService.addMember(USERNAME, CLUB_ID, createAddRequest(), "EXECUTIVE");
+
+            // then
+            assertThat(memberId).isEqualTo("new-member-id");
+            verify(clubMemberRepository, never()).findByClubIdAndRole(anyString(), any());
+        }
+
+        @Test
+        @DisplayName("role이 EXECUTIVE가 아니면 일반 부원(MEMBER)으로 추가한다")
+        void addMember_defaultsToMember() {
+            // given
+            Club club = createClub(USERNAME);
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+
+            given(clubMemberRepository.existsByClubIdAndEmail(CLUB_ID, "60201234@sangmyung.kr"))
+                    .willReturn(false);
+
+            ClubMember saved = mock(ClubMember.class);
+            given(saved.getId()).willReturn("new-member-id");
+            given(clubMemberRepository.save(any(ClubMember.class))).willReturn(saved);
+
+            // when
+            String memberId = clubMemberService.addMember(USERNAME, CLUB_ID, createAddRequest(), "MEMBER");
+
+            // then
+            assertThat(memberId).isEqualTo("new-member-id");
+        }
+
+        @Test
+        @DisplayName("이미 등록된 이메일이면 AlreadyClubMemberException이 발생한다")
+        void addMember_alreadyClubMember() {
+            // given
+            Club club = createClub(USERNAME);
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+
+            given(clubMemberRepository.existsByClubIdAndEmail(CLUB_ID, "60201234@sangmyung.kr"))
+                    .willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> clubMemberService.addMember(USERNAME, CLUB_ID, createAddRequest(), "MEMBER"))
+                    .isInstanceOf(AlreadyClubMemberException.class);
+
+            verify(clubMemberRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("동아리 관리자가 아니면 부원을 추가할 수 없다")
+        void addMember_notClubAdmin() {
+            // given
+            Club club = createClub("otheradmin1");
+            given(clubRepository.findById(CLUB_ID)).willReturn(Optional.of(club));
+
+            // when & then
+            assertThatThrownBy(() -> clubMemberService.addMember(USERNAME, CLUB_ID, createAddRequest(), "MEMBER"))
+                    .isInstanceOf(NotClubAdminException.class);
+
+            verify(clubMemberRepository, never()).save(any());
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardUserControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardUserControllerTest.java
@@ -1,0 +1,78 @@
+package org.project.ttokttok.domain.clubboard.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.clubboard.controller.dto.response.ClubBoardListResponse;
+import org.project.ttokttok.domain.clubboard.controller.dto.response.ClubBoardListResponse.ClubBoardSummary;
+import org.project.ttokttok.domain.clubboard.service.ClubBoardUserService;
+import org.project.ttokttok.global.annotationresolver.auth.AuthUserInfoResolver;
+import org.project.ttokttok.global.auth.jwt.service.TokenProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ClubBoardUserController.class)
+class ClubBoardUserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ClubBoardUserService clubBoardUserService;
+
+    @MockitoBean
+    private TokenProvider tokenProvider;
+
+    @MockitoBean
+    private AuthUserInfoResolver authUserInfoResolver;
+
+    private static final String CLUB_ID = "club-1";
+
+    @Test
+    @WithMockUser
+    @DisplayName("게시판 목록 조회 API를 기본 파라미터로 호출한다")
+    void getBoardListWithDefaultParams() throws Exception {
+        ClubBoardSummary summary = new ClubBoardSummary(
+                "board-1", "제목", "내용", "동아리", false, LocalDateTime.of(2026, 1, 1, 0, 0)
+        );
+        given(clubBoardUserService.getBoardList(CLUB_ID, 20, null))
+                .willReturn(ClubBoardListResponse.of(List.of(summary), false, null));
+
+        mockMvc.perform(get("/api/clubs/{clubId}/boards", CLUB_ID)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.boards[0].boardId").value("board-1"))
+                .andExpect(jsonPath("$.hasNext").value(false));
+
+        verify(clubBoardUserService).getBoardList(CLUB_ID, 20, null);
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("size와 cursor 파라미터를 전달하여 게시판 목록을 조회한다")
+    void getBoardListWithCursorAndSize() throws Exception {
+        given(clubBoardUserService.getBoardList(eq(CLUB_ID), eq(5), eq("cursor-1")))
+                .willReturn(ClubBoardListResponse.of(List.of(), true, "cursor-2"));
+
+        mockMvc.perform(get("/api/clubs/{clubId}/boards", CLUB_ID)
+                        .param("size", "5")
+                        .param("cursor", "cursor-1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.hasNext").value(true))
+                .andExpect(jsonPath("$.nextCursor").value("cursor-2"));
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/clubboard/domain/ClubBoardTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/domain/ClubBoardTest.java
@@ -1,0 +1,133 @@
+package org.project.ttokttok.domain.clubboard.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.club.domain.Club;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class ClubBoardTest {
+
+    @Nested
+    @DisplayName("create()")
+    class Create {
+
+        @Test
+        @DisplayName("올바른 정보로 게시글을 생성할 수 있다.")
+        void createSuccess() {
+            Club club = mock(Club.class);
+
+            ClubBoard board = ClubBoard.create("제목", "내용", club);
+
+            assertThat(board.getTitle()).isEqualTo("제목");
+            assertThat(board.getContent()).isEqualTo("내용");
+            assertThat(board.getClub()).isEqualTo(club);
+            assertThat(board.getId()).isNull(); // JPA 저장 전이므로 null
+        }
+
+        @Test
+        @DisplayName("제목이 비어있으면 예외가 발생한다.")
+        void createFailBlankTitle() {
+            Club club = mock(Club.class);
+
+            assertThatThrownBy(() -> ClubBoard.create(" ", "내용", club))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Title cannot be null or blank.");
+        }
+
+        @Test
+        @DisplayName("제목이 null이면 예외가 발생한다.")
+        void createFailNullTitle() {
+            Club club = mock(Club.class);
+
+            assertThatThrownBy(() -> ClubBoard.create(null, "내용", club))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Title cannot be null or blank.");
+        }
+
+        @Test
+        @DisplayName("내용이 비어있으면 예외가 발생한다.")
+        void createFailBlankContent() {
+            Club club = mock(Club.class);
+
+            assertThatThrownBy(() -> ClubBoard.create("제목", " ", club))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Content cannot be null or blank.");
+        }
+
+        @Test
+        @DisplayName("동아리가 null이면 예외가 발생한다.")
+        void createFailNullClub() {
+            assertThatThrownBy(() -> ClubBoard.create("제목", "내용", null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Club cannot be null.");
+        }
+    }
+
+    @Nested
+    @DisplayName("update()")
+    class Update {
+
+        @Test
+        @DisplayName("제목과 내용을 모두 수정할 수 있다.")
+        void updateBothFields() {
+            Club club = mock(Club.class);
+            ClubBoard board = ClubBoard.create("원제목", "원내용", club);
+
+            board.update("새 제목", "새 내용");
+
+            assertThat(board.getTitle()).isEqualTo("새 제목");
+            assertThat(board.getContent()).isEqualTo("새 내용");
+        }
+
+        @Test
+        @DisplayName("title만 전달하면 content는 기존 값을 유지한다.")
+        void updateTitleOnly() {
+            Club club = mock(Club.class);
+            ClubBoard board = ClubBoard.create("원제목", "원내용", club);
+
+            board.update("새 제목", null);
+
+            assertThat(board.getTitle()).isEqualTo("새 제목");
+            assertThat(board.getContent()).isEqualTo("원내용");
+        }
+
+        @Test
+        @DisplayName("content만 전달하면 title은 기존 값을 유지한다.")
+        void updateContentOnly() {
+            Club club = mock(Club.class);
+            ClubBoard board = ClubBoard.create("원제목", "원내용", club);
+
+            board.update(null, "새 내용");
+
+            assertThat(board.getTitle()).isEqualTo("원제목");
+            assertThat(board.getContent()).isEqualTo("새 내용");
+        }
+
+        @Test
+        @DisplayName("둘 다 null이면 아무 것도 바뀌지 않는다.")
+        void updateBothNull() {
+            Club club = mock(Club.class);
+            ClubBoard board = ClubBoard.create("원제목", "원내용", club);
+
+            board.update(null, null);
+
+            assertThat(board.getTitle()).isEqualTo("원제목");
+            assertThat(board.getContent()).isEqualTo("원내용");
+        }
+
+        @Test
+        @DisplayName("빈 문자열로 수정을 시도하면 예외가 발생한다.")
+        void updateBlankTitleThrows() {
+            Club club = mock(Club.class);
+            ClubBoard board = ClubBoard.create("원제목", "원내용", club);
+
+            assertThatThrownBy(() -> board.update(" ", null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Title cannot be null or blank.");
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/clubboard/service/ClubBoardUserServiceTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/service/ClubBoardUserServiceTest.java
@@ -1,0 +1,127 @@
+package org.project.ttokttok.domain.clubboard.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.domain.club.domain.Club;
+import org.project.ttokttok.domain.club.exception.ClubNotFoundException;
+import org.project.ttokttok.domain.club.repository.ClubRepository;
+import org.project.ttokttok.domain.clubboard.controller.dto.response.ClubBoardListResponse;
+import org.project.ttokttok.domain.clubboard.controller.dto.response.ClubBoardListResponse.ClubBoardSummary;
+import org.project.ttokttok.domain.clubboard.domain.ClubBoard;
+import org.project.ttokttok.domain.clubboard.repository.ClubBoardRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ClubBoardUserServiceTest {
+
+    private final ClubBoardRepository clubBoardRepository = mock(ClubBoardRepository.class);
+    private final ClubRepository clubRepository = mock(ClubRepository.class);
+    private final ClubBoardUserService clubBoardUserService =
+            new ClubBoardUserService(clubBoardRepository, clubRepository);
+
+    private ClubBoard mockBoard(String id, String title, String content) {
+        Club club = mock(Club.class);
+        lenient().when(club.getName()).thenReturn("동아리");
+
+        ClubBoard board = mock(ClubBoard.class);
+        lenient().when(board.getId()).thenReturn(id);
+        lenient().when(board.getTitle()).thenReturn(title);
+        lenient().when(board.getContent()).thenReturn(content);
+        lenient().when(board.getClub()).thenReturn(club);
+        lenient().when(board.getCreatedAt()).thenReturn(LocalDateTime.of(2026, 1, 1, 0, 0));
+        return board;
+    }
+
+    @Nested
+    @DisplayName("getBoardList()")
+    class GetBoardList {
+
+        @Test
+        @DisplayName("존재하지 않는 동아리를 조회하면 예외가 발생한다.")
+        void getBoardListClubNotFound() {
+            when(clubRepository.existsById("missing")).thenReturn(false);
+
+            assertThatThrownBy(() -> clubBoardUserService.getBoardList("missing", 20, null))
+                    .isInstanceOf(ClubNotFoundException.class);
+
+            verify(clubBoardRepository, never()).findBoardsByClubIdWithCursor(any(), anyInt(), any());
+        }
+
+        @Test
+        @DisplayName("다음 페이지가 없으면 hasNext가 false이고 nextCursor는 null이다.")
+        void getBoardListNoNextPage() {
+            when(clubRepository.existsById("club123")).thenReturn(true);
+
+            ClubBoard board1 = mockBoard("board1", "제목1", "내용1");
+            when(clubBoardRepository.findBoardsByClubIdWithCursor("club123", 20, null))
+                    .thenReturn(List.of(board1));
+
+            ClubBoardListResponse response = clubBoardUserService.getBoardList("club123", 20, null);
+
+            assertThat(response.hasNext()).isFalse();
+            assertThat(response.nextCursor()).isNull();
+            assertThat(response.boards()).hasSize(1);
+
+            ClubBoardSummary summary = response.boards().get(0);
+            assertThat(summary.boardId()).isEqualTo("board1");
+            assertThat(summary.title()).isEqualTo("제목1");
+            assertThat(summary.clubName()).isEqualTo("동아리");
+        }
+
+        @Test
+        @DisplayName("조회된 개수가 size보다 많으면 hasNext가 true이고 마지막 항목이 잘려나간다.")
+        void getBoardListHasNextPage() {
+            when(clubRepository.existsById("club123")).thenReturn(true);
+
+            ClubBoard board1 = mockBoard("board1", "제목1", "내용1");
+            ClubBoard board2 = mockBoard("board2", "제목2", "내용2");
+            // size가 1이지만 2개(size+1)를 반환하여 다음 페이지 존재를 알린다.
+            when(clubBoardRepository.findBoardsByClubIdWithCursor("club123", 1, null))
+                    .thenReturn(List.of(board1, board2));
+
+            ClubBoardListResponse response = clubBoardUserService.getBoardList("club123", 1, null);
+
+            assertThat(response.hasNext()).isTrue();
+            assertThat(response.nextCursor()).isEqualTo("board1");
+            assertThat(response.boards()).hasSize(1);
+            assertThat(response.boards().get(0).boardId()).isEqualTo("board1");
+        }
+
+        @Test
+        @DisplayName("게시글 내용에 img 태그가 있으면 hasImages가 true이다.")
+        void getBoardListHasImagesFromImgTag() {
+            when(clubRepository.existsById("club123")).thenReturn(true);
+
+            ClubBoard board = mockBoard("board1", "제목", "<p>본문 <img src='a.png'/></p>");
+            when(clubBoardRepository.findBoardsByClubIdWithCursor("club123", 20, null))
+                    .thenReturn(List.of(board));
+
+            ClubBoardListResponse response = clubBoardUserService.getBoardList("club123", 20, null);
+
+            assertThat(response.boards().get(0).hasImages()).isTrue();
+        }
+
+        @Test
+        @DisplayName("게시글 내용에 이미지가 없으면 hasImages가 false이다.")
+        void getBoardListNoImages() {
+            when(clubRepository.existsById("club123")).thenReturn(true);
+
+            ClubBoard board = mockBoard("board1", "제목", "그냥 텍스트 내용입니다.");
+            when(clubBoardRepository.findBoardsByClubIdWithCursor("club123", 20, null))
+                    .thenReturn(List.of(board));
+
+            ClubBoardListResponse response = clubBoardUserService.getBoardList("club123", 20, null);
+
+            assertThat(response.boards().get(0).hasImages()).isFalse();
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/favorite/domain/FavoriteTest.java
+++ b/src/test/java/org/project/ttokttok/domain/favorite/domain/FavoriteTest.java
@@ -1,0 +1,40 @@
+package org.project.ttokttok.domain.favorite.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.club.domain.Club;
+import org.project.ttokttok.domain.user.domain.User;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class FavoriteTest {
+
+    @Test
+    @DisplayName("create()로 즐겨찾기를 생성하면 사용자와 동아리가 설정된다.")
+    void createSuccess() {
+        User user = mock(User.class);
+        Club club = mock(Club.class);
+
+        Favorite favorite = Favorite.create(user, club);
+
+        assertThat(favorite.getUser()).isEqualTo(user);
+        assertThat(favorite.getClub()).isEqualTo(club);
+        assertThat(favorite.getId()).isNull(); // JPA 저장 전이므로 null
+    }
+
+    @Test
+    @DisplayName("서로 다른 사용자/동아리로 생성하면 각각 독립적인 즐겨찾기가 만들어진다.")
+    void createIndependentFavorites() {
+        User user1 = mock(User.class);
+        User user2 = mock(User.class);
+        Club club = mock(Club.class);
+
+        Favorite favorite1 = Favorite.create(user1, club);
+        Favorite favorite2 = Favorite.create(user2, club);
+
+        assertThat(favorite1.getUser()).isEqualTo(user1);
+        assertThat(favorite2.getUser()).isEqualTo(user2);
+        assertThat(favorite1.getClub()).isEqualTo(favorite2.getClub());
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/favorite/service/PopularityCalculatorTest.java
+++ b/src/test/java/org/project/ttokttok/domain/favorite/service/PopularityCalculatorTest.java
@@ -1,0 +1,74 @@
+package org.project.ttokttok.domain.favorite.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.global.config.ClubPopularityConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+class PopularityCalculatorTest {
+
+    private ClubPopularityConfig config;
+    private PopularityCalculator popularityCalculator;
+
+    @BeforeEach
+    void setUp() {
+        config = new ClubPopularityConfig();
+        popularityCalculator = new PopularityCalculator(config);
+    }
+
+    @Test
+    @DisplayName("기본 가중치(멤버 0.7, 즐겨찾기 2.5, 조회수 0.7)로 인기도 점수를 계산한다.")
+    void calculateWithDefaultWeight() {
+        // given: ClubPopularityConfig 기본값 (members=0.7, favorites=2.5, views=0.7)
+        long memberCount = 10;
+        long favoriteCount = 4;
+        long viewCount = 20;
+
+        // when
+        double score = popularityCalculator.calculate(memberCount, favoriteCount, viewCount);
+
+        // then: (10*0.7) + (4*2.5) + (20*0.7) = 7 + 10 + 14 = 31
+        assertThat(score).isCloseTo(31.0, within(0.0001));
+    }
+
+    @Test
+    @DisplayName("application-test.yml에서 사용하는 가중치(멤버 0.7, 즐겨찾기 0.3)로도 정확히 계산한다.")
+    void calculateWithTestYamlWeight() {
+        // given
+        config.getWeight().setMembers(0.7);
+        config.getWeight().setFavorites(0.3);
+        config.getWeight().setViews(0.0);
+
+        // when
+        double score = popularityCalculator.calculate(10, 20, 100);
+
+        // then: (10*0.7) + (20*0.3) + (100*0.0) = 7 + 6 + 0 = 13
+        assertThat(score).isCloseTo(13.0, within(0.0001));
+    }
+
+    @Test
+    @DisplayName("멤버, 즐겨찾기, 조회수가 모두 0이면 점수는 0이다.")
+    void calculateWithZeroCounts() {
+        double score = popularityCalculator.calculate(0, 0, 0);
+
+        assertThat(score).isZero();
+    }
+
+    @Test
+    @DisplayName("가중치가 커스텀 값이어도 각 요소에 정확히 곱해져 합산된다.")
+    void calculateWithCustomWeight() {
+        // given
+        config.getWeight().setMembers(2.0);
+        config.getWeight().setFavorites(1.0);
+        config.getWeight().setViews(0.5);
+
+        // when
+        double score = popularityCalculator.calculate(3, 5, 8);
+
+        // then: (3*2.0) + (5*1.0) + (8*0.5) = 6 + 5 + 4 = 15
+        assertThat(score).isCloseTo(15.0, within(0.0001));
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/memo/controller/MemoApiControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/memo/controller/MemoApiControllerTest.java
@@ -1,0 +1,128 @@
+package org.project.ttokttok.domain.memo.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.memo.controller.dto.request.MemoRequest;
+import org.project.ttokttok.domain.memo.service.MemoService;
+import org.project.ttokttok.domain.memo.service.dto.request.CreateMemoServiceRequest;
+import org.project.ttokttok.domain.memo.service.dto.request.DeleteMemoServiceRequest;
+import org.project.ttokttok.domain.memo.service.dto.request.UpdateMemoServiceRequest;
+import org.project.ttokttok.global.annotationresolver.auth.AuthUserInfoResolver;
+import org.project.ttokttok.global.auth.jwt.service.TokenProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemoApiController.class)
+class MemoApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private MemoService memoService;
+
+    @MockitoBean
+    private TokenProvider tokenProvider;
+
+    @MockitoBean
+    private AuthUserInfoResolver authUserInfoResolver;
+
+    private static final String USERNAME = "admin1234";
+    private static final String APPLICANT_ID = "applicant-1";
+    private static final String MEMO_ID = "memo-1";
+
+    private void givenAuthenticatedAdmin() throws Exception {
+        given(authUserInfoResolver.supportsParameter(any())).willReturn(true);
+        given(authUserInfoResolver.resolveArgument(any(), any(), any(), any())).willReturn(USERNAME);
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("메모 생성 API를 호출하면 memoId를 응답한다")
+    void createMemo() throws Exception {
+        // given
+        givenAuthenticatedAdmin();
+        MemoRequest request = new MemoRequest("면접 태도가 좋았음");
+        given(memoService.createMemo(eq(USERNAME), any(CreateMemoServiceRequest.class)))
+                .willReturn(MEMO_ID);
+
+        // when & then
+        mockMvc.perform(post("/api/admin/applies/{applicantId}/memos", APPLICANT_ID)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.memoId").value(MEMO_ID));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("메모 생성 시 content가 비어있으면 400을 응답한다")
+    void createMemo_BlankContent_BadRequest() throws Exception {
+        // given
+        givenAuthenticatedAdmin();
+        MemoRequest request = new MemoRequest(" ");
+
+        // when & then
+        mockMvc.perform(post("/api/admin/applies/{applicantId}/memos", APPLICANT_ID)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("메모 수정 API를 호출하면 성공 메시지를 응답한다")
+    void updateMemo() throws Exception {
+        // given
+        givenAuthenticatedAdmin();
+        MemoRequest request = new MemoRequest("수정된 메모 내용");
+
+        // when & then
+        mockMvc.perform(patch("/api/admin/applies/{applicantId}/memos/{memoId}", APPLICANT_ID, MEMO_ID)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("메모 수정에 성공했습니다."));
+
+        verify(memoService).updateMemo(eq(USERNAME), any(UpdateMemoServiceRequest.class));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("메모 삭제 API를 호출하면 성공 메시지를 응답한다")
+    void deleteMemo() throws Exception {
+        // given
+        givenAuthenticatedAdmin();
+
+        // when & then
+        mockMvc.perform(delete("/api/admin/applies/{applicantId}/memos/{memoId}", APPLICANT_ID, MEMO_ID)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("메모 삭제에 성공했습니다."));
+
+        verify(memoService).deleteMemo(eq(USERNAME), any(DeleteMemoServiceRequest.class));
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/memo/domain/MemoTest.java
+++ b/src/test/java/org/project/ttokttok/domain/memo/domain/MemoTest.java
@@ -1,0 +1,84 @@
+package org.project.ttokttok.domain.memo.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.project.ttokttok.domain.applicant.domain.DocumentPhase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+class MemoTest {
+
+    @Nested
+    @DisplayName("create() 테스트")
+    class CreateTest {
+
+        @Test
+        @DisplayName("서류 단계와 내용으로 메모를 생성할 수 있다")
+        void create_Success() {
+            // given
+            DocumentPhase documentPhase = mock(DocumentPhase.class);
+            String content = "면접 태도가 좋았음";
+
+            // when
+            Memo memo = Memo.create(documentPhase, content);
+
+            // then
+            assertThat(memo.getId()).isNotNull();
+            assertThat(memo.getContent()).isEqualTo(content);
+            assertThat(memo.getDocumentPhase()).isEqualTo(documentPhase);
+        }
+
+        @Test
+        @DisplayName("생성되는 메모의 id는 매번 고유하다")
+        void create_GeneratesUniqueId() {
+            // given
+            DocumentPhase documentPhase = mock(DocumentPhase.class);
+
+            // when
+            Memo memo1 = Memo.create(documentPhase, "내용1");
+            Memo memo2 = Memo.create(documentPhase, "내용2");
+
+            // then
+            assertThat(memo1.getId()).isNotEqualTo(memo2.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("updateContent() 테스트")
+    class UpdateContentTest {
+
+        @Test
+        @DisplayName("올바른 내용으로 메모 내용을 수정할 수 있다")
+        void updateContent_Success() {
+            // given
+            Memo memo = Memo.create(mock(DocumentPhase.class), "원래 내용");
+            String newContent = "수정된 내용";
+
+            // when
+            memo.updateContent(newContent);
+
+            // then
+            assertThat(memo.getContent()).isEqualTo(newContent);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {" ", "\t", "\n"})
+        @DisplayName("내용이 비어있으면 IllegalArgumentException이 발생한다")
+        void updateContent_Fail_BlankContent(String blankContent) {
+            // given
+            Memo memo = Memo.create(mock(DocumentPhase.class), "원래 내용");
+
+            // when & then
+            assertThatThrownBy(() -> memo.updateContent(blankContent))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("메모 내용은 비워둘 수 없습니다.");
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/memo/service/MemoServiceTest.java
+++ b/src/test/java/org/project/ttokttok/domain/memo/service/MemoServiceTest.java
@@ -1,0 +1,294 @@
+package org.project.ttokttok.domain.memo.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.domain.applicant.domain.Applicant;
+import org.project.ttokttok.domain.applicant.domain.DocumentPhase;
+import org.project.ttokttok.domain.applicant.exception.ApplicantNotFoundException;
+import org.project.ttokttok.domain.applicant.exception.UnAuthorizedApplicantAccessException;
+import org.project.ttokttok.domain.applicant.repository.ApplicantRepository;
+import org.project.ttokttok.domain.applyform.domain.ApplyForm;
+import org.project.ttokttok.domain.club.domain.Club;
+import org.project.ttokttok.domain.club.exception.NotClubAdminException;
+import org.project.ttokttok.domain.club.repository.ClubRepository;
+import org.project.ttokttok.domain.memo.service.dto.request.CreateMemoServiceRequest;
+import org.project.ttokttok.domain.memo.service.dto.request.DeleteMemoServiceRequest;
+import org.project.ttokttok.domain.memo.service.dto.request.UpdateMemoServiceRequest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MemoServiceTest {
+
+    @Mock
+    private ApplicantRepository applicantRepository;
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @InjectMocks
+    private MemoService memoService;
+
+    private static final String USERNAME = "admin1234";
+    private static final String CLUB_ID = "club-1";
+    private static final String APPLICANT_ID = "applicant-1";
+    private static final String CONTENT = "면접 태도가 좋았음";
+
+    // 소속 동아리 id가 clubId인 지원자를 만든다. documentPhase는 별도로 stub하지 않는 한 null이다.
+    private Applicant applicantInClub(String clubId) {
+        Applicant applicant = mock(Applicant.class);
+        ApplyForm applyForm = mock(ApplyForm.class);
+        Club applicantClub = mock(Club.class);
+        given(applicantClub.getId()).willReturn(clubId);
+        given(applyForm.getClub()).willReturn(applicantClub);
+        given(applicant.getApplyForm()).willReturn(applyForm);
+        return applicant;
+    }
+
+    @Nested
+    @DisplayName("createMemo 테스트")
+    class CreateMemoTest {
+
+        @Test
+        @DisplayName("정상 요청이면 메모를 생성하고 memoId를 반환한다")
+        void createMemo_Success() {
+            // given
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+
+            DocumentPhase documentPhase = mock(DocumentPhase.class);
+            given(documentPhase.addMemo(CONTENT)).willReturn("memo-1");
+            Applicant applicant = applicantInClub(CLUB_ID);
+            given(applicant.getDocumentPhase()).willReturn(documentPhase);
+            given(applicantRepository.findById(APPLICANT_ID)).willReturn(Optional.of(applicant));
+
+            CreateMemoServiceRequest request = CreateMemoServiceRequest.of(USERNAME, APPLICANT_ID, CONTENT);
+
+            // when
+            String memoId = memoService.createMemo(USERNAME, request);
+
+            // then
+            assertThat(memoId).isEqualTo("memo-1");
+            verify(documentPhase, times(1)).addMemo(CONTENT);
+        }
+
+        @Test
+        @DisplayName("동아리 관리자가 아니면 NotClubAdminException이 발생한다")
+        void createMemo_Fail_NotClubAdmin() {
+            // given
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.empty());
+            CreateMemoServiceRequest request = CreateMemoServiceRequest.of(USERNAME, APPLICANT_ID, CONTENT);
+
+            // when & then
+            assertThatThrownBy(() -> memoService.createMemo(USERNAME, request))
+                    .isInstanceOf(NotClubAdminException.class);
+
+            verify(applicantRepository, never()).findById(APPLICANT_ID);
+        }
+
+        @Test
+        @DisplayName("지원자를 찾을 수 없으면 ApplicantNotFoundException이 발생한다")
+        void createMemo_Fail_ApplicantNotFound() {
+            // given
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(mock(Club.class)));
+            given(applicantRepository.findById(APPLICANT_ID)).willReturn(Optional.empty());
+            CreateMemoServiceRequest request = CreateMemoServiceRequest.of(USERNAME, APPLICANT_ID, CONTENT);
+
+            // when & then
+            assertThatThrownBy(() -> memoService.createMemo(USERNAME, request))
+                    .isInstanceOf(ApplicantNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("지원자가 다른 동아리 소속이면 UnAuthorizedApplicantAccessException이 발생한다")
+        void createMemo_Fail_UnAuthorizedAccess() {
+            // given
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            Applicant applicant = applicantInClub("other-club");
+            given(applicantRepository.findById(APPLICANT_ID)).willReturn(Optional.of(applicant));
+            CreateMemoServiceRequest request = CreateMemoServiceRequest.of(USERNAME, APPLICANT_ID, CONTENT);
+
+            // when & then
+            assertThatThrownBy(() -> memoService.createMemo(USERNAME, request))
+                    .isInstanceOf(UnAuthorizedApplicantAccessException.class);
+        }
+
+        @Test
+        @DisplayName("서류 단계가 없는 지원자면 IllegalArgumentException이 발생한다")
+        void createMemo_Fail_NoDocumentPhase() {
+            // given
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            Applicant applicant = applicantInClub(CLUB_ID); // documentPhase는 stub하지 않아 기본값 null
+            given(applicantRepository.findById(APPLICANT_ID)).willReturn(Optional.of(applicant));
+            CreateMemoServiceRequest request = CreateMemoServiceRequest.of(USERNAME, APPLICANT_ID, CONTENT);
+
+            // when & then
+            assertThatThrownBy(() -> memoService.createMemo(USERNAME, request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("메모는 서류 지원자에만 작성할 수 있습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("updateMemo 테스트")
+    class UpdateMemoTest {
+
+        @Test
+        @DisplayName("정상 요청이면 documentPhase.updateMemo에 위임한다")
+        void updateMemo_Success() {
+            // given
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+
+            DocumentPhase documentPhase = mock(DocumentPhase.class);
+            Applicant applicant = applicantInClub(CLUB_ID);
+            given(applicant.getDocumentPhase()).willReturn(documentPhase);
+            given(applicantRepository.findById(APPLICANT_ID)).willReturn(Optional.of(applicant));
+
+            UpdateMemoServiceRequest request = UpdateMemoServiceRequest.of("memo-1", USERNAME, APPLICANT_ID, CONTENT);
+
+            // when
+            memoService.updateMemo(USERNAME, request);
+
+            // then
+            verify(documentPhase, times(1)).updateMemo("memo-1", CONTENT);
+        }
+
+        @Test
+        @DisplayName("동아리 관리자가 아니면 NotClubAdminException이 발생한다")
+        void updateMemo_Fail_NotClubAdmin() {
+            // given
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.empty());
+            UpdateMemoServiceRequest request = UpdateMemoServiceRequest.of("memo-1", USERNAME, APPLICANT_ID, CONTENT);
+
+            // when & then
+            assertThatThrownBy(() -> memoService.updateMemo(USERNAME, request))
+                    .isInstanceOf(NotClubAdminException.class);
+        }
+
+        @Test
+        @DisplayName("지원자가 다른 동아리 소속이면 UnAuthorizedApplicantAccessException이 발생한다")
+        void updateMemo_Fail_UnAuthorizedAccess() {
+            // given
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            Applicant applicant = applicantInClub("other-club");
+            given(applicantRepository.findById(APPLICANT_ID)).willReturn(Optional.of(applicant));
+            UpdateMemoServiceRequest request = UpdateMemoServiceRequest.of("memo-1", USERNAME, APPLICANT_ID, CONTENT);
+
+            // when & then
+            assertThatThrownBy(() -> memoService.updateMemo(USERNAME, request))
+                    .isInstanceOf(UnAuthorizedApplicantAccessException.class);
+        }
+
+        @Test
+        @DisplayName("서류 단계가 없는 지원자면 IllegalArgumentException이 발생한다")
+        void updateMemo_Fail_NoDocumentPhase() {
+            // given
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            Applicant applicant = applicantInClub(CLUB_ID);
+            given(applicantRepository.findById(APPLICANT_ID)).willReturn(Optional.of(applicant));
+            UpdateMemoServiceRequest request = UpdateMemoServiceRequest.of("memo-1", USERNAME, APPLICANT_ID, CONTENT);
+
+            // when & then
+            assertThatThrownBy(() -> memoService.updateMemo(USERNAME, request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("메모는 서류 지원자에만 수정할 수 있습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteMemo 테스트")
+    class DeleteMemoTest {
+
+        @Test
+        @DisplayName("정상 요청이면 documentPhase.deleteMemo에 위임한다")
+        void deleteMemo_Success() {
+            // given
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+
+            DocumentPhase documentPhase = mock(DocumentPhase.class);
+            Applicant applicant = applicantInClub(CLUB_ID);
+            given(applicant.getDocumentPhase()).willReturn(documentPhase);
+            given(applicantRepository.findById(APPLICANT_ID)).willReturn(Optional.of(applicant));
+
+            DeleteMemoServiceRequest request = DeleteMemoServiceRequest.of("memo-1", APPLICANT_ID, USERNAME);
+
+            // when
+            memoService.deleteMemo(USERNAME, request);
+
+            // then
+            verify(documentPhase, times(1)).deleteMemo("memo-1");
+        }
+
+        @Test
+        @DisplayName("지원자를 찾을 수 없으면 ApplicantNotFoundException이 발생한다")
+        void deleteMemo_Fail_ApplicantNotFound() {
+            // given
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(mock(Club.class)));
+            given(applicantRepository.findById(APPLICANT_ID)).willReturn(Optional.empty());
+            DeleteMemoServiceRequest request = DeleteMemoServiceRequest.of("memo-1", APPLICANT_ID, USERNAME);
+
+            // when & then
+            assertThatThrownBy(() -> memoService.deleteMemo(USERNAME, request))
+                    .isInstanceOf(ApplicantNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("지원자가 다른 동아리 소속이면 UnAuthorizedApplicantAccessException이 발생한다")
+        void deleteMemo_Fail_UnAuthorizedAccess() {
+            // given
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            Applicant applicant = applicantInClub("other-club");
+            given(applicantRepository.findById(APPLICANT_ID)).willReturn(Optional.of(applicant));
+            DeleteMemoServiceRequest request = DeleteMemoServiceRequest.of("memo-1", APPLICANT_ID, USERNAME);
+
+            // when & then
+            assertThatThrownBy(() -> memoService.deleteMemo(USERNAME, request))
+                    .isInstanceOf(UnAuthorizedApplicantAccessException.class);
+        }
+
+        @Test
+        @DisplayName("서류 단계가 없는 지원자면 IllegalArgumentException이 발생한다")
+        void deleteMemo_Fail_NoDocumentPhase() {
+            // given
+            Club club = mock(Club.class);
+            given(club.getId()).willReturn(CLUB_ID);
+            given(clubRepository.findByAdminUsername(USERNAME)).willReturn(Optional.of(club));
+            Applicant applicant = applicantInClub(CLUB_ID);
+            given(applicantRepository.findById(APPLICANT_ID)).willReturn(Optional.of(applicant));
+            DeleteMemoServiceRequest request = DeleteMemoServiceRequest.of("memo-1", APPLICANT_ID, USERNAME);
+
+            // when & then
+            assertThatThrownBy(() -> memoService.deleteMemo(USERNAME, request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("메모는 서류 지원자에만 삭제할 수 있습니다.");
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/notification/fcm/controller/FCMTokenApiControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/notification/fcm/controller/FCMTokenApiControllerTest.java
@@ -1,0 +1,104 @@
+package org.project.ttokttok.domain.notification.fcm.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.notification.fcm.controller.dto.request.FCMTokenDeleteRequest;
+import org.project.ttokttok.domain.notification.fcm.controller.dto.request.FCMTokenSaveRequest;
+import org.project.ttokttok.domain.notification.fcm.service.FCMTokenService;
+import org.project.ttokttok.domain.notification.fcm.service.dto.FCMTokenDeleteServiceRequest;
+import org.project.ttokttok.domain.notification.fcm.service.dto.FCMTokenSaveServiceRequest;
+import org.project.ttokttok.global.annotationresolver.auth.AuthUserInfoResolver;
+import org.project.ttokttok.global.auth.jwt.service.TokenProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(FCMTokenApiController.class)
+class FCMTokenApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private FCMTokenService fcmTokenService;
+
+    @MockitoBean
+    private TokenProvider tokenProvider;
+
+    @MockitoBean
+    private AuthUserInfoResolver authUserInfoResolver;
+
+    private static final String USER_EMAIL = "test@sangmyung.kr";
+
+    private void givenAuthenticatedUser() throws Exception {
+        given(authUserInfoResolver.supportsParameter(any())).willReturn(true);
+        given(authUserInfoResolver.resolveArgument(any(), any(), any(), any())).willReturn(USER_EMAIL);
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("FCM 토큰 저장 API를 호출하면 200과 완료 메시지를 응답한다")
+    void saveToken() throws Exception {
+        givenAuthenticatedUser();
+
+        FCMTokenSaveRequest request = new FCMTokenSaveRequest("fcm-token-value", "WEB");
+
+        mockMvc.perform(post("/api/users/fcm/token")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("FCM 토큰 저장 완료"));
+
+        verify(fcmTokenService).saveOrUpdate(any(FCMTokenSaveServiceRequest.class));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("토큰이 비어있는 채로 저장을 요청하면 400을 응답한다")
+    void saveTokenBlankToken() throws Exception {
+        givenAuthenticatedUser();
+
+        FCMTokenSaveRequest request = new FCMTokenSaveRequest(" ", "WEB");
+
+        mockMvc.perform(post("/api/users/fcm/token")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("FCM 토큰 삭제 API를 호출하면 200과 완료 메시지를 응답한다")
+    void deleteToken() throws Exception {
+        givenAuthenticatedUser();
+
+        FCMTokenDeleteRequest request = new FCMTokenDeleteRequest("fcm-token-value");
+
+        mockMvc.perform(delete("/api/users/fcm/token")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("FCM 토큰 삭제 완료"));
+
+        verify(fcmTokenService).delete(any(FCMTokenDeleteServiceRequest.class));
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/temp/applicant/controller/TempApplicantControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/temp/applicant/controller/TempApplicantControllerTest.java
@@ -1,0 +1,161 @@
+package org.project.ttokttok.domain.temp.applicant.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.temp.applicant.service.TempApplicantService;
+import org.project.ttokttok.domain.temp.applicant.service.dto.request.TempApplicantSaveServiceRequest;
+import org.project.ttokttok.domain.temp.applicant.service.dto.response.TempApplicantDataServiceResponse;
+import org.project.ttokttok.global.annotationresolver.auth.AuthUserInfoResolver;
+import org.project.ttokttok.global.auth.jwt.service.TokenProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TempApplicantController.class)
+class TempApplicantControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TempApplicantService tempApplicantService;
+
+    @MockitoBean
+    private TokenProvider tokenProvider;
+
+    @MockitoBean
+    private AuthUserInfoResolver authUserInfoResolver;
+
+    private void mockAuthUser(String email) throws Exception {
+        given(authUserInfoResolver.supportsParameter(any())).willReturn(true);
+        given(authUserInfoResolver.resolveArgument(any(), any(), any(), any())).willReturn(email);
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("임시 지원서 저장 API를 호출하면 201과 저장된 아이디를 반환한다")
+    void saveTempApplicant_ShouldReturnCreated() throws Exception {
+        // given
+        mockAuthUser("test@sangmyung.kr");
+        given(tempApplicantService.saveTempApplicant(any(TempApplicantSaveServiceRequest.class)))
+                .willReturn("temp-applicant-1");
+
+        String requestJson = """
+                {
+                  "name": "홍길동",
+                  "age": 22,
+                  "major": "컴퓨터공학과",
+                  "email": "test@sangmyung.kr",
+                  "phone": "010-1234-5678",
+                  "studentStatus": "ENROLLED",
+                  "grade": "FIRST_GRADE",
+                  "gender": "MALE",
+                  "answers": [
+                    {"questionId": "q1", "value": "답변입니다"}
+                  ]
+                }
+                """;
+
+        MockMultipartFile requestPart = new MockMultipartFile(
+                "request", "", MediaType.APPLICATION_JSON_VALUE, requestJson.getBytes()
+        );
+
+        // when & then
+        mockMvc.perform(multipart("/api/user/temp-applicant/{formId}", "form-1")
+                        .file(requestPart)
+                        .with(csrf()))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.tempApplicantId").value("temp-applicant-1"));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("임시 지원서 저장 API 호출 시 파일이 함께 전달되면 정상 처리된다")
+    void saveTempApplicant_WithFile_ShouldReturnCreated() throws Exception {
+        // given
+        mockAuthUser("test@sangmyung.kr");
+        given(tempApplicantService.saveTempApplicant(any(TempApplicantSaveServiceRequest.class)))
+                .willReturn("temp-applicant-2");
+
+        String requestJson = """
+                {
+                  "name": "홍길동",
+                  "answers": []
+                }
+                """;
+
+        MockMultipartFile requestPart = new MockMultipartFile(
+                "request", "", MediaType.APPLICATION_JSON_VALUE, requestJson.getBytes()
+        );
+        MockMultipartFile filePart = new MockMultipartFile(
+                "files", "resume.pdf", "application/pdf", "content".getBytes()
+        );
+        MockMultipartFile questionIdsPart = new MockMultipartFile(
+                "questionIds", "", MediaType.APPLICATION_JSON_VALUE, "[\"q-file\"]".getBytes()
+        );
+
+        // when & then
+        mockMvc.perform(multipart("/api/user/temp-applicant/{formId}", "form-1")
+                        .file(requestPart)
+                        .file(filePart)
+                        .file(questionIdsPart)
+                        .with(csrf()))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.tempApplicantId").value("temp-applicant-2"));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("임시 지원서 조회 API를 호출하면 200과 저장된 데이터를 반환한다")
+    void getTempApplicant_ShouldReturnOk() throws Exception {
+        // given
+        mockAuthUser("test@sangmyung.kr");
+        Map<String, Object> data = new HashMap<>();
+        data.put("name", "홍길동");
+
+        given(tempApplicantService.getTempApplicantData("test@sangmyung.kr", "form-1"))
+                .willReturn(TempApplicantDataServiceResponse.builder()
+                        .hasTempData(true)
+                        .data(data)
+                        .build());
+
+        // when & then
+        mockMvc.perform(get("/api/user/temp-applicant/{formId}", "form-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.hasTempData").value(true))
+                .andExpect(jsonPath("$.data.name").value("홍길동"));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("임시 지원서가 없으면 hasTempData가 false로 반환된다")
+    void getTempApplicant_ShouldReturnHasTempDataFalse() throws Exception {
+        // given
+        mockAuthUser("test@sangmyung.kr");
+        given(tempApplicantService.getTempApplicantData("test@sangmyung.kr", "form-1"))
+                .willReturn(TempApplicantDataServiceResponse.builder()
+                        .hasTempData(false)
+                        .data(null)
+                        .build());
+
+        // when & then
+        mockMvc.perform(get("/api/user/temp-applicant/{formId}", "form-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.hasTempData").value(false));
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/temp/applicant/domain/TempApplicantTest.java
+++ b/src/test/java/org/project/ttokttok/domain/temp/applicant/domain/TempApplicantTest.java
@@ -1,0 +1,62 @@
+package org.project.ttokttok.domain.temp.applicant.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TempApplicantTest {
+
+    @Nested
+    @DisplayName("create(): 임시 지원서 생성 테스트")
+    class CreateTest {
+
+        @Test
+        @DisplayName("전달된 값으로 임시 지원서를 생성한다")
+        void create_Success() {
+            // given
+            String formId = "form-1";
+            String userEmail = "test@sangmyung.kr";
+            Map<String, Object> tempData = new HashMap<>();
+            tempData.put("name", "홍길동");
+
+            // when
+            TempApplicant tempApplicant = TempApplicant.create(formId, userEmail, tempData);
+
+            // then
+            assertThat(tempApplicant.getFormId()).isEqualTo(formId);
+            assertThat(tempApplicant.getUserEmail()).isEqualTo(userEmail);
+            assertThat(tempApplicant.getTempData()).isEqualTo(tempData);
+            assertThat(tempApplicant.getId()).isNull(); // JPA 저장 전이므로 null
+        }
+    }
+
+    @Nested
+    @DisplayName("update(): 임시 지원서 수정 테스트")
+    class UpdateTest {
+
+        @Test
+        @DisplayName("새로운 데이터로 임시 지원서 내용을 교체한다")
+        void update_Success() {
+            // given
+            Map<String, Object> originalData = new HashMap<>();
+            originalData.put("name", "홍길동");
+            TempApplicant tempApplicant = TempApplicant.create("form-1", "test@sangmyung.kr", originalData);
+
+            Map<String, Object> newData = new HashMap<>();
+            newData.put("name", "김철수");
+            newData.put("age", 23);
+
+            // when
+            tempApplicant.update(newData);
+
+            // then
+            assertThat(tempApplicant.getTempData()).isEqualTo(newData);
+            assertThat(tempApplicant.getTempData()).isNotEqualTo(originalData);
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/temp/applicant/service/TempApplicantServiceTest.java
+++ b/src/test/java/org/project/ttokttok/domain/temp/applicant/service/TempApplicantServiceTest.java
@@ -1,0 +1,181 @@
+package org.project.ttokttok.domain.temp.applicant.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.domain.applicant.domain.enums.Gender;
+import org.project.ttokttok.domain.applicant.domain.enums.Grade;
+import org.project.ttokttok.domain.applicant.domain.enums.StudentStatus;
+import org.project.ttokttok.domain.temp.applicant.controller.dto.request.TempAnswer;
+import org.project.ttokttok.domain.temp.applicant.controller.dto.request.TempApplicantSaveRequest;
+import org.project.ttokttok.domain.temp.applicant.domain.TempApplicant;
+import org.project.ttokttok.domain.temp.applicant.repository.TempApplicantRepository;
+import org.project.ttokttok.domain.temp.applicant.service.dto.request.TempApplicantSaveServiceRequest;
+import org.project.ttokttok.domain.temp.applicant.service.dto.response.TempApplicantDataServiceResponse;
+import org.project.ttokttok.infrastructure.s3.service.S3Service;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TempApplicantServiceTest {
+
+    @Mock
+    private TempApplicantRepository tempApplicantRepository;
+
+    @Mock
+    private S3Service s3Service;
+
+    @InjectMocks
+    private TempApplicantService tempApplicantService;
+
+    private TempApplicantSaveServiceRequest buildRequest(
+            String email, String formId, List<TempAnswer> answers,
+            List<String> questionIds, List<MultipartFile> files
+    ) {
+        TempApplicantSaveRequest request = new TempApplicantSaveRequest(
+                "홍길동", 22, "컴퓨터공학과", email, "010-1234-5678",
+                StudentStatus.ENROLLED, Grade.FIRST_GRADE, Gender.MALE, answers
+        );
+
+        return TempApplicantSaveServiceRequest.of(email, formId, request, questionIds, files);
+    }
+
+    @Test
+    @DisplayName("saveTempApplicant(): 기존 임시 지원서가 없으면 새로 생성한다")
+    void saveTempApplicant_CreatesNew_WhenNoExisting() {
+        // given
+        String email = "test@sangmyung.kr";
+        String formId = "form-1";
+        TempApplicantSaveServiceRequest request = buildRequest(
+                email, formId, List.of(new TempAnswer("q1", "답변")), null, null
+        );
+
+        given(tempApplicantRepository.findByUserEmailAndFormId(email, formId))
+                .willReturn(Optional.empty());
+
+        TempApplicant saved = mock(TempApplicant.class);
+        given(saved.getId()).willReturn("temp-1");
+        given(tempApplicantRepository.save(any(TempApplicant.class))).willReturn(saved);
+
+        // when
+        String result = tempApplicantService.saveTempApplicant(request);
+
+        // then
+        assertThat(result).isEqualTo("temp-1");
+        verify(tempApplicantRepository, times(1)).save(any(TempApplicant.class));
+    }
+
+    @Test
+    @DisplayName("saveTempApplicant(): 기존 임시 지원서가 있으면 업데이트한다")
+    void saveTempApplicant_UpdatesExisting_WhenPresent() {
+        // given
+        String email = "test@sangmyung.kr";
+        String formId = "form-1";
+        TempApplicantSaveServiceRequest request = buildRequest(
+                email, formId, List.of(new TempAnswer("q1", "답변")), null, null
+        );
+
+        TempApplicant existing = mock(TempApplicant.class);
+        given(existing.getId()).willReturn("temp-existing");
+        given(tempApplicantRepository.findByUserEmailAndFormId(email, formId))
+                .willReturn(Optional.of(existing));
+
+        // when
+        String result = tempApplicantService.saveTempApplicant(request);
+
+        // then
+        assertThat(result).isEqualTo("temp-existing");
+        verify(existing, times(1)).update(any(Map.class));
+        verify(tempApplicantRepository, never()).save(any(TempApplicant.class));
+    }
+
+    @Test
+    @DisplayName("saveTempApplicant(): 파일 응답이 있으면 S3에 업로드하고 답변에 포함시킨다")
+    void saveTempApplicant_UploadsFile_WhenFilesPresent() {
+        // given
+        String email = "test@sangmyung.kr";
+        String formId = "form-1";
+        MultipartFile file = new MockMultipartFile("file", "resume.pdf", "application/pdf", "content".getBytes());
+
+        TempApplicantSaveServiceRequest request = buildRequest(
+                email, formId, List.of(), List.of("q-file"), List.of(file)
+        );
+
+        given(tempApplicantRepository.findByUserEmailAndFormId(email, formId))
+                .willReturn(Optional.empty());
+        given(s3Service.uploadFile(eq(file), anyString())).willReturn("https://s3.bucket/resume.pdf");
+
+        TempApplicant saved = mock(TempApplicant.class);
+        given(saved.getId()).willReturn("temp-1");
+        given(tempApplicantRepository.save(any(TempApplicant.class))).willReturn(saved);
+
+        // when
+        tempApplicantService.saveTempApplicant(request);
+
+        // then
+        verify(s3Service, times(1)).uploadFile(file, "temp-applicants/" + email + "/");
+
+        ArgumentCaptor<TempApplicant> captor = ArgumentCaptor.forClass(TempApplicant.class);
+        verify(tempApplicantRepository).save(captor.capture());
+
+        @SuppressWarnings("unchecked")
+        List<TempAnswer> savedAnswers = (List<TempAnswer>) captor.getValue().getTempData().get("answers");
+        assertThat(savedAnswers)
+                .extracting(TempAnswer::questionId, TempAnswer::value)
+                .containsExactly(org.assertj.core.groups.Tuple.tuple("q-file", "https://s3.bucket/resume.pdf"));
+    }
+
+    @Test
+    @DisplayName("getTempApplicantData(): 임시 지원서가 존재하면 데이터를 반환한다")
+    void getTempApplicantData_WhenExists() {
+        // given
+        String email = "test@sangmyung.kr";
+        String formId = "form-1";
+        Map<String, Object> tempData = new HashMap<>();
+        tempData.put("name", "홍길동");
+
+        TempApplicant existing = mock(TempApplicant.class);
+        given(existing.getTempData()).willReturn(tempData);
+        given(tempApplicantRepository.findByUserEmailAndFormId(email, formId))
+                .willReturn(Optional.of(existing));
+
+        // when
+        TempApplicantDataServiceResponse response = tempApplicantService.getTempApplicantData(email, formId);
+
+        // then
+        assertThat(response.hasTempData()).isTrue();
+        assertThat(response.data()).isEqualTo(tempData);
+    }
+
+    @Test
+    @DisplayName("getTempApplicantData(): 임시 지원서가 없으면 hasTempData가 false이고 데이터는 null이다")
+    void getTempApplicantData_WhenNotExists() {
+        // given
+        String email = "test@sangmyung.kr";
+        String formId = "form-1";
+        given(tempApplicantRepository.findByUserEmailAndFormId(email, formId))
+                .willReturn(Optional.empty());
+
+        // when
+        TempApplicantDataServiceResponse response = tempApplicantService.getTempApplicantData(email, formId);
+
+        // then
+        assertThat(response.hasTempData()).isFalse();
+        assertThat(response.data()).isNull();
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/temp/applyform/controller/TempApplyFormControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/temp/applyform/controller/TempApplyFormControllerTest.java
@@ -1,0 +1,95 @@
+package org.project.ttokttok.domain.temp.applyform.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.temp.applyform.controller.dto.request.TempApplyFormSaveRequest;
+import org.project.ttokttok.domain.temp.applyform.service.TempApplyFormService;
+import org.project.ttokttok.global.annotationresolver.auth.AuthUserInfoResolver;
+import org.project.ttokttok.global.auth.jwt.service.TokenProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TempApplyFormController.class)
+class TempApplyFormControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TempApplyFormService tempApplyFormService;
+
+    @MockitoBean
+    private TokenProvider tokenProvider;
+
+    @MockitoBean
+    private AuthUserInfoResolver authUserInfoResolver;
+
+    private void mockAuthUser(String email) throws Exception {
+        given(authUserInfoResolver.supportsParameter(any())).willReturn(true);
+        given(authUserInfoResolver.resolveArgument(any(), any(), any(), any())).willReturn(email);
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("임시 지원폼 저장 API를 호출하면 201과 저장된 아이디를 반환한다")
+    void saveTempApplyForm_ShouldReturnCreated() throws Exception {
+        // given
+        mockAuthUser("admin@sangmyung.kr");
+        given(tempApplyFormService.saveTempApplyForm(any(TempApplyFormSaveRequest.class)))
+                .willReturn("temp-form-1");
+
+        String requestBody = """
+                {
+                  "clubId": "club-1",
+                  "title": "임시 지원폼",
+                  "subTitle": "부제목",
+                  "applyStartDate": "2026-07-01",
+                  "applyEndDate": "2026-07-31",
+                  "hasInterview": true,
+                  "maxApplyCount": 3,
+                  "grades": ["FIRST_GRADE"],
+                  "formJson": []
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(post("/api/admin/temp-applyform")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.tempApplyFormId").value("temp-form-1"));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("임시 지원폼 저장 시 동아리 ID가 비어있으면 400을 반환한다")
+    void saveTempApplyForm_ShouldReturnBadRequest_WhenClubIdBlank() throws Exception {
+        // given
+        mockAuthUser("admin@sangmyung.kr");
+
+        String requestBody = """
+                {
+                  "clubId": ""
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(post("/api/admin/temp-applyform")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/temp/applyform/domain/TempApplyFormTest.java
+++ b/src/test/java/org/project/ttokttok/domain/temp/applyform/domain/TempApplyFormTest.java
@@ -1,0 +1,132 @@
+package org.project.ttokttok.domain.temp.applyform.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.applyform.domain.enums.ApplicableGrade;
+import org.project.ttokttok.domain.applyform.domain.enums.QuestionType;
+import org.project.ttokttok.domain.applyform.domain.json.Question;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TempApplyFormTest {
+
+    @Nested
+    @DisplayName("create(): 임시 지원폼 생성 테스트")
+    class CreateTest {
+
+        @Test
+        @DisplayName("전달된 값으로 임시 지원폼을 생성한다")
+        void create_Success() {
+            // given
+            List<Question> questions = List.of(
+                    new Question("q1", "이름", null, QuestionType.SHORT_ANSWER, true, null)
+            );
+
+            // when
+            TempApplyForm tempApplyForm = TempApplyForm.create(
+                    "club-1", "임시 지원폼", "부제목",
+                    LocalDate.of(2026, 7, 1), LocalDate.of(2026, 7, 31),
+                    true, LocalDate.of(2026, 8, 1), LocalDate.of(2026, 8, 5),
+                    3, Set.of(ApplicableGrade.FIRST_GRADE), questions
+            );
+
+            // then
+            assertThat(tempApplyForm.getClubId()).isEqualTo("club-1");
+            assertThat(tempApplyForm.getTitle()).isEqualTo("임시 지원폼");
+            assertThat(tempApplyForm.getSubTitle()).isEqualTo("부제목");
+            assertThat(tempApplyForm.getApplyStartDate()).isEqualTo(LocalDate.of(2026, 7, 1));
+            assertThat(tempApplyForm.getApplyEndDate()).isEqualTo(LocalDate.of(2026, 7, 31));
+            assertThat(tempApplyForm.isHasInterview()).isTrue();
+            assertThat(tempApplyForm.getMaxApplyCount()).isEqualTo(3);
+            assertThat(tempApplyForm.getGrades()).containsExactly(ApplicableGrade.FIRST_GRADE);
+            assertThat(tempApplyForm.getFormJson()).isEqualTo(questions);
+        }
+
+        @Test
+        @DisplayName("학년과 질문 목록이 null이면 빈 컬렉션으로 생성된다")
+        void create_NullCollections_DefaultsToEmpty() {
+            // when
+            TempApplyForm tempApplyForm = TempApplyForm.create(
+                    "club-1", null, null,
+                    null, null,
+                    false, null, null,
+                    null, null, null
+            );
+
+            // then
+            assertThat(tempApplyForm.getGrades()).isEmpty();
+            assertThat(tempApplyForm.getFormJson()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("update(): 임시 지원폼 수정 테스트")
+    class UpdateTest {
+
+        @Test
+        @DisplayName("전달된 값으로 임시 지원폼 내용을 모두 교체한다")
+        void update_Success() {
+            // given
+            TempApplyForm tempApplyForm = TempApplyForm.create(
+                    "club-1", "기존 제목", "기존 부제목",
+                    LocalDate.of(2026, 7, 1), LocalDate.of(2026, 7, 31),
+                    false, null, null,
+                    1, Set.of(ApplicableGrade.FIRST_GRADE), List.of()
+            );
+
+            List<Question> newQuestions = List.of(
+                    new Question("q2", "전공", null, QuestionType.SHORT_ANSWER, false, null)
+            );
+
+            // when
+            tempApplyForm.update(
+                    "새로운 제목", "새로운 부제목",
+                    LocalDate.of(2026, 9, 1), LocalDate.of(2026, 9, 30),
+                    true, LocalDate.of(2026, 10, 1), LocalDate.of(2026, 10, 5),
+                    5, Set.of(ApplicableGrade.THIRD_GRADE), newQuestions
+            );
+
+            // then
+            assertThat(tempApplyForm.getTitle()).isEqualTo("새로운 제목");
+            assertThat(tempApplyForm.getSubTitle()).isEqualTo("새로운 부제목");
+            assertThat(tempApplyForm.getApplyStartDate()).isEqualTo(LocalDate.of(2026, 9, 1));
+            assertThat(tempApplyForm.getApplyEndDate()).isEqualTo(LocalDate.of(2026, 9, 30));
+            assertThat(tempApplyForm.isHasInterview()).isTrue();
+            assertThat(tempApplyForm.getInterviewStartDate()).isEqualTo(LocalDate.of(2026, 10, 1));
+            assertThat(tempApplyForm.getMaxApplyCount()).isEqualTo(5);
+            assertThat(tempApplyForm.getGrades()).containsExactly(ApplicableGrade.THIRD_GRADE);
+            assertThat(tempApplyForm.getFormJson()).isEqualTo(newQuestions);
+        }
+
+        @Test
+        @DisplayName("학년과 질문 목록에 null을 전달하면 빈 컬렉션으로 초기화된다")
+        void update_NullCollections_ResetsToEmpty() {
+            // given
+            TempApplyForm tempApplyForm = TempApplyForm.create(
+                    "club-1", "기존 제목", "기존 부제목",
+                    LocalDate.of(2026, 7, 1), LocalDate.of(2026, 7, 31),
+                    false, null, null,
+                    1, Set.of(ApplicableGrade.FIRST_GRADE), List.of(
+                            new Question("q1", "이름", null, QuestionType.SHORT_ANSWER, true, null)
+                    )
+            );
+
+            // when
+            tempApplyForm.update(
+                    "새로운 제목", null,
+                    null, null,
+                    false, null, null,
+                    null, null, null
+            );
+
+            // then
+            assertThat(tempApplyForm.getGrades()).isEmpty();
+            assertThat(tempApplyForm.getFormJson()).isEmpty();
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/temp/applyform/service/TempApplyFormServiceTest.java
+++ b/src/test/java/org/project/ttokttok/domain/temp/applyform/service/TempApplyFormServiceTest.java
@@ -1,0 +1,124 @@
+package org.project.ttokttok.domain.temp.applyform.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.domain.applyform.domain.enums.ApplicableGrade;
+import org.project.ttokttok.domain.applyform.domain.enums.QuestionType;
+import org.project.ttokttok.domain.applyform.domain.json.Question;
+import org.project.ttokttok.domain.temp.applyform.controller.dto.request.TempApplyFormSaveRequest;
+import org.project.ttokttok.domain.temp.applyform.domain.TempApplyForm;
+import org.project.ttokttok.domain.temp.applyform.repository.TempApplyFormRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TempApplyFormServiceTest {
+
+    @Mock
+    private TempApplyFormRepository tempApplyFormRepository;
+
+    @InjectMocks
+    private TempApplyFormService tempApplyFormService;
+
+    private TempApplyFormSaveRequest buildRequest(String clubId) {
+        return new TempApplyFormSaveRequest(
+                clubId,
+                "임시 지원폼 제목",
+                "부제목",
+                LocalDate.of(2026, 7, 1),
+                LocalDate.of(2026, 7, 31),
+                true,
+                LocalDate.of(2026, 8, 1),
+                LocalDate.of(2026, 8, 5),
+                3,
+                Set.of(ApplicableGrade.FIRST_GRADE),
+                List.of(new Question("q1", "이름", null, QuestionType.SHORT_ANSWER, true, null))
+        );
+    }
+
+    @Test
+    @DisplayName("saveTempApplyForm(): 기존 임시 지원폼이 없으면 새로 생성한다")
+    void saveTempApplyForm_CreatesNew_WhenNoExisting() {
+        // given
+        String clubId = "club-1";
+        TempApplyFormSaveRequest request = buildRequest(clubId);
+
+        given(tempApplyFormRepository.findByClubId(clubId)).willReturn(Optional.empty());
+
+        TempApplyForm saved = mock(TempApplyForm.class);
+        given(saved.getId()).willReturn("temp-form-1");
+        given(tempApplyFormRepository.save(any(TempApplyForm.class))).willReturn(saved);
+
+        // when
+        String result = tempApplyFormService.saveTempApplyForm(request);
+
+        // then
+        assertThat(result).isEqualTo("temp-form-1");
+
+        ArgumentCaptor<TempApplyForm> captor = ArgumentCaptor.forClass(TempApplyForm.class);
+        verify(tempApplyFormRepository, times(1)).save(captor.capture());
+        assertThat(captor.getValue().getClubId()).isEqualTo(clubId);
+        assertThat(captor.getValue().getTitle()).isEqualTo("임시 지원폼 제목");
+    }
+
+    @Test
+    @DisplayName("saveTempApplyForm(): 기존 임시 지원폼이 있으면 업데이트한다")
+    void saveTempApplyForm_UpdatesExisting_WhenPresent() {
+        // given
+        String clubId = "club-1";
+        TempApplyFormSaveRequest request = buildRequest(clubId);
+
+        TempApplyForm existing = mock(TempApplyForm.class);
+        given(existing.getId()).willReturn("temp-form-existing");
+        given(tempApplyFormRepository.findByClubId(clubId)).willReturn(Optional.of(existing));
+
+        // when
+        String result = tempApplyFormService.saveTempApplyForm(request);
+
+        // then
+        assertThat(result).isEqualTo("temp-form-existing");
+        verify(existing, times(1)).update(
+                request.title(), request.subTitle(), request.applyStartDate(), request.applyEndDate(),
+                true, request.interviewStartDate(), request.interviewEndDate(),
+                request.maxApplyCount(), request.grades(), request.formJson()
+        );
+        verify(tempApplyFormRepository, never()).save(any(TempApplyForm.class));
+    }
+
+    @Test
+    @DisplayName("saveTempApplyForm(): hasInterview이 null이면 false로 저장된다")
+    void saveTempApplyForm_NullHasInterview_DefaultsToFalse() {
+        // given
+        String clubId = "club-1";
+        TempApplyFormSaveRequest request = new TempApplyFormSaveRequest(
+                clubId, null, null, null, null,
+                null, null, null, null, null, null
+        );
+
+        given(tempApplyFormRepository.findByClubId(clubId)).willReturn(Optional.empty());
+        TempApplyForm saved = mock(TempApplyForm.class);
+        given(saved.getId()).willReturn("temp-form-2");
+        given(tempApplyFormRepository.save(any(TempApplyForm.class))).willReturn(saved);
+
+        // when
+        tempApplyFormService.saveTempApplyForm(request);
+
+        // then
+        ArgumentCaptor<TempApplyForm> captor = ArgumentCaptor.forClass(TempApplyForm.class);
+        verify(tempApplyFormRepository).save(captor.capture());
+        assertThat(captor.getValue().isHasInterview()).isFalse();
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/user/controller/UserAuthControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/user/controller/UserAuthControllerTest.java
@@ -1,0 +1,188 @@
+package org.project.ttokttok.domain.user.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.user.service.UserAuthService;
+import org.project.ttokttok.domain.user.service.dto.request.LoginServiceRequest;
+import org.project.ttokttok.domain.user.service.dto.request.ResetPasswordServiceRequest;
+import org.project.ttokttok.domain.user.service.dto.request.SignupServiceRequest;
+import org.project.ttokttok.domain.user.service.dto.response.LoginServiceResponse;
+import org.project.ttokttok.domain.user.service.dto.response.UserReissueServiceResponse;
+import org.project.ttokttok.domain.user.service.dto.response.UserServiceResponse;
+import org.project.ttokttok.global.annotationresolver.auth.AuthUserInfoResolver;
+import org.project.ttokttok.global.auth.jwt.service.TokenProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserAuthController.class)
+class UserAuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserAuthService userAuthService;
+
+    @MockitoBean
+    private TokenProvider tokenProvider;
+
+    @MockitoBean
+    private AuthUserInfoResolver authUserInfoResolver;
+
+    private static final String EMAIL = "202021000@sangmyung.kr";
+
+    @Test
+    @WithMockUser
+    @DisplayName("이메일 인증코드 발송 API를 호출하면 200을 반환한다")
+    void sendVerificationCode() throws Exception {
+        doNothing().when(userAuthService).sendVerificationCode(any());
+
+        mockMvc.perform(post("/api/user/auth/send-verification").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"" + EMAIL + "\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("인증코드가 발송되었습니다."));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("이메일 인증코드 검증 API를 호출하면 200을 반환한다")
+    void verifyEmail() throws Exception {
+        given(userAuthService.verifyEmail(any(), any())).willReturn(true);
+
+        mockMvc.perform(post("/api/user/auth/verify-email").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"" + EMAIL + "\",\"code\":\"123456\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("이메일 인증이 완료되었습니다."));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("회원가입 API를 호출하면 200과 사용자 정보를 반환한다")
+    void signup() throws Exception {
+        UserServiceResponse serviceResponse = UserServiceResponse.builder()
+                .id("user-1").email(EMAIL).name("홍길동")
+                .isEmailVerified(true).termsAgreed(true).build();
+        given(userAuthService.signup(any(SignupServiceRequest.class))).willReturn(serviceResponse);
+
+        String body = "{\"email\":\"" + EMAIL + "\",\"verificationCode\":\"123456\","
+                + "\"password\":\"Password123!\",\"passwordConfirm\":\"Password123!\","
+                + "\"name\":\"홍길동\",\"termsAgreed\":true}";
+
+        mockMvc.perform(post("/api/user/auth/signup").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("회원가입이 완료되었습니다."))
+                .andExpect(jsonPath("$.data.email").value(EMAIL))
+                .andExpect(jsonPath("$.data.name").value("홍길동"));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("비밀번호가 약하면 회원가입은 400을 반환한다")
+    void signup_withWeakPassword_returnsBadRequest() throws Exception {
+        String body = "{\"email\":\"" + EMAIL + "\",\"verificationCode\":\"123456\","
+                + "\"password\":\"weak\",\"passwordConfirm\":\"weak\","
+                + "\"name\":\"홍길동\",\"termsAgreed\":true}";
+
+        mockMvc.perform(post("/api/user/auth/signup").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("로그인 API를 호출하면 200과 토큰/사용자 정보를 반환한다")
+    void login() throws Exception {
+        UserServiceResponse user = UserServiceResponse.builder()
+                .id("user-1").email(EMAIL).name("홍길동")
+                .isEmailVerified(true).termsAgreed(true).build();
+        LoginServiceResponse serviceResponse = LoginServiceResponse.builder()
+                .accessToken("access-token").refreshToken("refresh-token").user(user).build();
+        given(userAuthService.login(any(LoginServiceRequest.class))).willReturn(serviceResponse);
+
+        String body = "{\"email\":\"" + EMAIL + "\",\"password\":\"Password123!\",\"rememberMe\":true}";
+
+        mockMvc.perform(post("/api/user/auth/login").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("로그인 성공"))
+                .andExpect(jsonPath("$.data.accessToken").value("access-token"))
+                .andExpect(jsonPath("$.data.refreshToken").value("refresh-token"))
+                .andExpect(jsonPath("$.data.user.email").value(EMAIL));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("토큰 재발급 API를 호출하면 200과 새 토큰을 반환한다")
+    void reIssue() throws Exception {
+        given(userAuthService.reissue(any()))
+                .willReturn(new UserReissueServiceResponse("new-access", "new-refresh", 3600L));
+
+        mockMvc.perform(post("/api/user/auth/re-issue").with(csrf())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer some-refresh-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("토큰 재발급 성공"))
+                .andExpect(jsonPath("$.data.accessToken").value("new-access"))
+                .andExpect(jsonPath("$.data.refreshToken").value("new-refresh"));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("비밀번호 재설정 코드 발송 API를 호출하면 200을 반환한다")
+    void sendPasswordResetCode() throws Exception {
+        doNothing().when(userAuthService).sendPasswordResetCode(any());
+
+        mockMvc.perform(post("/api/user/auth/send-reset-code").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"email\":\"" + EMAIL + "\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("비밀번호 재설정 코드가 발송되었습니다."));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("비밀번호 재설정 API를 호출하면 200을 반환한다")
+    void resetPassword() throws Exception {
+        doNothing().when(userAuthService).resetPassword(any(ResetPasswordServiceRequest.class));
+
+        String body = "{\"email\":\"" + EMAIL + "\",\"verificationCode\":\"123456\","
+                + "\"newPassword\":\"Password123!\",\"newPasswordConfirm\":\"Password123!\"}";
+
+        mockMvc.perform(post("/api/user/auth/reset-password").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("비밀번호가 재설정되었습니다."));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("로그아웃 API를 호출하면 200을 반환한다")
+    void logout() throws Exception {
+        doNothing().when(userAuthService).logout(any(), any());
+
+        mockMvc.perform(post("/api/user/auth/logout").with(csrf())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer some-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("로그아웃이 완료되었습니다."));
+    }
+}

--- a/src/test/java/org/project/ttokttok/global/excel/ExcelServiceTest.java
+++ b/src/test/java/org/project/ttokttok/global/excel/ExcelServiceTest.java
@@ -1,0 +1,86 @@
+package org.project.ttokttok.global.excel;
+
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.applicant.domain.enums.Grade;
+import org.project.ttokttok.domain.clubMember.domain.MemberRole;
+import org.project.ttokttok.domain.clubMember.service.dto.response.ClubMemberInExcelResponse;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ExcelService - 부원 목록 엑셀 생성")
+class ExcelServiceTest {
+
+    private final ExcelService excelService = new ExcelService();
+
+    @Test
+    @DisplayName("부원 목록으로 유효한 XLSX 바이트 배열을 생성한다")
+    void createMemberExcel_returnsValidXlsxBytes() throws IOException {
+        // given
+        List<ClubMemberInExcelResponse> members = List.of(
+                new ClubMemberInExcelResponse(Grade.FIRST_GRADE, "홍길동", "컴퓨터과학과", MemberRole.PRESIDENT),
+                new ClubMemberInExcelResponse(Grade.THIRD_GRADE, "김철수", "소프트웨어학과", MemberRole.MEMBER)
+        );
+
+        // when
+        byte[] result = excelService.createMemberExcel("떡떡 동아리", members);
+
+        // then
+        assertThat(result).isNotEmpty();
+        // XLSX(zip) 시그니처: 'P'(0x50), 'K'(0x4B)
+        assertThat(result[0]).isEqualTo((byte) 0x50);
+        assertThat(result[1]).isEqualTo((byte) 0x4B);
+    }
+
+    @Test
+    @DisplayName("생성된 엑셀의 시트명/헤더/데이터 행이 올바르게 채워진다")
+    void createMemberExcel_hasCorrectSheetHeaderAndRows() throws IOException {
+        // given
+        List<ClubMemberInExcelResponse> members = List.of(
+                new ClubMemberInExcelResponse(Grade.SECOND_GRADE, "이영희", "경영학과", MemberRole.EXECUTIVE)
+        );
+
+        // when
+        byte[] result = excelService.createMemberExcel("테스트동아리", members);
+
+        // then
+        try (Workbook workbook = WorkbookFactory.create(new ByteArrayInputStream(result))) {
+            Sheet sheet = workbook.getSheetAt(0);
+            assertThat(sheet.getSheetName()).isEqualTo("테스트동아리 부원 목록");
+
+            Row header = sheet.getRow(0);
+            assertThat(header.getCell(0).getStringCellValue()).isEqualTo("학년");
+            assertThat(header.getCell(1).getStringCellValue()).isEqualTo("이름");
+            assertThat(header.getCell(2).getStringCellValue()).isEqualTo("전공");
+            assertThat(header.getCell(3).getStringCellValue()).isEqualTo("역할");
+
+            Row dataRow = sheet.getRow(1);
+            assertThat(dataRow.getCell(0).getStringCellValue()).isEqualTo("2");
+            assertThat(dataRow.getCell(1).getStringCellValue()).isEqualTo("이영희");
+            assertThat(dataRow.getCell(2).getStringCellValue()).isEqualTo("경영학과");
+            assertThat(dataRow.getCell(3).getStringCellValue()).isEqualTo("임원진");
+        }
+    }
+
+    @Test
+    @DisplayName("부원이 없어도 헤더만 있는 엑셀을 생성한다")
+    void createMemberExcel_withEmptyMembers_createsHeaderOnly() throws IOException {
+        // when
+        byte[] result = excelService.createMemberExcel("빈동아리", List.of());
+
+        // then
+        try (Workbook workbook = WorkbookFactory.create(new ByteArrayInputStream(result))) {
+            Sheet sheet = workbook.getSheetAt(0);
+            assertThat(sheet.getRow(0)).isNotNull();
+            assertThat(sheet.getRow(1)).isNull();
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/global/util/cookie/CookieUtilTest.java
+++ b/src/test/java/org/project/ttokttok/global/util/cookie/CookieUtilTest.java
@@ -1,0 +1,117 @@
+package org.project.ttokttok.global.util.cookie;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseCookie;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("CookieUtil - 쿠키 생성/만료")
+class CookieUtilTest {
+
+    private final CookieUtil cookieUtil = createCookieUtil("Lax", false);
+
+    private CookieUtil createCookieUtil(String sameSite, boolean secure) {
+        CookieUtil util = new CookieUtil();
+        ReflectionTestUtils.setField(util, "cookieSameSite", sameSite);
+        ReflectionTestUtils.setField(util, "cookieSecure", secure);
+        ReflectionTestUtils.setField(util, "activeProfile", "test");
+        return util;
+    }
+
+    @AfterEach
+    void clearProfileProperty() {
+        System.clearProperty("spring.profiles.active");
+    }
+
+    @Test
+    @DisplayName("createResponseCookie는 httpOnly/path/maxAge가 설정된 쿠키를 생성한다")
+    void createResponseCookie() {
+        ResponseCookie cookie = cookieUtil.createResponseCookie("access", "token-value", Duration.ofMinutes(30));
+
+        assertThat(cookie.getName()).isEqualTo("access");
+        assertThat(cookie.getValue()).isEqualTo("token-value");
+        assertThat(cookie.isHttpOnly()).isTrue();
+        assertThat(cookie.getPath()).isEqualTo("/");
+        assertThat(cookie.getMaxAge()).isEqualTo(Duration.ofMinutes(30));
+        assertThat(cookie.getSameSite()).isEqualTo("Lax");
+    }
+
+    @Test
+    @DisplayName("expireResponseCookie는 값이 비어있고 maxAge가 0인 쿠키를 생성한다")
+    void expireResponseCookie() {
+        ResponseCookie cookie = cookieUtil.expireResponseCookie("access");
+
+        assertThat(cookie.getValue()).isEmpty();
+        assertThat(cookie.getMaxAge()).isEqualTo(Duration.ZERO);
+        assertThat(cookie.isHttpOnly()).isTrue();
+    }
+
+    @Test
+    @DisplayName("expireBothTokenCookies는 액세스/리프레시 쿠키 2개를 만료시킨다")
+    void expireBothTokenCookies() {
+        ResponseCookie[] cookies = cookieUtil.expireBothTokenCookies();
+
+        assertThat(cookies).hasSize(2);
+        assertThat(cookies[0].getMaxAge()).isEqualTo(Duration.ZERO);
+        assertThat(cookies[1].getMaxAge()).isEqualTo(Duration.ZERO);
+    }
+
+    @Test
+    @DisplayName("expireUserTokenCookies는 사용자용 쿠키 2개를 만료시킨다")
+    void expireUserTokenCookies() {
+        ResponseCookie[] cookies = cookieUtil.expireUserTokenCookies();
+
+        assertThat(cookies).hasSize(2);
+        assertThat(cookies[0].getValue()).isEmpty();
+        assertThat(cookies[1].getValue()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("secure=true로 설정하면 생성 쿠키의 secure 플래그가 활성화된다")
+    void createResponseCookie_withSecure() {
+        CookieUtil secureUtil = createCookieUtil("None", true);
+
+        ResponseCookie cookie = secureUtil.createResponseCookie("access", "v", Duration.ofMinutes(1));
+
+        assertThat(cookie.isSecure()).isTrue();
+        assertThat(cookie.getSameSite()).isEqualTo("None");
+    }
+
+    @Test
+    @DisplayName("static 메서드는 prod 프로필에서 secure=true, SameSite=None을 사용한다")
+    void createResponseCookieStatic_prod() {
+        System.setProperty("spring.profiles.active", "prod");
+
+        ResponseCookie cookie = CookieUtil.createResponseCookieStatic("access", "v", Duration.ofMinutes(1));
+
+        assertThat(cookie.isSecure()).isTrue();
+        assertThat(cookie.getSameSite()).isEqualTo("None");
+    }
+
+    @Test
+    @DisplayName("static 메서드는 dev 프로필에서 secure=false, SameSite=Lax를 사용한다")
+    void createResponseCookieStatic_dev() {
+        System.setProperty("spring.profiles.active", "dev");
+
+        ResponseCookie cookie = CookieUtil.createResponseCookieStatic("access", "v", Duration.ofMinutes(1));
+
+        assertThat(cookie.isSecure()).isFalse();
+        assertThat(cookie.getSameSite()).isEqualTo("Lax");
+    }
+
+    @Test
+    @DisplayName("static expire 메서드는 만료 쿠키를 생성한다")
+    void expireResponseCookieStatic() {
+        System.setProperty("spring.profiles.active", "dev");
+
+        ResponseCookie cookie = CookieUtil.expireResponseCookieStatic("access");
+
+        assertThat(cookie.getValue()).isEmpty();
+        assertThat(cookie.getMaxAge()).isEqualTo(Duration.ZERO);
+    }
+}

--- a/src/test/java/org/project/ttokttok/infrastructure/email/service/EmailServiceBehaviorTest.java
+++ b/src/test/java/org/project/ttokttok/infrastructure/email/service/EmailServiceBehaviorTest.java
@@ -1,0 +1,130 @@
+package org.project.ttokttok.infrastructure.email.service;
+
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.domain.applicant.controller.dto.request.MailFormatRequest;
+import org.project.ttokttok.infrastructure.email.dto.EmailRequest;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EmailService - 이메일 발송 동작")
+class EmailServiceBehaviorTest {
+
+    @Mock
+    private JavaMailSender mailSender;
+
+    @InjectMocks
+    private EmailService emailService;
+
+    @BeforeEach
+    void setFields() {
+        ReflectionTestUtils.setField(emailService, "fromAddress", "noreply@sangmyung.kr");
+        ReflectionTestUtils.setField(emailService, "fromName", "TtokTtok");
+        ReflectionTestUtils.setField(emailService, "replyTo", "reply@sangmyung.kr");
+    }
+
+    private MimeMessage emptyMimeMessage() {
+        return new MimeMessage((jakarta.mail.Session) null);
+    }
+
+    @Test
+    @DisplayName("sendEmail은 MimeMessage를 구성해 메일을 발송한다")
+    void sendEmail_success() {
+        given(mailSender.createMimeMessage()).willReturn(emptyMimeMessage());
+        EmailRequest request = EmailRequest.createVerificationEmail("user@sangmyung.kr", "123456");
+
+        emailService.sendEmail(request);
+
+        verify(mailSender).send(org.mockito.ArgumentMatchers.any(MimeMessage.class));
+    }
+
+    @Test
+    @DisplayName("메일 발송 중 MailException이 발생하면 RuntimeException으로 감싼다")
+    void sendEmail_whenMailFails_throwsRuntime() {
+        given(mailSender.createMimeMessage()).willReturn(emptyMimeMessage());
+        doThrow(new MailSendException("발송 실패")).when(mailSender)
+                .send(org.mockito.ArgumentMatchers.any(MimeMessage.class));
+        EmailRequest request = EmailRequest.createVerificationEmail("user@sangmyung.kr", "123456");
+
+        assertThatThrownBy(() -> emailService.sendEmail(request))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("이메일 발송");
+    }
+
+    @Test
+    @DisplayName("generateVerificationCode는 6자리 숫자 코드를 생성한다")
+    void generateVerificationCode() {
+        String code = emailService.generateVerificationCode();
+
+        assertThat(code).hasSize(6).containsPattern("\\d{6}");
+    }
+
+    @Test
+    @DisplayName("isValidSangmyungEmail은 상명대 이메일만 true를 반환한다")
+    void isValidSangmyungEmail() {
+        assertThat(emailService.isValidSangmyungEmail("a@sangmyung.kr")).isTrue();
+        assertThat(emailService.isValidSangmyungEmail("a@gmail.com")).isFalse();
+        assertThat(emailService.isValidSangmyungEmail(null)).isFalse();
+        assertThat(emailService.isValidSangmyungEmail("  ")).isFalse();
+    }
+
+    @Test
+    @DisplayName("sendVerificationCode는 상명대 이메일이 아니면 예외를 던진다")
+    void sendVerificationCode_invalidEmail() {
+        assertThatThrownBy(() -> emailService.sendVerificationCode("a@gmail.com"))
+                .isInstanceOf(IllegalArgumentException.class);
+        verify(mailSender, never()).send(org.mockito.ArgumentMatchers.any(MimeMessage.class));
+    }
+
+    @Test
+    @DisplayName("sendVerificationCode는 유효한 이메일에 인증코드를 발송하고 코드를 반환한다")
+    void sendVerificationCode_success() {
+        given(mailSender.createMimeMessage()).willReturn(emptyMimeMessage());
+
+        String code = emailService.sendVerificationCode("user@sangmyung.kr");
+
+        assertThat(code).hasSize(6);
+        verify(mailSender).send(org.mockito.ArgumentMatchers.any(MimeMessage.class));
+    }
+
+    @Test
+    @DisplayName("sendPasswordResetCode는 재설정 코드를 발송하고 코드를 반환한다")
+    void sendPasswordResetCode_success() {
+        given(mailSender.createMimeMessage()).willReturn(emptyMimeMessage());
+
+        String code = emailService.sendPasswordResetCode("user@sangmyung.kr");
+
+        assertThat(code).hasSize(6);
+        verify(mailSender).send(org.mockito.ArgumentMatchers.any(MimeMessage.class));
+    }
+
+    @Test
+    @DisplayName("sendResultMail은 유효하지 않은 이메일은 건너뛰고 유효한 이메일에만 발송한다")
+    void sendResultMail_skipsInvalidEmails() {
+        given(mailSender.createMimeMessage()).willReturn(emptyMimeMessage());
+        MailFormatRequest request = new MailFormatRequest("합격", "축하합니다");
+
+        emailService.sendResultMail(List.of("valid@sangmyung.kr", "invalid-email", "another@gmail.com"), request);
+
+        // 유효한 이메일 2건에 대해서만 발송 시도 (invalid-email 제외)
+        verify(mailSender, atLeastOnce()).send(org.mockito.ArgumentMatchers.any(MimeMessage.class));
+    }
+}

--- a/src/test/java/org/project/ttokttok/infrastructure/health/HealthCheckControllerTest.java
+++ b/src/test/java/org/project/ttokttok/infrastructure/health/HealthCheckControllerTest.java
@@ -1,0 +1,37 @@
+package org.project.ttokttok.infrastructure.health;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.global.annotationresolver.auth.AuthUserInfoResolver;
+import org.project.ttokttok.global.auth.jwt.service.TokenProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(HealthCheckController.class)
+class HealthCheckControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TokenProvider tokenProvider;
+
+    @MockitoBean
+    private AuthUserInfoResolver authUserInfoResolver;
+
+    @Test
+    @WithMockUser
+    @DisplayName("헬스 체크 API를 호출하면 200과 status=Healthy를 반환한다")
+    void healthCheck_returnsHealthy() throws Exception {
+        mockMvc.perform(get("/health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("Healthy"));
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용
- **Jacoco 도입 및 80% 라인 커버리지 하드 게이트 적용** (`check.dependsOn jacocoTestCoverageVerification`, minimum 0.80)
  - 생성 QueryDSL(`Q*`)/DTO/`docs`/`config`/`enums`/`exception` 등은 커버리지 산정에서 제외
- **테스트 0개였던 도메인 백필**: `clubMember`, `memo` (service / controller / domain / repository)
- **미테스트 서비스 단위 테스트 추가**: ApplicantAdmin·ApplicantUser, ApplyFormUser, ClubMember, ClubBoardUser, ClubAdmin, ClubUser(list/popular/search), Memo, TempApplicant, TempApplyForm, Excel, Email
- **미테스트 컨트롤러 `@WebMvcTest` 추가**: ApplicantAdmin, ApplyForm Admin/User, ClubUser, ClubMember, ClubBoard Admin/User, Memo, FCMToken, TempApplicant/ApplyForm, UserAuth, HealthCheck
- **리포지토리 테스트 추가**: `ClubMemberCustomRepositoryImpl`, `ClubCustomRepositoryImpl`(QueryDSL 쿼리 실행 커버리지)
- **엔티티/유틸 테스트 추가**: Applicant/DocumentPhase/InterviewPhase, ApplyForm, Club, ClubBoard, Favorite, PopularityCalculator, Memo, Temp*, CookieUtil 등

### 📊 결과
- 라인 커버리지 **31.1% → 80.8%** (2134/2640), BRANCH 62.6%, METHOD 86.3%
- 테스트 수 **376 → 631개, 전량 통과** (`bash maintenance/verify.sh` green)
- Swagger 문서 변경 없음 / **DB 변경 없음**(Flyway 마이그레이션 없음) / **production 로직 변경 없음**(테스트 전용)

> 참고: 검증 과정에서 `ClubMemberService.addMember`의 회장/부회장 중복검증 분기가 도달 불가(dead code)임을 확인했습니다. 이번 PR 범위(테스트 추가)에서는 production 코드를 수정하지 않았고, 별도 이슈로 다루는 것을 제안합니다.

---

## 🔍 관련 이슈
- 해결한 이슈 번호: #322

---

## ✅ 체크리스트
- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요? (`verify.sh` green + 80% 커버리지 게이트 통과)
- [x] 라벨을 붙혔나요? (`Test - 테스트`)
- [x] 팀 코드 컨벤션 준수하였나요? (Mockito 단위 / `@WebMvcTest` / `RepositoryTestSupport` 패턴)

---

## 💬 기타 참고 사항
- 커버리지 게이트는 `check`(=`build`) 단계에서 강제됩니다. 이후 80% 미만 시 로컬 빌드가 실패합니다. (CI는 `-x test`로 스킵되어 영향 없음)
- 기존 `ClubAdminServiceTest`는 전체 주석 처리 상태였어 신규 `ClubAdminServiceBehaviorTest`로 대체 커버했습니다.
- `ApplyFormAdminApiControllerTest`는 `JsonNullable` 역직렬화를 위해 `@Import(JsonConfig.class)`를 적용했습니다.