### PR TITLE
PR 제목 컨벤션 rule 추가 및 ship 스킬 반영 (chore/#328 -> develop)

### DIFF
--- a/.omc/skills/ship/SKILL.md
+++ b/.omc/skills/ship/SKILL.md
@@ -101,11 +101,11 @@ Every issue body must also cover the fields from [`maintenance/task.md`](../../.
    ```
    The `pre-push` hook enforces branch naming, blocks force-push, and blocks direct pushes to `main`/`develop` — do not bypass it.
 
-9. **Create the PR** against `develop`, using only the upper half of `.github/PULL_REQUEST_TEMPLATE.md` (everything above the "아래 부터 `develop -> main` PR 템플릿입니다" divider — the release-PR section below it does not apply here):
+9. **Create the PR** against `develop`, using only the upper half of `.github/PULL_REQUEST_TEMPLATE.md` (everything above the "아래 부터 `develop -> main` PR 템플릿입니다" divider — the release-PR section below it does not apply here). The title must follow [`rules/agent/pr-title.md`](../../../rules/agent/pr-title.md): `<작업 내용> (<branch> -> develop)` — Korean 작업 내용, no issue number in the title (the branch already carries `#<issue>`):
    ```bash
-   gh pr create --base develop --head "<branch>" --title "<title>" --body-file <generated PR body> --label "<mapped label>"
+   gh pr create --base develop --head "<branch>" --title "<작업 내용> (<branch> -> develop)" --body-file <generated PR body> --label "<mapped label>"
    ```
-   Auto-check the checklist items you can actually verify (로컬 테스트 완료 — since verify.sh passed; 라벨을 붙혔나요 — yes; 팀 코드 컨벤션 준수 — yes), fill in 관련 이슈 with `#<issue-number>`, and summarize the change in 기타 참고 사항.
+   e.g. `--title "파일 업로드 로직 개선 (refactor/#326 -> develop)"`. Auto-check the checklist items you can actually verify (로컬 테스트 완료 — since verify.sh passed; 라벨을 붙혔나요 — yes; 팀 코드 컨벤션 준수 — yes), fill in 관련 이슈 with `#<issue-number>`, and summarize the change in 기타 참고 사항.
 
 10. **Cleanup** — leave the worktree and branch on disk (for review follow-up commits); do not remove them automatically. If you used `EnterWorktree`, you may call `ExitWorktree({action: "keep"})` to return the parent session to its original directory without deleting anything.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,7 @@ Detailed, situational rules live under [`rules/`](rules/) — common agent rules
 
 - **Commit messages** → [`rules/agent/commit-message.md`](rules/agent/commit-message.md)
 - **Branches** → [`rules/agent/branch-naming.md`](rules/agent/branch-naming.md)
+- **PR titles** → [`rules/agent/pr-title.md`](rules/agent/pr-title.md)
 
 ---
 

--- a/rules/agent/pr-title.md
+++ b/rules/agent/pr-title.md
@@ -1,0 +1,11 @@
+# Rule: PR Title Convention
+
+> Indexed from [`AGENTS.md`](../../AGENTS.md) → Git Conventions. Applied when opening PRs (manually or via the `ship` skill). Not git-hook enforced — PR titles live on the remote, so this is a convention plus automation, not a local hook.
+
+- **Format:** `<작업 내용> (<작업 브랜치> -> <머지받을 브랜치>)`
+- **Language:** Korean (the `작업 내용` part)
+- **Issue number:** omit it from the title. The branch name already carries `#<issue>` inside the parentheses, and the issue link belongs in the PR body (`관련 이슈`).
+- **Example:**
+  ```text
+  파일 업로드 로직 개선 (refactor/#326 -> develop)
+  ```


### PR DESCRIPTION
## ✨ 작업 내용
PR 제목 컨벤션을 명문화하고 `ship` 스킬 자동화에 반영했습니다.

- `rules/agent/pr-title.md` 신규: 형식 `<작업 내용> (<작업 브랜치> -> <머지받을 브랜치>)`, 제목에 이슈 번호 제외(브랜치명에 `#<issue>` 포함), 한국어 작업 내용.
- `AGENTS.md` Git Conventions 인덱스에 PR 제목 rule 링크 추가.
- `ship` 스킬 step 9를 새 제목 형식으로 갱신 → rule과 자동화 일치.
- 본 PR 제목 자체가 새 형식을 따릅니다 (dogfooding).
- Swagger 변경: 없음 / DB 변경: 없음

---

## 🔍 관련 이슈
- 해결한 이슈 번호: #328

---

## ✅ 체크리스트
- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요? (`bash maintenance/verify.sh` 그린)
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항
> 리뷰어가 알아야 할 특이사항, 주의사항이 있다면 작성해주세요.

- PR 제목은 로컬 git hook으로 강제할 수 없어(원격 대상), 컨벤션 문서 + `ship` 스킬 자동화로 관리합니다.
- 기존 rule 문서(`commit-message.md`, `branch-naming.md`)와 동일하게 영어로 작성했습니다.
