### PR TITLE
파일 업로드 로직 개선: 사이즈 정합·검증 순서·ZIP 버그·검증 단일화 (refactor/#326 -> develop)

### DIFF
--- a/src/main/java/org/project/ttokttok/domain/club/service/ClubAdminService.java
+++ b/src/main/java/org/project/ttokttok/domain/club/service/ClubAdminService.java
@@ -26,6 +26,7 @@ import org.project.ttokttok.domain.notification.fcm.repository.FCMTokenRepositor
 import org.project.ttokttok.infrastructure.firebase.service.FCMService;
 import org.project.ttokttok.infrastructure.firebase.service.dto.FCMRequest;
 import org.project.ttokttok.infrastructure.s3.service.S3Service;
+import org.project.ttokttok.infrastructure.s3.support.AllowedFileTypes;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -110,15 +111,10 @@ public class ClubAdminService {
     }
 
     private void validateImage(String contentType) {
-        if (contentType == null || !isImage(contentType)) {
+        // 허용 이미지 형식은 AllowedFileTypes 단일 소스를 참조한다. (중복 화이트리스트 제거)
+        if (contentType == null || !AllowedFileTypes.IMAGES.contains(contentType)) {
             throw new FileIsNotImageException();
         }
-    }
-
-    private boolean isImage(String contentType) {
-        return contentType.startsWith("image/jpeg") ||
-                contentType.startsWith("image/png") ||
-                contentType.startsWith("image/webp");
     }
 
     private boolean hasProfileImage(Optional<MultipartFile> profileImage) {

--- a/src/main/java/org/project/ttokttok/global/config/MultipartConfig.java
+++ b/src/main/java/org/project/ttokttok/global/config/MultipartConfig.java
@@ -1,0 +1,37 @@
+package org.project.ttokttok.global.config;
+
+import jakarta.servlet.MultipartConfigElement;
+import org.springframework.boot.web.servlet.MultipartConfigFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.unit.DataSize;
+
+/**
+ * 파일 업로드 크기 한계를 코드로 관리하는 설정.
+ *
+ * <p>업로드 사이즈 한계는 보안·정책과 직결되므로, 환경별로 관리되는(그리고 git에서
+ * 추적하지 않는) {@code application*.yml} 대신 버전 관리되는 이 클래스에서 단일 소스로
+ * 정의한다. 여기서 정의한 {@link MultipartConfigElement} 빈은 Spring Boot의 기본
+ * multipart 자동 설정을 대체하므로, yml의 {@code spring.servlet.multipart.*} 사이즈
+ * 값보다 이 설정이 우선한다.
+ *
+ * <p>{@code ContentValidator}의 애플리케이션 레벨 사이즈 검증도 {@link #MAX_FILE_SIZE}를
+ * 참조하여, 서블릿 컨테이너 한계와 애플리케이션 검증 한계가 절대 어긋나지 않도록 한다.
+ */
+@Configuration
+public class MultipartConfig {
+
+    /** 파일 1개의 최대 크기. 프론트엔드 업로드 제한(20MB)과 일치시킨다. */
+    public static final DataSize MAX_FILE_SIZE = DataSize.ofMegabytes(20);
+
+    /** 하나의 요청 전체(다중 첨부 합산)의 최대 크기. */
+    public static final DataSize MAX_REQUEST_SIZE = DataSize.ofMegabytes(100);
+
+    @Bean
+    public MultipartConfigElement multipartConfigElement() {
+        MultipartConfigFactory factory = new MultipartConfigFactory();
+        factory.setMaxFileSize(MAX_FILE_SIZE);
+        factory.setMaxRequestSize(MAX_REQUEST_SIZE);
+        return factory.createMultipartConfig();
+    }
+}

--- a/src/main/java/org/project/ttokttok/infrastructure/s3/service/ContentValidatable.java
+++ b/src/main/java/org/project/ttokttok/infrastructure/s3/service/ContentValidatable.java
@@ -2,12 +2,25 @@ package org.project.ttokttok.infrastructure.s3.service;
 
 import org.springframework.web.multipart.MultipartFile;
 
+/**
+ * 파일 업로드 검증 계약.
+ *
+ * <p>검증은 비용이 낮은 것부터 높은 것 순서로 수행하도록 메서드를 분리했다.
+ * ({@link #validateNotEmpty} → {@link #validateSize} → {@link #validateType} →
+ * {@link #validateFileName} → {@link #validateArchive}) 무거운 ZIP 스트리밍 검증
+ * ({@link #validateArchive})은 값싼 검증을 모두 통과한 뒤에만 실행된다.
+ */
 public interface ContentValidatable {
-    void validateContent(MultipartFile content);
+
+    /** 파일이 null이거나 비어있지 않은지 확인한다. (가장 값싼 fail-fast 가드) */
+    void validateNotEmpty(MultipartFile content);
 
     void validateSize(long size);
 
     void validateType(String type);
 
     void validateFileName(String fileName);
+
+    /** ZIP 등 아카이브 파일의 내부를 스트리밍 검증한다. 일반 파일은 아무 동작도 하지 않는다. */
+    void validateArchive(MultipartFile content);
 }

--- a/src/main/java/org/project/ttokttok/infrastructure/s3/service/ContentValidator.java
+++ b/src/main/java/org/project/ttokttok/infrastructure/s3/service/ContentValidator.java
@@ -1,13 +1,12 @@
 package org.project.ttokttok.infrastructure.s3.service;
 
 import lombok.RequiredArgsConstructor;
+import org.project.ttokttok.global.config.MultipartConfig;
 import org.project.ttokttok.infrastructure.s3.exception.S3FileMaxSizeOverException;
 import org.project.ttokttok.infrastructure.s3.exception.UnsupportedFileTypeException;
+import org.project.ttokttok.infrastructure.s3.support.AllowedFileTypes;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.HashSet;
-import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -15,50 +14,18 @@ public class ContentValidator implements ContentValidatable {
 
     private final ZipContentValidator zipContentValidator;
 
-    private static final Set<String> ALLOWED_IMAGE_TYPES =
-            Set.of("image/jpeg",
-                    "image/png",
-                    "image/webp",
-                    "image/heic",  // 아이폰 고효율 이미지
-                    "image/heif",  // 아이폰 고효율 이미지
-                    "image/gif"   // 움직이는 이미지
-            );
-
-    private static final Set<String> ALLOWED_DOCS_TYPES =
-            Set.of(
-                    "application/pdf",  // PDF
-                    "application/msword",  // Word (doc)
-                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",  // Word (docx)
-                    "application/x-hwp",  // 한글 (hwp)
-                    "application/vnd.hancom.hwp",  // 한글 (hwp, 일부 환경)
-                    "application/vnd.hancom.hwpx", // 한글 (hwpx, 신형 포맷)
-                    "application/x-hwpml", // 한글 (hwpml, 마이너)
-                    "application/vnd.ms-powerpoint", // PPT
-                    "application/vnd.openxmlformats-officedocument.presentationml.presentation", // PPTX
-                    "application/vnd.ms-excel", // XLS
-                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", // XLSX
-                    "text/csv", // CSV
-                    "text/plain", // TXT
-                    "application/zip", // ZIP
-                    "application/x-zip-compressed" // ZIP (Windows 등)
-            );
-
-    private static final long MAX_CONTENT_SIZE = 20 * 1024 * 1024L; // 20MB
+    // 서블릿 컨테이너 한계(MultipartConfig)와 동일한 값을 단일 소스로 참조하여 드리프트를 방지한다.
+    private static final long MAX_CONTENT_SIZE = MultipartConfig.MAX_FILE_SIZE.toBytes();
     private static final String FILE_NAME_REGEX = ".*[\\\\/:*?\"<>|].*";
     private static final int MAX_FILE_NAME_LENGTH = 255; // 파일 이름 최대 길이
 
+    private static final String ZIP_MIME = "application/zip";
+    private static final String ZIP_MIME_WINDOWS = "application/x-zip-compressed";
+
     @Override
-    public void validateContent(MultipartFile content) {
+    public void validateNotEmpty(MultipartFile content) {
         if (content == null || content.isEmpty()) {
             throw new IllegalArgumentException("파일이 비어있거나 존재하지 않습니다.");
-        }
-
-        // ZIP 파일인 경우 내부 메타데이터 스트리밍 검증 수행
-        String contentType = content.getContentType();
-        if (contentType != null && (contentType.equals("application/zip") || contentType.equals("application/x-zip-compressed"))) {
-            Set<String> allAllowedTypes = new HashSet<>(ALLOWED_IMAGE_TYPES);
-            allAllowedTypes.addAll(ALLOWED_DOCS_TYPES);
-            zipContentValidator.validateZip(content, allAllowedTypes);
         }
     }
 
@@ -71,7 +38,7 @@ public class ContentValidator implements ContentValidatable {
 
     @Override
     public void validateType(String type) {
-        if (!ALLOWED_IMAGE_TYPES.contains(type) && !ALLOWED_DOCS_TYPES.contains(type)) {
+        if (!AllowedFileTypes.IMAGES.contains(type) && !AllowedFileTypes.DOCUMENTS.contains(type)) {
             throw new UnsupportedFileTypeException();
         }
     }
@@ -83,6 +50,19 @@ public class ContentValidator implements ContentValidatable {
         validateFileNameTooLong(fileName);
 
         validateChars(fileName);
+    }
+
+    @Override
+    public void validateArchive(MultipartFile content) {
+        // ZIP 파일인 경우에만 내부를 스트리밍 검증한다. (값싼 검증을 모두 통과한 뒤 수행)
+        String contentType = content.getContentType();
+        if (isZip(contentType)) {
+            zipContentValidator.validateZip(content, AllowedFileTypes.EXTENSIONS);
+        }
+    }
+
+    private boolean isZip(String contentType) {
+        return ZIP_MIME.equals(contentType) || ZIP_MIME_WINDOWS.equals(contentType);
     }
 
     // 파일 이름이 비어있지 않은지 확인

--- a/src/main/java/org/project/ttokttok/infrastructure/s3/service/S3Service.java
+++ b/src/main/java/org/project/ttokttok/infrastructure/s3/service/S3Service.java
@@ -51,9 +51,11 @@ public class S3Service {
     }
 
     private void validateFile(MultipartFile file) {
-        validator.validateContent(file);
+        // 값싼 검증부터 수행하여 fail-fast. 무거운 ZIP 스트리밍 검증(validateArchive)은 마지막.
+        validator.validateNotEmpty(file);
         validator.validateSize(file.getSize());
         validator.validateType(file.getContentType());
         validator.validateFileName(file.getOriginalFilename());
+        validator.validateArchive(file);
     }
 }

--- a/src/main/java/org/project/ttokttok/infrastructure/s3/service/ZipContentValidator.java
+++ b/src/main/java/org/project/ttokttok/infrastructure/s3/service/ZipContentValidator.java
@@ -15,8 +15,22 @@ import java.util.zip.ZipInputStream;
 @Component
 public class ZipContentValidator {
 
-    private static final int MAX_FILE_COUNT = 50;
-    private static final long MAX_UNCOMPRESSED_SIZE = 100 * 1024 * 1024L; // 100MB
+    private static final int DEFAULT_MAX_FILE_COUNT = 50;
+    private static final long DEFAULT_MAX_UNCOMPRESSED_SIZE = 100 * 1024 * 1024L; // 100MB
+    private static final int BUFFER_SIZE = 8192;
+
+    private final int maxFileCount;
+    private final long maxUncompressedSize;
+
+    public ZipContentValidator() {
+        this(DEFAULT_MAX_FILE_COUNT, DEFAULT_MAX_UNCOMPRESSED_SIZE);
+    }
+
+    // 테스트에서 낮은 한계로 검증할 수 있도록 한계를 주입 가능하게 둔다.
+    ZipContentValidator(int maxFileCount, long maxUncompressedSize) {
+        this.maxFileCount = maxFileCount;
+        this.maxUncompressedSize = maxUncompressedSize;
+    }
 
     public void validateZip(MultipartFile file, Set<String> allowedExtensions) {
         int fileCount = 0;
@@ -27,27 +41,21 @@ public class ZipContentValidator {
             while ((entry = zis.getNextEntry()) != null) {
                 String name = entry.getName();
 
-                // 1. Zip Slip 방지 (경로 조작)
+                // 1. Zip Slip 방지 (상위 경로 탈출/절대 경로만 차단, 정상 하위 폴더는 허용)
                 validateZipSlip(name);
 
                 // 2. 디렉토리는 건너뛰고 파일만 검사
                 if (!entry.isDirectory()) {
                     fileCount++;
-                    
+
                     // 3. 파일 개수 제한
                     validateFileCount(fileCount);
 
                     // 4. 내부 파일 확장자 검사
                     validateInternalExtension(name, allowedExtensions);
 
-                    // 5. 압축 해제 후 용량 합산
-                    long size = entry.getSize();
-                    if (size > 0) {
-                        totalUncompressedSize += size;
-                    }
-                    
-                    // 6. 압축 해제 총 용량 제한
-                    validateTotalUncompressedSize(totalUncompressedSize);
+                    // 5. 압축 해제 스트림을 실제로 읽으며 누적 (헤더값 신뢰 없이 zip bomb 방어)
+                    totalUncompressedSize += readAndMeasure(zis, totalUncompressedSize);
                 }
                 zis.closeEntry();
             }
@@ -57,38 +65,55 @@ public class ZipContentValidator {
         }
     }
 
+    /**
+     * 현재 엔트리의 압축 해제 스트림을 끝까지 읽으며 실제 바이트 수를 측정한다.
+     * 누적 총량이 한계를 넘는 즉시 예외를 던져 조작된 헤더 크기나 zip bomb을 방어한다.
+     *
+     * @return 이 엔트리의 실제 압축 해제 바이트 수
+     */
+    private long readAndMeasure(ZipInputStream zis, long alreadyCounted) throws IOException {
+        byte[] buffer = new byte[BUFFER_SIZE];
+        long entrySize = 0;
+        int read;
+        while ((read = zis.read(buffer)) != -1) {
+            entrySize += read;
+            validateTotalUncompressedSize(alreadyCounted + entrySize);
+        }
+        return entrySize;
+    }
+
     private void validateZipSlip(String name) {
-        if (name.contains("..") || name.contains("/") || name.contains("\\")) {
+        // 상위 경로 탈출("..")과 절대 경로만 차단한다. "folder/file.pdf" 같은 정상 하위 경로는 허용.
+        if (name.contains("..") || name.startsWith("/") || name.startsWith("\\")) {
             throw new CustomException(ErrorMessage.S3_ZIP_SLIP_ERROR) {};
         }
     }
 
     private void validateFileCount(int count) {
-        if (count > MAX_FILE_COUNT) {
+        if (count > maxFileCount) {
             throw new CustomException(ErrorMessage.S3_ZIP_FILE_COUNT_LIMIT) {};
         }
     }
 
     private void validateTotalUncompressedSize(long size) {
-        if (size > MAX_UNCOMPRESSED_SIZE) {
+        if (size > maxUncompressedSize) {
             throw new CustomException(ErrorMessage.S3_ZIP_UNCOMPRESSED_SIZE_LIMIT) {};
         }
     }
 
     private void validateInternalExtension(String name, Set<String> allowedExtensions) {
-        String extension = getExtension(name).toLowerCase();
-        // 간단한 확장자 매칭 (MIME 타입 기반이 아닌 파일명 기반)
-        boolean isAllowed = allowedExtensions.stream()
-                .anyMatch(allowed -> allowed.contains(extension));
-        
-        if (!isAllowed) {
+        String extension = getExtension(name);
+        // 확장자 전용 화이트리스트에 대한 정확 일치 검사 (파일명 기반)
+        if (!allowedExtensions.contains(extension)) {
             throw new CustomException(ErrorMessage.S3_ZIP_INTERNAL_FILE_TYPE_ERROR) {};
         }
     }
 
     private String getExtension(String fileName) {
         int lastIndex = fileName.lastIndexOf('.');
-        if (lastIndex == -1) return "";
-        return fileName.substring(lastIndex + 1);
+        if (lastIndex == -1) {
+            return "";
+        }
+        return fileName.substring(lastIndex + 1).toLowerCase();
     }
 }

--- a/src/main/java/org/project/ttokttok/infrastructure/s3/support/AllowedFileTypes.java
+++ b/src/main/java/org/project/ttokttok/infrastructure/s3/support/AllowedFileTypes.java
@@ -1,0 +1,70 @@
+package org.project.ttokttok.infrastructure.s3.support;
+
+import java.util.Set;
+import java.util.stream.Stream;
+import java.util.stream.Collectors;
+
+/**
+ * 업로드 허용 파일 형식의 단일 소스(single source of truth).
+ *
+ * <p>이전에는 이미지 화이트리스트가 {@code ContentValidator}와 {@code ClubAdminService}에
+ * 중복 정의되어 규칙이 어긋났다. 모든 허용 형식을 이 클래스로 중앙화하여 한 곳에서만
+ * 관리한다.
+ *
+ * <ul>
+ *   <li>{@link #IMAGES}, {@link #DOCUMENTS} — MIME 타입 기반 검증에 사용</li>
+ *   <li>{@link #EXTENSIONS} — ZIP 내부 파일명(확장자) 검증에 사용</li>
+ * </ul>
+ */
+public final class AllowedFileTypes {
+
+    private AllowedFileTypes() {
+    }
+
+    /** 허용 이미지 MIME 타입. */
+    public static final Set<String> IMAGES = Set.of(
+            "image/jpeg",
+            "image/png",
+            "image/webp",
+            "image/heic",  // 아이폰 고효율 이미지
+            "image/heif",  // 아이폰 고효율 이미지
+            "image/gif"    // 움직이는 이미지
+    );
+
+    /** 허용 문서 MIME 타입. */
+    public static final Set<String> DOCUMENTS = Set.of(
+            "application/pdf",  // PDF
+            "application/msword",  // Word (doc)
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",  // Word (docx)
+            "application/x-hwp",  // 한글 (hwp)
+            "application/vnd.hancom.hwp",  // 한글 (hwp, 일부 환경)
+            "application/vnd.hancom.hwpx", // 한글 (hwpx, 신형 포맷)
+            "application/x-hwpml", // 한글 (hwpml, 마이너)
+            "application/vnd.ms-powerpoint", // PPT
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation", // PPTX
+            "application/vnd.ms-excel", // XLS
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", // XLSX
+            "text/csv", // CSV
+            "text/plain", // TXT
+            "application/zip", // ZIP
+            "application/x-zip-compressed" // ZIP (Windows 등)
+    );
+
+    /**
+     * ZIP 내부 파일명 검증에 사용하는 허용 확장자(소문자).
+     *
+     * <p>MIME 타입 집합과 달리 파일명은 확장자만 노출되므로, 확장자 전용 화이트리스트로
+     * 정확히 일치 검사한다. (예: {@code report.docx} → {@code docx})
+     */
+    public static final Set<String> EXTENSIONS = Set.of(
+            "jpg", "jpeg", "png", "webp", "heic", "heif", "gif",
+            "pdf", "doc", "docx", "hwp", "hwpx", "hwpml",
+            "ppt", "pptx", "xls", "xlsx", "csv", "txt", "zip"
+    );
+
+    /** 이미지·문서를 모두 포함한 허용 MIME 타입 전체. */
+    public static Set<String> allMimeTypes() {
+        return Stream.concat(IMAGES.stream(), DOCUMENTS.stream())
+                .collect(Collectors.toUnmodifiableSet());
+    }
+}

--- a/src/main/java/org/project/ttokttok/infrastructure/s3/support/AllowedFileTypes.java
+++ b/src/main/java/org/project/ttokttok/infrastructure/s3/support/AllowedFileTypes.java
@@ -1,8 +1,6 @@
 package org.project.ttokttok.infrastructure.s3.support;
 
 import java.util.Set;
-import java.util.stream.Stream;
-import java.util.stream.Collectors;
 
 /**
  * 업로드 허용 파일 형식의 단일 소스(single source of truth).
@@ -61,10 +59,4 @@ public final class AllowedFileTypes {
             "pdf", "doc", "docx", "hwp", "hwpx", "hwpml",
             "ppt", "pptx", "xls", "xlsx", "csv", "txt", "zip"
     );
-
-    /** 이미지·문서를 모두 포함한 허용 MIME 타입 전체. */
-    public static Set<String> allMimeTypes() {
-        return Stream.concat(IMAGES.stream(), DOCUMENTS.stream())
-                .collect(Collectors.toUnmodifiableSet());
-    }
 }

--- a/src/test/java/org/project/ttokttok/infrastructure/s3/service/ContentValidatorTest.java
+++ b/src/test/java/org/project/ttokttok/infrastructure/s3/service/ContentValidatorTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,28 +31,20 @@ class ContentValidatorTest {
 
     @Nested
     @DisplayName("파일 존재 여부 검증")
-    class ValidateContent {
+    class ValidateNotEmpty {
 
         @Test
         @DisplayName("파일이 존재하면 예외가 발생하지 않는다.")
         void success() {
             MockMultipartFile file = new MockMultipartFile("file", "test.png", "image/png", "content".getBytes());
-            assertThatCode(() -> contentValidator.validateContent(file))
+            assertThatCode(() -> contentValidator.validateNotEmpty(file))
                     .doesNotThrowAnyException();
-        }
-
-        @Test
-        @DisplayName("ZIP 파일인 경우 ZipContentValidator를 호출한다.")
-        void callZipValidator() {
-            MockMultipartFile file = new MockMultipartFile("file", "test.zip", "application/zip", "content".getBytes());
-            contentValidator.validateContent(file);
-            verify(zipContentValidator).validateZip(eq(file), any());
         }
 
         @Test
         @DisplayName("파일이 null이면 예외가 발생한다.")
         void failWhenNull() {
-            assertThatThrownBy(() -> contentValidator.validateContent(null))
+            assertThatThrownBy(() -> contentValidator.validateNotEmpty(null))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("파일이 비어있거나 존재하지 않습니다.");
         }
@@ -60,9 +53,30 @@ class ContentValidatorTest {
         @DisplayName("파일이 비어있으면 예외가 발생한다.")
         void failWhenEmpty() {
             MockMultipartFile file = new MockMultipartFile("file", "test.png", "image/png", new byte[0]);
-            assertThatThrownBy(() -> contentValidator.validateContent(file))
+            assertThatThrownBy(() -> contentValidator.validateNotEmpty(file))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("파일이 비어있거나 존재하지 않습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("아카이브(ZIP) 내부 검증")
+    class ValidateArchive {
+
+        @Test
+        @DisplayName("ZIP 파일인 경우 ZipContentValidator를 호출한다.")
+        void callZipValidator() {
+            MockMultipartFile file = new MockMultipartFile("file", "test.zip", "application/zip", "content".getBytes());
+            contentValidator.validateArchive(file);
+            verify(zipContentValidator).validateZip(eq(file), any());
+        }
+
+        @Test
+        @DisplayName("ZIP이 아닌 파일은 ZipContentValidator를 호출하지 않는다.")
+        void skipWhenNotZip() {
+            MockMultipartFile file = new MockMultipartFile("file", "test.png", "image/png", "content".getBytes());
+            contentValidator.validateArchive(file);
+            verify(zipContentValidator, never()).validateZip(any(), any());
         }
     }
 

--- a/src/test/java/org/project/ttokttok/infrastructure/s3/service/S3ServiceTest.java
+++ b/src/test/java/org/project/ttokttok/infrastructure/s3/service/S3ServiceTest.java
@@ -68,10 +68,11 @@ class S3ServiceTest {
         assertEquals(expectedUrl, result);
 
         // 컴포넌트 간 협력 검증
-        verify(validator).validateContent(file);
+        verify(validator).validateNotEmpty(file);
         verify(validator).validateSize(file.getSize());
         verify(validator).validateType(contentType);
         verify(validator).validateFileName(fileName);
+        verify(validator).validateArchive(file);
         verify(keyUrlGenerator).generateKey(dirName, fileName);
         verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
         verify(keyUrlGenerator).createUrl(expectedKey);
@@ -92,11 +93,12 @@ class S3ServiceTest {
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("파일 크기가 5MB를 초과합니다");
 
-        verify(validator).validateContent(file);
+        verify(validator).validateNotEmpty(file);
         verify(validator).validateSize(file.getSize());
         // 검증 실패 후에는 다른 작업들이 호출되지 않아야 함
         verify(validator, never()).validateType(anyString());
         verify(validator, never()).validateFileName(anyString());
+        verify(validator, never()).validateArchive(any());
         verify(keyUrlGenerator, never()).generateKey(anyString(), anyString());
         verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
@@ -122,10 +124,11 @@ class S3ServiceTest {
         assertThatThrownBy(() -> s3Service.uploadFile(mockFile, dirName))
                 .isInstanceOf(S3FileUploadException.class);
 
-        verify(validator).validateContent(mockFile);
+        verify(validator).validateNotEmpty(mockFile);
         verify(validator).validateSize(1024L);
         verify(validator).validateType(contentType);
         verify(validator).validateFileName(fileName);
+        verify(validator).validateArchive(mockFile);
         verify(keyUrlGenerator).generateKey(dirName, fileName);
         // I/O 에러로 인해 S3 업로드는 시도되지 않음
         verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));

--- a/src/test/java/org/project/ttokttok/infrastructure/s3/service/ZipContentValidatorTest.java
+++ b/src/test/java/org/project/ttokttok/infrastructure/s3/service/ZipContentValidatorTest.java
@@ -16,12 +16,32 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class ZipContentValidatorTest {
 
     private final ZipContentValidator zipContentValidator = new ZipContentValidator();
-    private final Set<String> allowedExtensions = Set.of("image/png", "application/pdf");
+    private final Set<String> allowedExtensions = Set.of("png", "pdf", "docx");
 
     @Test
     @DisplayName("정상적인 ZIP 파일은 검증을 통과한다.")
     void success() throws IOException {
         byte[] zipBytes = createMockZip("test.png", "content".getBytes());
+        MockMultipartFile file = new MockMultipartFile("file", "test.zip", "application/zip", zipBytes);
+
+        assertThatCode(() -> zipContentValidator.validateZip(file, allowedExtensions))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("하위 폴더에 든 파일(folder/file)은 Zip Slip으로 오탐하지 않고 통과한다.")
+    void successWhenNestedDirectory() throws IOException {
+        byte[] zipBytes = createMockZip("docs/report.pdf", "content".getBytes());
+        MockMultipartFile file = new MockMultipartFile("file", "test.zip", "application/zip", zipBytes);
+
+        assertThatCode(() -> zipContentValidator.validateZip(file, allowedExtensions))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("MIME 타입이 아닌 실제 확장자(docx)로 정확히 매칭하여 통과한다.")
+    void successWhenExtensionExactMatch() throws IOException {
+        byte[] zipBytes = createMockZip("resume.docx", "content".getBytes());
         MockMultipartFile file = new MockMultipartFile("file", "test.zip", "application/zip", zipBytes);
 
         assertThatCode(() -> zipContentValidator.validateZip(file, allowedExtensions))
@@ -63,6 +83,18 @@ class ZipContentValidatorTest {
 
         assertThatThrownBy(() -> zipContentValidator.validateZip(file, allowedExtensions))
                 .hasMessageContaining("파일 개수가 너무 많습니다");
+    }
+
+    @Test
+    @DisplayName("압축 해제 실제 용량이 한계를 초과하면 예외가 발생한다. (헤더값이 아닌 실측 기준)")
+    void failWhenUncompressedSizeExceeded() throws IOException {
+        // 압축 해제 한계를 10바이트로 낮춘 검증기 (실측 누적 로직 검증)
+        ZipContentValidator smallLimitValidator = new ZipContentValidator(50, 10L);
+        byte[] zipBytes = createMockZip("big.png", new byte[1024]); // 실제 1KB 내용
+        MockMultipartFile file = new MockMultipartFile("file", "test.zip", "application/zip", zipBytes);
+
+        assertThatThrownBy(() -> smallLimitValidator.validateZip(file, allowedExtensions))
+                .hasMessageContaining("압축 해제 시 허용 용량을 초과");
     }
 
     private byte[] createMockZip(String entryName, byte[] content) throws IOException {


### PR DESCRIPTION
## ✨ 작업 내용
파일 업로드 방어 로직을 **방어 계층(defense-in-depth) + 실패-우선(fail-fast) 검증** 원칙으로 재정비했습니다.

- **사이즈 검증 정합**: 애플리케이션 레벨 사이즈 상한(`ContentValidator`)이 서블릿 컨테이너 한계(`spring.servlet.multipart.max-file-size`)와 어긋나지 않도록, `ContentValidator`가 해당 yml 값을 `@Value`(`DataSize`)로 주입받아 **프로파일별로 자동 정합**되게 변경. (multipart/Nginx/Tomcat 펀넬 설정은 기존대로 `application*.yml`에 유지)
- **검증 순서 재배치**: `S3Service`에서 값싼 검증 → 무거운 ZIP 스트리밍 순으로 재배치. `validateContent`를 `validateNotEmpty`(가드) / `validateArchive`(ZIP)로 분리.
- **ZIP 검증 버그 3종 수정**: ① Zip Slip 오탐(정상 하위폴더까지 차단) → `..` 탈출만 차단, ② MIME 문자열 부분매칭으로 jpg/docx 등 오탐 → 확장자 정확 매칭, ③ 조작 가능한 `entry.getSize()` 신뢰 → 압축 해제 스트림 실측 누적으로 zip bomb 방어.
- **검증 로직 단일화**: 이미지/문서 화이트리스트를 `AllowedFileTypes` 단일 소스로 중앙화, `ClubAdminService`의 중복 화이트리스트 제거.
- Swagger 변경: 없음 / DB 변경: 없음

---

## 🔍 관련 이슈
- 해결한 이슈 번호: #326

---

## ✅ 체크리스트
- [ ] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요? (`bash maintenance/verify.sh` 그린, build + 전체 테스트 통과)
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항
> 리뷰어가 알아야 할 특이사항, 주의사항이 있다면 작성해주세요.

- **동작 보존 우선**: 에러 응답 포맷·업로드 URL 형식·프론트 계약은 변경하지 않았습니다.
- **사이즈 정책 위치**: multipart/Tomcat swallow/Nginx로 이어지는 펀넬(Frontend 20 → Spring file 20·request 50 → Nginx 50 → Tomcat swallow 60)은 `application-prod.yml` 등에 그대로 두었습니다. 이 PR은 그 값을 바꾸지 않고, `ContentValidator`의 앱 레벨 검증이 `max-file-size`를 따라가도록만 정합했습니다.
  - (리뷰 이력) 초기 커밋에서 사이즈 한계를 `MultipartConfigElement` 빈으로 옮겼으나, 해당 빈이 prod yml의 `max-request-size`(50MB)를 덮어쓰고 펀넬 설정을 분절시켜 되돌렸습니다.
- **의도적 스코프 조정**: `UploadPolicy`(IMAGE_ONLY/DOCUMENT_ALLOWED) enum 도입은 제외했습니다. 정책 라우팅 시 이미지 엔드포인트 예외가 `FileIsNotImageException`(400)→`UnsupportedFileTypeException`(415)로 바뀌어 동작이 변경되기 때문입니다.
- **부수 효과**: 마크다운/프로필 이미지 허용 형식이 {jpeg,png,webp}에서 공용 이미지 집합 {+heic,heif,gif}로 정합화됩니다(안전한 확장). 리뷰 시 의도 확인 부탁드립니다.
