### PR TITLE
applicant 전형 처리(isDocument) 분기 제거 및 phase 다형화 리팩토링 (refactor/#324 -> develop)

### DIFF
--- a/src/main/java/org/project/ttokttok/domain/applicant/controller/enums/Kind.java
+++ b/src/main/java/org/project/ttokttok/domain/applicant/controller/enums/Kind.java
@@ -2,6 +2,7 @@ package org.project.ttokttok.domain.applicant.controller.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.project.ttokttok.domain.applicant.domain.enums.ApplicantPhase;
 import org.project.ttokttok.domain.applicant.exception.InvalidKindException;
 
 @Getter
@@ -13,10 +14,10 @@ public enum Kind {
 
     final String value;
 
-    public static boolean isDocument(String value) {
+    public static ApplicantPhase toApplicantPhase(String value) {
         return switch (value.toUpperCase()) {
-            case "DOCUMENT" -> true;
-            case "INTERVIEW" -> false;
+            case "DOCUMENT" -> ApplicantPhase.DOCUMENT;
+            case "INTERVIEW" -> ApplicantPhase.INTERVIEW;
             default -> throw new InvalidKindException();
         };
     }

--- a/src/main/java/org/project/ttokttok/domain/applicant/domain/Applicant.java
+++ b/src/main/java/org/project/ttokttok/domain/applicant/domain/Applicant.java
@@ -13,6 +13,7 @@ import org.project.ttokttok.global.entity.BaseTimeEntity;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Entity
 @Getter
@@ -149,6 +150,43 @@ public class Applicant extends BaseTimeEntity {
 
     public void failInterview() {
         this.interviewPhase.updateStatus(PhaseStatus.FAIL);
+    }
+
+    // 현재 단계(phase) 기준으로 전형 상태를 변경한다.
+    // 서류/면접 분기는 이 메서드가 캡슐화하며, 각 단계별 가드는 위임 대상 메서드가 그대로 유지한다.
+    public void changeEvaluationStatus(ApplicantPhase phase, PhaseStatus status) {
+        switch (phase) {
+            case DOCUMENT -> changeDocumentStatus(status);
+            case INTERVIEW -> changeInterviewStatus(status);
+        }
+    }
+
+    private void changeDocumentStatus(PhaseStatus status) {
+        switch (status) {
+            case PASS -> passDocumentEvaluation();
+            case FAIL -> failDocumentEvaluation();
+            case EVALUATING -> setDocumentEvaluating();
+        }
+    }
+
+    private void changeInterviewStatus(PhaseStatus status) {
+        switch (status) {
+            case PASS -> passInterview();
+            case FAIL -> failInterview();
+            case EVALUATING -> setInterviewEvaluating();
+        }
+    }
+
+    // 해당 단계에 실제로 존재할 때만 그 단계의 상태를 반환한다. (없으면 empty)
+    public Optional<PhaseStatus> statusOf(ApplicantPhase phase) {
+        return switch (phase) {
+            case DOCUMENT -> (isInDocumentPhase() && documentPhase != null)
+                    ? Optional.of(documentPhase.getStatus())
+                    : Optional.empty();
+            case INTERVIEW -> (isInInterviewPhase() && hasInterviewPhase() && interviewPhase != null)
+                    ? Optional.of(interviewPhase.getStatus())
+                    : Optional.empty();
+        };
     }
 
     // 편의 메서드들

--- a/src/main/java/org/project/ttokttok/domain/applicant/service/ApplicantAdminService.java
+++ b/src/main/java/org/project/ttokttok/domain/applicant/service/ApplicantAdminService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.project.ttokttok.domain.applicant.controller.enums.Kind;
 import org.project.ttokttok.domain.applicant.domain.Applicant;
+import org.project.ttokttok.domain.applicant.domain.enums.ApplicantPhase;
 import org.project.ttokttok.domain.applicant.domain.enums.PhaseStatus;
 import org.project.ttokttok.domain.applicant.exception.*;
 import org.project.ttokttok.domain.applicant.repository.ApplicantRepository;
@@ -149,7 +150,8 @@ public class ApplicantAdminService {
 
         validateApplicantAccess(applicant.getApplyForm().getClub().getId(), club.getId());
 
-        updateApplicantPhaseStatus(applicant, request.status(), request.kind());
+        ApplicantPhase phase = Kind.toApplicantPhase(request.kind());
+        applicant.changeEvaluationStatus(phase, request.status());
     }
 
     @Transactional
@@ -157,9 +159,9 @@ public class ApplicantAdminService {
         Club club = validateClubAdmin(request.username());
 
         ApplyForm currentApplyForm = findActiveApplyForm(request.clubId());
-        boolean isDocument = Kind.isDocument(request.kind());
-        int passedApplicantCount = processApplicants(currentApplyForm, club, isDocument);
-        int finalizedApplicantCount = calculateFinalizedApplicantCount(currentApplyForm.getId(), isDocument) + passedApplicantCount;
+        ApplicantPhase phase = Kind.toApplicantPhase(request.kind());
+        int passedApplicantCount = processApplicants(currentApplyForm, club, phase);
+        int finalizedApplicantCount = calculateFinalizedApplicantCount(currentApplyForm.getId(), phase) + passedApplicantCount;
 
         return ApplicantFinalizeServiceResponse.of(passedApplicantCount, finalizedApplicantCount);
     }
@@ -172,14 +174,14 @@ public class ApplicantAdminService {
         validateClubAdmin(username);
         
         ApplyForm currentApplyForm = findActiveApplyForm(clubId);
-        boolean isDocument = Kind.isDocument(kind);
+        ApplicantPhase phase = Kind.toApplicantPhase(kind);
 
-        List<String> passedEmails = filterApplicantsByStatus(currentApplyForm.getId(), isDocument, PASS)
+        List<String> passedEmails = filterApplicantsByStatus(currentApplyForm.getId(), phase, PASS)
                 .stream()
                 .map(Applicant::getEmail)
                 .toList();
 
-        List<String> failedEmails = filterApplicantsByStatus(currentApplyForm.getId(), isDocument, FAIL)
+        List<String> failedEmails = filterApplicantsByStatus(currentApplyForm.getId(), phase, FAIL)
                 .stream()
                 .map(Applicant::getEmail)
                 .toList();
@@ -198,10 +200,10 @@ public class ApplicantAdminService {
                 .orElseThrow(ActiveApplyFormNotFoundException::new);
     }
 
-    private int processApplicants(ApplyForm applyForm, Club club, boolean isDocument) {
-        List<Applicant> passedApplicants = filterApplicantsByStatus(applyForm.getId(), isDocument, PASS);
+    private int processApplicants(ApplyForm applyForm, Club club, ApplicantPhase phase) {
+        List<Applicant> passedApplicants = filterApplicantsByStatus(applyForm.getId(), phase, PASS);
 
-        if (!passedApplicants.isEmpty() && !isDocument) {
+        if (!passedApplicants.isEmpty() && phase == ApplicantPhase.INTERVIEW) {
             savePassedApplicantsAsClubMembers(passedApplicants, club);
         } else if (!passedApplicants.isEmpty() && applyForm.isHasInterview()) {
             passedApplicants.stream()
@@ -215,42 +217,21 @@ public class ApplicantAdminService {
         return passedApplicants.size();
     }
 
-    private int calculateFinalizedApplicantCount(String applyFormId, boolean isDocument) {
-        return applicantRepository.findByApplyFormId(applyFormId)
+    private int calculateFinalizedApplicantCount(String applyFormId, ApplicantPhase phase) {
+        return (int) applicantRepository.findByApplyFormId(applyFormId)
                 .stream()
-                .mapToInt(applicant -> {
-                    Integer status = failApplicantCount(isDocument, applicant);
-                    if (status != null)
-                        return status;
-                    return 0;
-                })
-                .sum();
+                .filter(applicant -> applicant.statusOf(phase)
+                        .filter(status -> status == FAIL)
+                        .isPresent())
+                .count();
     }
 
-    private Integer failApplicantCount(boolean isDocument, Applicant applicant) {
-        if (isDocument && applicant.isInDocumentPhase()) {
-            PhaseStatus status = applicant.getDocumentPhase() != null ?
-                    applicant.getDocumentPhase().getStatus() : null;
-            return (status == FAIL) ? 1 : 0;
-        } else if (!isDocument && applicant.isInInterviewPhase()) {
-            PhaseStatus status = applicant.hasInterviewPhase() ?
-                    applicant.getInterviewPhase().getStatus() : null;
-            return (status == FAIL) ? 1 : 0;
-        }
-        return null;
-    }
-
-    private List<Applicant> filterApplicantsByStatus(String applyFormId, boolean isDocument, PhaseStatus status) {
+    private List<Applicant> filterApplicantsByStatus(String applyFormId, ApplicantPhase phase, PhaseStatus status) {
         return applicantRepository.findByApplyFormId(applyFormId)
                 .stream()
-                .filter(applicant -> {
-                    if (isDocument) {
-                        return applicant.isInDocumentPhase() && applicant.getDocumentPhase().getStatus() == status;
-                    } else if (applicant.isInInterviewPhase()) {
-                        return applicant.hasInterviewPhase() && applicant.getInterviewPhase().getStatus() == status;
-                    }
-                    return false;
-                })
+                .filter(applicant -> applicant.statusOf(phase)
+                        .filter(phaseStatus -> phaseStatus == status)
+                        .isPresent())
                 .toList();
     }
 
@@ -293,43 +274,6 @@ public class ApplicantAdminService {
     private void validateApplicantAccess(String applicantClubId, String targetClubId) {
         if (!applicantClubId.equals(targetClubId)) {
             throw new UnAuthorizedApplicantAccessException();
-        }
-    }
-
-    private void updateApplicantPhaseStatus(Applicant applicant, PhaseStatus status, String kind) {
-
-        boolean isDocument = Kind.isDocument(kind);
-
-        if (status == PASS) {
-            handlePassStatus(applicant, isDocument);
-        } else if (status == PhaseStatus.FAIL) {
-            handleFailStatus(applicant, isDocument);
-        } else if (status == PhaseStatus.EVALUATING) {
-            handleEvaluatingStatus(applicant, isDocument);
-        }
-    }
-
-    private void handlePassStatus(Applicant applicant, boolean isDocument) {
-        if (isDocument) {
-            applicant.passDocumentEvaluation();
-        } else {
-            applicant.passInterview();
-        }
-    }
-
-    private void handleFailStatus(Applicant applicant, boolean isDocument) {
-        if (isDocument) {
-            applicant.failDocumentEvaluation();
-        } else {
-            applicant.failInterview();
-        }
-    }
-
-    private void handleEvaluatingStatus(Applicant applicant, boolean isDocument) {
-        if (isDocument) {
-            applicant.setDocumentEvaluating();
-        } else {
-            applicant.setInterviewEvaluating();
         }
     }
 }

--- a/src/test/java/org/project/ttokttok/domain/applicant/service/ApplicantAdminServiceTest.java
+++ b/src/test/java/org/project/ttokttok/domain/applicant/service/ApplicantAdminServiceTest.java
@@ -10,7 +10,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.project.ttokttok.domain.applicant.controller.dto.request.MailFormatRequest;
 import org.project.ttokttok.domain.applicant.domain.Applicant;
 import org.project.ttokttok.domain.applicant.domain.DocumentPhase;
-import org.project.ttokttok.domain.applicant.domain.InterviewPhase;
+import org.project.ttokttok.domain.applicant.domain.enums.ApplicantPhase;
 import org.project.ttokttok.domain.applicant.domain.enums.Gender;
 import org.project.ttokttok.domain.applicant.domain.enums.Grade;
 import org.project.ttokttok.domain.applicant.domain.enums.PhaseStatus;
@@ -444,7 +444,7 @@ class ApplicantAdminServiceTest {
             applicantAdminService.updateApplicantStatus(request);
 
             // then
-            verify(applicant).passDocumentEvaluation();
+            verify(applicant).changeEvaluationStatus(ApplicantPhase.DOCUMENT, PhaseStatus.PASS);
         }
 
         @Test
@@ -463,7 +463,7 @@ class ApplicantAdminServiceTest {
             applicantAdminService.updateApplicantStatus(request);
 
             // then
-            verify(applicant).failDocumentEvaluation();
+            verify(applicant).changeEvaluationStatus(ApplicantPhase.DOCUMENT, PhaseStatus.FAIL);
         }
 
         @Test
@@ -482,7 +482,7 @@ class ApplicantAdminServiceTest {
             applicantAdminService.updateApplicantStatus(request);
 
             // then
-            verify(applicant).setDocumentEvaluating();
+            verify(applicant).changeEvaluationStatus(ApplicantPhase.DOCUMENT, PhaseStatus.EVALUATING);
         }
 
         @Test
@@ -501,7 +501,7 @@ class ApplicantAdminServiceTest {
             applicantAdminService.updateApplicantStatus(request);
 
             // then
-            verify(applicant).passInterview();
+            verify(applicant).changeEvaluationStatus(ApplicantPhase.INTERVIEW, PhaseStatus.PASS);
         }
 
         @Test
@@ -520,7 +520,7 @@ class ApplicantAdminServiceTest {
             applicantAdminService.updateApplicantStatus(request);
 
             // then
-            verify(applicant).failInterview();
+            verify(applicant).changeEvaluationStatus(ApplicantPhase.INTERVIEW, PhaseStatus.FAIL);
         }
 
         @Test
@@ -539,7 +539,7 @@ class ApplicantAdminServiceTest {
             applicantAdminService.updateApplicantStatus(request);
 
             // then
-            verify(applicant).setInterviewEvaluating();
+            verify(applicant).changeEvaluationStatus(ApplicantPhase.INTERVIEW, PhaseStatus.EVALUATING);
         }
 
         @Test
@@ -606,17 +606,11 @@ class ApplicantAdminServiceTest {
             given(applyFormRepository.findByClubIdAndStatus(CLUB_ID, ACTIVE)).willReturn(Optional.of(applyForm));
 
             Applicant passedApplicant = mock(Applicant.class);
-            given(passedApplicant.isInDocumentPhase()).willReturn(true);
-            DocumentPhase passedDocumentPhase = mock(DocumentPhase.class);
-            given(passedDocumentPhase.getStatus()).willReturn(PhaseStatus.PASS);
-            given(passedApplicant.getDocumentPhase()).willReturn(passedDocumentPhase);
+            given(passedApplicant.statusOf(ApplicantPhase.DOCUMENT)).willReturn(Optional.of(PhaseStatus.PASS));
             given(passedApplicant.isInInterviewPhase()).willReturn(false);
 
             Applicant failedApplicant = mock(Applicant.class);
-            given(failedApplicant.isInDocumentPhase()).willReturn(true);
-            DocumentPhase failedDocumentPhase = mock(DocumentPhase.class);
-            given(failedDocumentPhase.getStatus()).willReturn(PhaseStatus.FAIL);
-            given(failedApplicant.getDocumentPhase()).willReturn(failedDocumentPhase);
+            given(failedApplicant.statusOf(ApplicantPhase.DOCUMENT)).willReturn(Optional.of(PhaseStatus.FAIL));
 
             given(applicantRepository.findByApplyFormId(APPLY_FORM_ID))
                     .willReturn(List.of(passedApplicant, failedApplicant));
@@ -646,11 +640,7 @@ class ApplicantAdminServiceTest {
             given(applyFormRepository.findByClubIdAndStatus(CLUB_ID, ACTIVE)).willReturn(Optional.of(applyForm));
 
             Applicant passedApplicant = mock(Applicant.class);
-            given(passedApplicant.isInInterviewPhase()).willReturn(true);
-            given(passedApplicant.hasInterviewPhase()).willReturn(true);
-            InterviewPhase interviewPhase = mock(InterviewPhase.class);
-            given(interviewPhase.getStatus()).willReturn(PhaseStatus.PASS);
-            given(passedApplicant.getInterviewPhase()).willReturn(interviewPhase);
+            given(passedApplicant.statusOf(ApplicantPhase.INTERVIEW)).willReturn(Optional.of(PhaseStatus.PASS));
             given(passedApplicant.getName()).willReturn("홍길동");
             given(passedApplicant.getGrade()).willReturn(Grade.FIRST_GRADE);
             given(passedApplicant.getMajor()).willReturn("컴퓨터공학과");
@@ -684,11 +674,7 @@ class ApplicantAdminServiceTest {
             given(applyFormRepository.findByClubIdAndStatus(CLUB_ID, ACTIVE)).willReturn(Optional.of(applyForm));
 
             Applicant passedApplicant = mock(Applicant.class);
-            given(passedApplicant.isInInterviewPhase()).willReturn(true);
-            given(passedApplicant.hasInterviewPhase()).willReturn(true);
-            InterviewPhase interviewPhase = mock(InterviewPhase.class);
-            given(interviewPhase.getStatus()).willReturn(PhaseStatus.PASS);
-            given(passedApplicant.getInterviewPhase()).willReturn(interviewPhase);
+            given(passedApplicant.statusOf(ApplicantPhase.INTERVIEW)).willReturn(Optional.of(PhaseStatus.PASS));
             given(passedApplicant.getEmail()).willReturn("hong@test.com");
 
             given(applicantRepository.findByApplyFormId(APPLY_FORM_ID)).willReturn(List.of(passedApplicant));
@@ -752,17 +738,11 @@ class ApplicantAdminServiceTest {
             given(applyFormRepository.findByClubIdAndStatus(CLUB_ID, ACTIVE)).willReturn(Optional.of(applyForm));
 
             Applicant passedApplicant = mock(Applicant.class);
-            given(passedApplicant.isInDocumentPhase()).willReturn(true);
-            DocumentPhase passedPhase = mock(DocumentPhase.class);
-            given(passedPhase.getStatus()).willReturn(PhaseStatus.PASS);
-            given(passedApplicant.getDocumentPhase()).willReturn(passedPhase);
+            given(passedApplicant.statusOf(ApplicantPhase.DOCUMENT)).willReturn(Optional.of(PhaseStatus.PASS));
             given(passedApplicant.getEmail()).willReturn("passed@test.com");
 
             Applicant failedApplicant = mock(Applicant.class);
-            given(failedApplicant.isInDocumentPhase()).willReturn(true);
-            DocumentPhase failedPhase = mock(DocumentPhase.class);
-            given(failedPhase.getStatus()).willReturn(PhaseStatus.FAIL);
-            given(failedApplicant.getDocumentPhase()).willReturn(failedPhase);
+            given(failedApplicant.statusOf(ApplicantPhase.DOCUMENT)).willReturn(Optional.of(PhaseStatus.FAIL));
             given(failedApplicant.getEmail()).willReturn("failed@test.com");
 
             given(applicantRepository.findByApplyFormId(APPLY_FORM_ID))


### PR DESCRIPTION
## ✨ 작업 내용
- `applicant` 도메인 관리자 전형 처리의 서류/면접(`isDocument`) 분기 제어 결합을 제거하고, phase별 분기를 `Applicant` 엔티티로 흡수했습니다.
  - `Applicant.changeEvaluationStatus(ApplicantPhase, PhaseStatus)` — 서류/면접 × 합/불/평가중 분기를 엔티티가 캡슐화(기존 pass/fail/evaluating 메서드에 위임하여 단계별 가드 보존).
  - `Applicant.statusOf(ApplicantPhase): Optional<PhaseStatus>` — 해당 단계에 실제 존재할 때만 상태 반환(null 가드 흡수).
  - `ApplicantAdminService`: `boolean isDocument` 스레딩 제거 → `ApplicantPhase`로 대체. `updateApplicantPhaseStatus`/`handlePass·Fail·EvaluatingStatus`/`failApplicantCount` 제거, `filterApplicantsByStatus`·`calculateFinalizedApplicantCount`를 `statusOf` 기반으로 단순화.
  - `Kind.toApplicantPhase(String)` 추가, 미사용 `Kind.isDocument(String)` 제거.
- **API 호출 양식 불변**: 컨트롤러 엔드포인트, `@RequestParam Kind kind`, 요청/응답 DTO는 그대로 유지했습니다.
- **Swagger 문서**: 변경 없음(요청/응답 스펙 동일).
- **DB 변경**: 없음.

## 🔍 관련 이슈
- 해결한 이슈 번호: #324

## ✅ 체크리스트
- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요? (`bash maintenance/verify.sh` — clean build + 전체 테스트 + jacoco green, 1m48s)
- [x] 라벨을 붙혔나요? (`Refactor - 리펙토링`)
- [x] 팀 코드 컨벤션 준수하였나요?

## 💬 기타 참고 사항
- 순수 내부 리팩토링으로 도메인 동작은 보존됩니다. 도메인 동작 보장은 실제 엔티티를 사용하는 `ApplicantTest`가 담당합니다.
- `ApplicantAdminServiceTest`는 `Applicant`를 mock으로 두고 옛 협력 메서드(`passDocumentEvaluation` 등)를 verify/stub하던 **상호작용 테스트**였습니다. 협력 계약이 `changeEvaluationStatus`/`statusOf`로 바뀌면서 10건이 실패하여, 새 엔티티 API에 맞게 stub/verify를 갱신했습니다(동작 변경 아님).
- 기존의 서류 pass 가드 비대칭(pass에는 면접-단계 가드 없음, fail/evaluating에는 있음)은 **의도적으로 그대로 보존**했습니다. 통일이 필요하면 별도 이슈로 다루는 것을 제안합니다.
- 커밋은 작업 단위로 3개로 분리했습니다(엔티티 API 추가 → 서비스 리팩토링 → 테스트 갱신).
