### PR TITLE
공지사항 저장/목록/상세 API 및 운영자 역할 추가 (feat/#331 -> develop)

### DIFF
--- a/src/main/java/org/project/ttokttok/domain/notice/controller/NoticeAdminController.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/controller/NoticeAdminController.java
@@ -1,0 +1,38 @@
+package org.project.ttokttok.domain.notice.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.project.ttokttok.domain.notice.controller.docs.NoticeAdminDocs;
+import org.project.ttokttok.domain.notice.controller.dto.request.CreateNoticeRequest;
+import org.project.ttokttok.domain.notice.controller.dto.response.NoticeCreateResponse;
+import org.project.ttokttok.domain.notice.service.NoticeAdminService;
+import org.project.ttokttok.global.annotation.auth.AuthUserInfo;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 공지사항 관리 API 컨트롤러
+ * 서비스 운영/유지보수 팀(ROLE_SUPER_ADMIN)이 전역 공지사항을 저장하는 API를 제공합니다.
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/super-admin/notices")
+public class NoticeAdminController implements NoticeAdminDocs {
+
+    private final NoticeAdminService noticeAdminService;
+
+    @PostMapping
+    public ResponseEntity<NoticeCreateResponse> createNotice(
+            @AuthUserInfo String username,
+            @RequestBody @Valid CreateNoticeRequest request
+    ) {
+        String noticeId = noticeAdminService.createNotice(request.toServiceRequest(username));
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new NoticeCreateResponse(noticeId));
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/notice/controller/NoticeUserController.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/controller/NoticeUserController.java
@@ -1,0 +1,39 @@
+package org.project.ttokttok.domain.notice.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.project.ttokttok.domain.notice.controller.docs.NoticeUserDocs;
+import org.project.ttokttok.domain.notice.controller.dto.response.NoticeDetailResponse;
+import org.project.ttokttok.domain.notice.controller.dto.response.NoticeListResponse;
+import org.project.ttokttok.domain.notice.service.NoticeUserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 공지사항 조회 API 컨트롤러
+ * 누구나(비로그인 포함) 서비스 공지사항 목록/상세를 조회할 수 있는 API를 제공합니다.
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notices")
+public class NoticeUserController implements NoticeUserDocs {
+
+    private final NoticeUserService noticeUserService;
+
+    @GetMapping
+    public ResponseEntity<NoticeListResponse> getNotices(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) String keyword
+    ) {
+        return ResponseEntity.ok(noticeUserService.getNotices(page, size, keyword));
+    }
+
+    @GetMapping("/{noticeId}")
+    public ResponseEntity<NoticeDetailResponse> getNoticeDetail(@PathVariable String noticeId) {
+        return ResponseEntity.ok(noticeUserService.getNoticeDetail(noticeId));
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/notice/controller/docs/NoticeAdminDocs.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/controller/docs/NoticeAdminDocs.java
@@ -1,0 +1,54 @@
+package org.project.ttokttok.domain.notice.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.project.ttokttok.domain.notice.controller.dto.request.CreateNoticeRequest;
+import org.project.ttokttok.domain.notice.controller.dto.response.NoticeCreateResponse;
+import org.project.ttokttok.global.exception.dto.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "[운영자] 공지사항 관리 API", description = "서비스 운영/유지보수 팀이 전역 공지사항을 작성하는 API 입니다.")
+public interface NoticeAdminDocs {
+
+    @Operation(
+            summary = "공지사항 저장",
+            description = """
+                    서비스 전역 공지사항을 저장합니다.
+                    운영자(ROLE_SUPER_ADMIN) 권한을 가진 계정만 호출할 수 있습니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "공지사항 저장 성공",
+                    content = @Content(schema = @Schema(implementation = NoticeCreateResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (제목/내용 누락)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 요청"
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "운영자 권한이 없는 요청"
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 작동 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    ResponseEntity<NoticeCreateResponse> createNotice(
+            @Parameter(description = "인증된 운영자 아이디", hidden = true) String username,
+            @Parameter(description = "공지사항 저장 요청 (제목, 내용)") CreateNoticeRequest request
+    );
+}

--- a/src/main/java/org/project/ttokttok/domain/notice/controller/docs/NoticeUserDocs.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/controller/docs/NoticeUserDocs.java
@@ -1,0 +1,60 @@
+package org.project.ttokttok.domain.notice.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.project.ttokttok.domain.notice.controller.dto.response.NoticeDetailResponse;
+import org.project.ttokttok.domain.notice.controller.dto.response.NoticeListResponse;
+import org.project.ttokttok.global.exception.dto.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "[공용] 공지사항 조회 API", description = "누구나(비로그인 포함) 서비스 공지사항을 조회하는 API 입니다.")
+public interface NoticeUserDocs {
+
+    @Operation(
+            summary = "공지사항 목록 조회",
+            description = """
+                    서비스 공지사항 목록을 페이지 번호(1-based) 기반으로 조회합니다. 최신순으로 정렬됩니다.
+                    keyword가 있으면 제목에 해당 키워드가 포함된 공지만 조회합니다.
+                    응답의 totalCount로 "총 N건"을 표시할 수 있습니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = NoticeListResponse.class))
+            )
+    })
+    ResponseEntity<NoticeListResponse> getNotices(
+            @Parameter(description = "페이지 번호 (기본값 1)") int page,
+            @Parameter(description = "페이지당 개수 (기본값 10)") int size,
+            @Parameter(description = "제목 검색어 (선택)") String keyword
+    );
+
+    @Operation(
+            summary = "공지사항 상세 조회",
+            description = """
+                    공지사항 상세 내용을 조회합니다. 조회 시 조회수가 1 증가합니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = NoticeDetailResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "공지사항을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    ResponseEntity<NoticeDetailResponse> getNoticeDetail(
+            @Parameter(description = "공지사항 ID", required = true) String noticeId
+    );
+}

--- a/src/main/java/org/project/ttokttok/domain/notice/controller/dto/request/CreateNoticeRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/controller/dto/request/CreateNoticeRequest.java
@@ -1,0 +1,16 @@
+package org.project.ttokttok.domain.notice.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import org.project.ttokttok.domain.notice.service.dto.request.CreateNoticeServiceRequest;
+
+public record CreateNoticeRequest(
+        @NotBlank(message = "제목은 비어 있을 수 없습니다.")
+        String title,
+
+        @NotBlank(message = "내용은 비어 있을 수 없습니다.")
+        String content
+) {
+    public CreateNoticeServiceRequest toServiceRequest(String username) {
+        return new CreateNoticeServiceRequest(username, title, content);
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/notice/controller/dto/response/NoticeCreateResponse.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/controller/dto/response/NoticeCreateResponse.java
@@ -1,0 +1,6 @@
+package org.project.ttokttok.domain.notice.controller.dto.response;
+
+public record NoticeCreateResponse(
+        String noticeId
+) {
+}

--- a/src/main/java/org/project/ttokttok/domain/notice/controller/dto/response/NoticeDetailResponse.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/controller/dto/response/NoticeDetailResponse.java
@@ -8,6 +8,7 @@ public record NoticeDetailResponse(
         String noticeId,
         String title,
         String content,
+        String createdBy,
         LocalDateTime createdAt,
         int viewCount
 ) {
@@ -16,6 +17,7 @@ public record NoticeDetailResponse(
                 notice.getId(),
                 notice.getTitle(),
                 notice.getContent(),
+                notice.getCreatedBy(),
                 notice.getCreatedAt(),
                 notice.getViewCount()
         );

--- a/src/main/java/org/project/ttokttok/domain/notice/controller/dto/response/NoticeDetailResponse.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/controller/dto/response/NoticeDetailResponse.java
@@ -1,0 +1,23 @@
+package org.project.ttokttok.domain.notice.controller.dto.response;
+
+import org.project.ttokttok.domain.notice.domain.Notice;
+
+import java.time.LocalDateTime;
+
+public record NoticeDetailResponse(
+        String noticeId,
+        String title,
+        String content,
+        LocalDateTime createdAt,
+        int viewCount
+) {
+    public static NoticeDetailResponse from(Notice notice) {
+        return new NoticeDetailResponse(
+                notice.getId(),
+                notice.getTitle(),
+                notice.getContent(),
+                notice.getCreatedAt(),
+                notice.getViewCount()
+        );
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/notice/controller/dto/response/NoticeListResponse.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/controller/dto/response/NoticeListResponse.java
@@ -1,0 +1,35 @@
+package org.project.ttokttok.domain.notice.controller.dto.response;
+
+import org.project.ttokttok.domain.notice.domain.Notice;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record NoticeListResponse(
+        int currentPage,
+        int totalPage,
+        int totalCount,
+        List<NoticeSummary> notices
+) {
+
+    // 목록 한 행에 노출되는 요약 정보 (제목 / 작성일 / 조회수)
+    public record NoticeSummary(
+            String noticeId,
+            String title,
+            LocalDateTime createdAt,
+            int viewCount
+    ) {
+        public static NoticeSummary from(Notice notice) {
+            return new NoticeSummary(
+                    notice.getId(),
+                    notice.getTitle(),
+                    notice.getCreatedAt(),
+                    notice.getViewCount()
+            );
+        }
+    }
+
+    public static NoticeListResponse of(int currentPage, int totalPage, int totalCount, List<NoticeSummary> notices) {
+        return new NoticeListResponse(currentPage, totalPage, totalCount, notices);
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/notice/domain/Notice.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/domain/Notice.java
@@ -1,0 +1,77 @@
+package org.project.ttokttok.domain.notice.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.project.ttokttok.global.entity.BaseTimeEntity;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Table(name = "notices")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notice extends BaseTimeEntity {
+
+    @PrePersist
+    private void generateId() {
+        if (this.id == null) {
+            this.id = UUID.randomUUID().toString();
+        }
+    }
+
+    @Id
+    @Column(length = 36, updatable = false, unique = true)
+    private String id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private int viewCount;
+
+    @Builder
+    private Notice(String title, String content) {
+        this.title = title;
+        this.content = content;
+        this.viewCount = 0;
+    }
+
+    // ------- 정적 메서드 -------
+    public static Notice create(String title, String content) {
+        validateTitle(title);
+        validateContent(content);
+
+        return Notice.builder()
+                .title(title)
+                .content(content)
+                .build();
+    }
+
+    // ------- 비즈니스 로직 메서드 -------
+    public void increaseViewCount() {
+        this.viewCount++;
+    }
+
+    // ------- 유효성 검사 메서드 -------
+    private static void validateTitle(String title) {
+        if (title == null || title.isBlank()) {
+            throw new IllegalArgumentException("Title cannot be null or blank.");
+        }
+    }
+
+    private static void validateContent(String content) {
+        if (content == null || content.isBlank()) {
+            throw new IllegalArgumentException("Content cannot be null or blank.");
+        }
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/notice/domain/Notice.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/domain/Notice.java
@@ -36,24 +36,30 @@ public class Notice extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
+    // 작성한 운영자 username (감사/책임 추적용)
+    @Column(name = "created_by", nullable = false, updatable = false)
+    private String createdBy;
+
     @Column(nullable = false)
     private int viewCount;
 
     @Builder
-    private Notice(String title, String content) {
+    private Notice(String title, String content, String createdBy) {
         this.title = title;
         this.content = content;
+        this.createdBy = createdBy;
         this.viewCount = 0;
     }
 
     // ------- 정적 메서드 -------
-    public static Notice create(String title, String content) {
+    public static Notice create(String title, String content, String createdBy) {
         validateTitle(title);
         validateContent(content);
 
         return Notice.builder()
                 .title(title)
                 .content(content)
+                .createdBy(createdBy)
                 .build();
     }
 

--- a/src/main/java/org/project/ttokttok/domain/notice/domain/Notice.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/domain/Notice.java
@@ -57,11 +57,6 @@ public class Notice extends BaseTimeEntity {
                 .build();
     }
 
-    // ------- 비즈니스 로직 메서드 -------
-    public void increaseViewCount() {
-        this.viewCount++;
-    }
-
     // ------- 유효성 검사 메서드 -------
     private static void validateTitle(String title) {
         if (title == null || title.isBlank()) {

--- a/src/main/java/org/project/ttokttok/domain/notice/exception/NoticeNotFoundException.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/exception/NoticeNotFoundException.java
@@ -1,0 +1,10 @@
+package org.project.ttokttok.domain.notice.exception;
+
+import org.project.ttokttok.global.exception.ErrorMessage;
+import org.project.ttokttok.global.exception.exception.CustomException;
+
+public class NoticeNotFoundException extends CustomException {
+    public NoticeNotFoundException() {
+        super(ErrorMessage.NOTICE_NOT_FOUND);
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/notice/repository/NoticeCustomRepository.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/repository/NoticeCustomRepository.java
@@ -1,0 +1,9 @@
+package org.project.ttokttok.domain.notice.repository;
+
+import org.project.ttokttok.domain.notice.repository.dto.NoticePageQueryResponse;
+
+public interface NoticeCustomRepository {
+
+    // 공지사항 목록을 페이지 번호(1-based) 기반으로 조회하며, keyword가 있으면 제목으로 필터링한다.
+    NoticePageQueryResponse searchNotices(int page, int size, String keyword);
+}

--- a/src/main/java/org/project/ttokttok/domain/notice/repository/NoticeCustomRepositoryImpl.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/repository/NoticeCustomRepositoryImpl.java
@@ -1,0 +1,51 @@
+package org.project.ttokttok.domain.notice.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.project.ttokttok.domain.notice.domain.Notice;
+import org.project.ttokttok.domain.notice.repository.dto.NoticePageQueryResponse;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static org.project.ttokttok.domain.notice.domain.QNotice.notice;
+
+@Repository
+@RequiredArgsConstructor
+public class NoticeCustomRepositoryImpl implements NoticeCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public NoticePageQueryResponse searchNotices(int page, int size, String keyword) {
+        BooleanExpression keywordCondition = titleContains(keyword);
+
+        List<Notice> content = queryFactory
+                .selectFrom(notice)
+                .where(keywordCondition)
+                .orderBy(notice.createdAt.desc(), notice.id.desc())
+                .offset((long) size * (page - 1))
+                .limit(size)
+                .fetch();
+
+        Long totalCount = queryFactory
+                .select(notice.count())
+                .from(notice)
+                .where(keywordCondition)
+                .fetchOne();
+
+        return NoticePageQueryResponse.builder()
+                .content(content)
+                .totalCount(totalCount == null ? 0L : totalCount)
+                .build();
+    }
+
+    // keyword가 있으면 제목 부분일치 조건을, 없으면 null(조건 없음)을 반환한다.
+    private BooleanExpression titleContains(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return null;
+        }
+        return notice.title.contains(keyword);
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/repository/NoticeRepository.java
@@ -2,6 +2,14 @@ package org.project.ttokttok.domain.notice.repository;
 
 import org.project.ttokttok.domain.notice.domain.Notice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NoticeRepository extends JpaRepository<Notice, String>, NoticeCustomRepository {
+
+    // 조회수 원자적 증가 (동시 상세 조회 시 read-modify-write 경쟁으로 인한 조회수 유실 방지)
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Notice n SET n.viewCount = n.viewCount + 1 WHERE n.id = :noticeId")
+    int increaseViewCount(@Param("noticeId") String noticeId);
 }

--- a/src/main/java/org/project/ttokttok/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/repository/NoticeRepository.java
@@ -1,0 +1,7 @@
+package org.project.ttokttok.domain.notice.repository;
+
+import org.project.ttokttok.domain.notice.domain.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice, String>, NoticeCustomRepository {
+}

--- a/src/main/java/org/project/ttokttok/domain/notice/repository/dto/NoticePageQueryResponse.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/repository/dto/NoticePageQueryResponse.java
@@ -1,0 +1,13 @@
+package org.project.ttokttok.domain.notice.repository.dto;
+
+import lombok.Builder;
+import org.project.ttokttok.domain.notice.domain.Notice;
+
+import java.util.List;
+
+@Builder
+public record NoticePageQueryResponse(
+        List<Notice> content,
+        long totalCount
+) {
+}

--- a/src/main/java/org/project/ttokttok/domain/notice/service/NoticeAdminService.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/service/NoticeAdminService.java
@@ -1,12 +1,14 @@
 package org.project.ttokttok.domain.notice.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.project.ttokttok.domain.notice.domain.Notice;
 import org.project.ttokttok.domain.notice.repository.NoticeRepository;
 import org.project.ttokttok.domain.notice.service.dto.request.CreateNoticeServiceRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class NoticeAdminService {
@@ -16,9 +18,14 @@ public class NoticeAdminService {
     // 공지사항 생성 (운영자 전용)
     @Transactional
     public String createNotice(CreateNoticeServiceRequest request) {
-        Notice notice = Notice.create(request.title(), request.content());
+        Notice notice = Notice.create(request.title(), request.content(), request.username());
 
-        return noticeRepository.save(notice)
+        String noticeId = noticeRepository.save(notice)
                 .getId();
+
+        // 전역 공지 작성은 책임 추적을 위해 감사 로그를 남긴다.
+        log.info("공지사항 생성: noticeId={}, createdBy={}", noticeId, request.username());
+
+        return noticeId;
     }
 }

--- a/src/main/java/org/project/ttokttok/domain/notice/service/NoticeAdminService.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/service/NoticeAdminService.java
@@ -1,0 +1,24 @@
+package org.project.ttokttok.domain.notice.service;
+
+import lombok.RequiredArgsConstructor;
+import org.project.ttokttok.domain.notice.domain.Notice;
+import org.project.ttokttok.domain.notice.repository.NoticeRepository;
+import org.project.ttokttok.domain.notice.service.dto.request.CreateNoticeServiceRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeAdminService {
+
+    private final NoticeRepository noticeRepository;
+
+    // 공지사항 생성 (운영자 전용)
+    @Transactional
+    public String createNotice(CreateNoticeServiceRequest request) {
+        Notice notice = Notice.create(request.title(), request.content());
+
+        return noticeRepository.save(notice)
+                .getId();
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/notice/service/NoticeUserService.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/service/NoticeUserService.java
@@ -33,13 +33,16 @@ public class NoticeUserService {
         return NoticeListResponse.of(page, totalPage, (int) queryResponse.totalCount(), summaries);
     }
 
-    // 공지사항 상세 조회 (조회 시 조회수 증가, 비로그인 공개)
+    // 공지사항 상세 조회 (조회 시 조회수 원자적 증가, 비로그인 공개)
     @Transactional
     public NoticeDetailResponse getNoticeDetail(String noticeId) {
+        int updated = noticeRepository.increaseViewCount(noticeId);
+        if (updated == 0) {
+            throw new NoticeNotFoundException();
+        }
+
         Notice notice = noticeRepository.findById(noticeId)
                 .orElseThrow(NoticeNotFoundException::new);
-
-        notice.increaseViewCount();
 
         return NoticeDetailResponse.from(notice);
     }

--- a/src/main/java/org/project/ttokttok/domain/notice/service/NoticeUserService.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/service/NoticeUserService.java
@@ -17,20 +17,28 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NoticeUserService {
 
+    // 공개 엔드포인트이므로 과도한 size 요청(대량 조회/DoS)과 음수/0 page·size로 인한 오류를 방지한다.
+    private static final int MIN_PAGE = 1;
+    private static final int MIN_PAGE_SIZE = 1;
+    private static final int MAX_PAGE_SIZE = 100;
+
     private final NoticeRepository noticeRepository;
 
     // 공지사항 목록 조회 (페이지 번호 기반 + 제목 검색, 비로그인 공개)
     @Transactional(readOnly = true)
     public NoticeListResponse getNotices(int page, int size, String keyword) {
-        NoticePageQueryResponse queryResponse = noticeRepository.searchNotices(page, size, keyword);
+        int safePage = Math.max(page, MIN_PAGE);
+        int safeSize = Math.min(Math.max(size, MIN_PAGE_SIZE), MAX_PAGE_SIZE);
 
-        int totalPage = (int) Math.ceil((double) queryResponse.totalCount() / size);
+        NoticePageQueryResponse queryResponse = noticeRepository.searchNotices(safePage, safeSize, keyword);
+
+        int totalPage = (int) Math.ceil((double) queryResponse.totalCount() / safeSize);
 
         List<NoticeSummary> summaries = queryResponse.content().stream()
                 .map(NoticeSummary::from)
                 .toList();
 
-        return NoticeListResponse.of(page, totalPage, (int) queryResponse.totalCount(), summaries);
+        return NoticeListResponse.of(safePage, totalPage, (int) queryResponse.totalCount(), summaries);
     }
 
     // 공지사항 상세 조회 (조회 시 조회수 원자적 증가, 비로그인 공개)

--- a/src/main/java/org/project/ttokttok/domain/notice/service/NoticeUserService.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/service/NoticeUserService.java
@@ -1,0 +1,46 @@
+package org.project.ttokttok.domain.notice.service;
+
+import lombok.RequiredArgsConstructor;
+import org.project.ttokttok.domain.notice.controller.dto.response.NoticeDetailResponse;
+import org.project.ttokttok.domain.notice.controller.dto.response.NoticeListResponse;
+import org.project.ttokttok.domain.notice.controller.dto.response.NoticeListResponse.NoticeSummary;
+import org.project.ttokttok.domain.notice.domain.Notice;
+import org.project.ttokttok.domain.notice.exception.NoticeNotFoundException;
+import org.project.ttokttok.domain.notice.repository.NoticeRepository;
+import org.project.ttokttok.domain.notice.repository.dto.NoticePageQueryResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeUserService {
+
+    private final NoticeRepository noticeRepository;
+
+    // 공지사항 목록 조회 (페이지 번호 기반 + 제목 검색, 비로그인 공개)
+    @Transactional(readOnly = true)
+    public NoticeListResponse getNotices(int page, int size, String keyword) {
+        NoticePageQueryResponse queryResponse = noticeRepository.searchNotices(page, size, keyword);
+
+        int totalPage = (int) Math.ceil((double) queryResponse.totalCount() / size);
+
+        List<NoticeSummary> summaries = queryResponse.content().stream()
+                .map(NoticeSummary::from)
+                .toList();
+
+        return NoticeListResponse.of(page, totalPage, (int) queryResponse.totalCount(), summaries);
+    }
+
+    // 공지사항 상세 조회 (조회 시 조회수 증가, 비로그인 공개)
+    @Transactional
+    public NoticeDetailResponse getNoticeDetail(String noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(NoticeNotFoundException::new);
+
+        notice.increaseViewCount();
+
+        return NoticeDetailResponse.from(notice);
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/notice/service/dto/request/CreateNoticeServiceRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/notice/service/dto/request/CreateNoticeServiceRequest.java
@@ -1,0 +1,8 @@
+package org.project.ttokttok.domain.notice.service.dto.request;
+
+public record CreateNoticeServiceRequest(
+        String username,
+        String title,
+        String content
+) {
+}

--- a/src/main/java/org/project/ttokttok/domain/superadmin/bootstrap/SuperAdminBootstrap.java
+++ b/src/main/java/org/project/ttokttok/domain/superadmin/bootstrap/SuperAdminBootstrap.java
@@ -1,0 +1,61 @@
+package org.project.ttokttok.domain.superadmin.bootstrap;
+
+import lombok.extern.slf4j.Slf4j;
+import org.project.ttokttok.domain.superadmin.domain.SuperAdmin;
+import org.project.ttokttok.domain.superadmin.repository.SuperAdminRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 운영자(ROLE_SUPER_ADMIN) 계정 부트스트랩.
+ * 자격증명을 저장소에 커밋하지 않기 위해, 앱 시작 시 환경변수(시크릿)로 주입된
+ * SUPER_ADMIN_USERNAME / SUPER_ADMIN_PASSWORD 로 운영자 계정을 멱등적으로 생성한다.
+ * - 자격증명이 비어 있으면 아무 것도 하지 않는다(로컬/테스트 등).
+ * - 동일 username 계정이 이미 있으면 생성하지 않는다.
+ */
+@Slf4j
+@Component
+public class SuperAdminBootstrap implements ApplicationRunner {
+
+    private final SuperAdminRepository superAdminRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final String bootstrapUsername;
+    private final String bootstrapPassword;
+
+    public SuperAdminBootstrap(
+            SuperAdminRepository superAdminRepository,
+            PasswordEncoder passwordEncoder,
+            @Value("${super.admin.username:}") String bootstrapUsername,
+            @Value("${super.admin.password:}") String bootstrapPassword
+    ) {
+        this.superAdminRepository = superAdminRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.bootstrapUsername = bootstrapUsername;
+        this.bootstrapPassword = bootstrapPassword;
+    }
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        if (bootstrapUsername.isBlank() || bootstrapPassword.isBlank()) {
+            log.info("운영자 부트스트랩 자격증명 미설정 - 건너뜁니다. (SUPER_ADMIN_USERNAME/PASSWORD)");
+            return;
+        }
+
+        if (superAdminRepository.findByUsername(bootstrapUsername).isPresent()) {
+            return; // 이미 존재 -> 멱등적으로 아무 것도 하지 않음
+        }
+
+        SuperAdmin superAdmin = SuperAdmin.create(
+                bootstrapUsername,
+                passwordEncoder.encode(bootstrapPassword)
+        );
+        superAdminRepository.save(superAdmin);
+
+        log.info("운영자 계정 부트스트랩 완료: username={}", bootstrapUsername);
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/superadmin/controller/SuperAdminAuthController.java
+++ b/src/main/java/org/project/ttokttok/domain/superadmin/controller/SuperAdminAuthController.java
@@ -1,0 +1,34 @@
+package org.project.ttokttok.domain.superadmin.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.project.ttokttok.domain.superadmin.controller.docs.SuperAdminAuthDocs;
+import org.project.ttokttok.domain.superadmin.controller.dto.request.SuperAdminLoginRequest;
+import org.project.ttokttok.domain.superadmin.controller.dto.response.SuperAdminLoginResponse;
+import org.project.ttokttok.domain.superadmin.service.SuperAdminAuthService;
+import org.project.ttokttok.domain.superadmin.service.dto.response.SuperAdminLoginServiceResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 운영자 인증 API 컨트롤러
+ * 서비스 운영/유지보수 팀 계정의 로그인 및 ROLE_SUPER_ADMIN 토큰 발급을 제공합니다.
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/super-admin")
+public class SuperAdminAuthController implements SuperAdminAuthDocs {
+
+    private final SuperAdminAuthService superAdminAuthService;
+
+    @PostMapping("/login")
+    public ResponseEntity<SuperAdminLoginResponse> login(@RequestBody @Valid SuperAdminLoginRequest request) {
+        SuperAdminLoginServiceResponse response = superAdminAuthService.login(request.toServiceRequest());
+
+        return ResponseEntity.ok()
+                .body(SuperAdminLoginResponse.of(response.accessToken(), response.refreshToken()));
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/superadmin/controller/docs/SuperAdminAuthDocs.java
+++ b/src/main/java/org/project/ttokttok/domain/superadmin/controller/docs/SuperAdminAuthDocs.java
@@ -1,0 +1,55 @@
+package org.project.ttokttok.domain.superadmin.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.project.ttokttok.domain.superadmin.controller.dto.request.SuperAdminLoginRequest;
+import org.project.ttokttok.domain.superadmin.controller.dto.response.SuperAdminLoginResponse;
+import org.project.ttokttok.global.exception.dto.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "[운영자] 운영자 인증 API", description = "서비스 운영/유지보수 팀(ROLE_SUPER_ADMIN) 인증 API 입니다.")
+public interface SuperAdminAuthDocs {
+
+    @Operation(
+            summary = "운영자 로그인",
+            description = """
+                    운영자 계정으로 로그인합니다.
+                    성공 시 ROLE_SUPER_ADMIN 권한을 담은 액세스 토큰과 리프레시 토큰을 반환합니다.
+                    이 액세스 토큰으로 공지사항 저장 API(/api/super-admin/notices)를 호출할 수 있습니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "로그인 성공",
+                    content = @Content(schema = @Schema(implementation = SuperAdminLoginResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (아이디/비밀번호 누락)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "비밀번호 불일치"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "운영자를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 작동 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    ResponseEntity<SuperAdminLoginResponse> login(
+            @Parameter(description = "운영자 로그인 요청 (아이디, 비밀번호)") SuperAdminLoginRequest request
+    );
+}

--- a/src/main/java/org/project/ttokttok/domain/superadmin/controller/dto/request/SuperAdminLoginRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/superadmin/controller/dto/request/SuperAdminLoginRequest.java
@@ -1,0 +1,19 @@
+package org.project.ttokttok.domain.superadmin.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import org.project.ttokttok.domain.superadmin.service.dto.request.SuperAdminLoginServiceRequest;
+
+public record SuperAdminLoginRequest(
+        @NotBlank(message = "아이디가 비어 있습니다.")
+        String username,
+
+        @NotBlank(message = "비밀번호가 비어 있습니다.")
+        String password
+) {
+    public SuperAdminLoginServiceRequest toServiceRequest() {
+        return SuperAdminLoginServiceRequest.builder()
+                .username(username)
+                .password(password)
+                .build();
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/superadmin/controller/dto/response/SuperAdminLoginResponse.java
+++ b/src/main/java/org/project/ttokttok/domain/superadmin/controller/dto/response/SuperAdminLoginResponse.java
@@ -1,0 +1,10 @@
+package org.project.ttokttok.domain.superadmin.controller.dto.response;
+
+public record SuperAdminLoginResponse(
+        String accessToken,
+        String refreshToken
+) {
+    public static SuperAdminLoginResponse of(String accessToken, String refreshToken) {
+        return new SuperAdminLoginResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/superadmin/domain/SuperAdmin.java
+++ b/src/main/java/org/project/ttokttok/domain/superadmin/domain/SuperAdmin.java
@@ -1,0 +1,55 @@
+package org.project.ttokttok.domain.superadmin.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.project.ttokttok.domain.superadmin.exception.SuperAdminPasswordNotMatchException;
+import org.project.ttokttok.global.entity.BaseTimeEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Entity
+@Table(name = "super_admins")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SuperAdmin extends BaseTimeEntity {
+
+    @Id
+    @Getter
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(length = 36, updatable = false, unique = true)
+    private String id;
+
+    @Getter
+    @Column(nullable = false, updatable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Builder
+    private SuperAdmin(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    // ------- 정적 메서드 -------
+    public static SuperAdmin create(String username, String password) {
+        return SuperAdmin.builder()
+                .username(username)
+                .password(password)
+                .build();
+    }
+
+    // ------- 검증용 메서드 -------
+    public void validatePassword(String rawPassword, PasswordEncoder passwordEncoder) {
+        if (!passwordEncoder.matches(rawPassword, this.password)) {
+            throw new SuperAdminPasswordNotMatchException();
+        }
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/superadmin/exception/SuperAdminNotFoundException.java
+++ b/src/main/java/org/project/ttokttok/domain/superadmin/exception/SuperAdminNotFoundException.java
@@ -1,0 +1,10 @@
+package org.project.ttokttok.domain.superadmin.exception;
+
+import org.project.ttokttok.global.exception.ErrorMessage;
+import org.project.ttokttok.global.exception.exception.CustomException;
+
+public class SuperAdminNotFoundException extends CustomException {
+    public SuperAdminNotFoundException() {
+        super(ErrorMessage.SUPER_ADMIN_NOT_FOUND);
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/superadmin/exception/SuperAdminPasswordNotMatchException.java
+++ b/src/main/java/org/project/ttokttok/domain/superadmin/exception/SuperAdminPasswordNotMatchException.java
@@ -1,0 +1,10 @@
+package org.project.ttokttok.domain.superadmin.exception;
+
+import org.project.ttokttok.global.exception.ErrorMessage;
+import org.project.ttokttok.global.exception.exception.CustomException;
+
+public class SuperAdminPasswordNotMatchException extends CustomException {
+    public SuperAdminPasswordNotMatchException() {
+        super(ErrorMessage.SUPER_ADMIN_PASSWORD_NOT_MATCH);
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/superadmin/repository/SuperAdminRepository.java
+++ b/src/main/java/org/project/ttokttok/domain/superadmin/repository/SuperAdminRepository.java
@@ -1,0 +1,10 @@
+package org.project.ttokttok.domain.superadmin.repository;
+
+import org.project.ttokttok.domain.superadmin.domain.SuperAdmin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SuperAdminRepository extends JpaRepository<SuperAdmin, String> {
+    Optional<SuperAdmin> findByUsername(String username);
+}

--- a/src/main/java/org/project/ttokttok/domain/superadmin/service/SuperAdminAuthService.java
+++ b/src/main/java/org/project/ttokttok/domain/superadmin/service/SuperAdminAuthService.java
@@ -1,0 +1,45 @@
+package org.project.ttokttok.domain.superadmin.service;
+
+import lombok.RequiredArgsConstructor;
+import org.project.ttokttok.domain.superadmin.domain.SuperAdmin;
+import org.project.ttokttok.domain.superadmin.exception.SuperAdminNotFoundException;
+import org.project.ttokttok.domain.superadmin.repository.SuperAdminRepository;
+import org.project.ttokttok.domain.superadmin.service.dto.request.SuperAdminLoginServiceRequest;
+import org.project.ttokttok.domain.superadmin.service.dto.response.SuperAdminLoginServiceResponse;
+import org.project.ttokttok.global.auth.jwt.dto.request.TokenRequest;
+import org.project.ttokttok.global.auth.jwt.dto.response.TokenResponse;
+import org.project.ttokttok.global.auth.jwt.service.TokenProvider;
+import org.project.ttokttok.infrastructure.redis.service.RefreshTokenRedisService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import static org.project.ttokttok.global.entity.Role.ROLE_SUPER_ADMIN;
+
+@Service
+@RequiredArgsConstructor
+public class SuperAdminAuthService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final SuperAdminRepository superAdminRepository;
+    private final TokenProvider tokenProvider;
+    private final RefreshTokenRedisService refreshTokenRedisService;
+
+    // 운영자 로그인 -> ROLE_SUPER_ADMIN 토큰 발급
+    public SuperAdminLoginServiceResponse login(SuperAdminLoginServiceRequest request) {
+        SuperAdmin superAdmin = superAdminRepository.findByUsername(request.username())
+                .orElseThrow(SuperAdminNotFoundException::new);
+
+        superAdmin.validatePassword(request.password(), passwordEncoder);
+
+        TokenResponse tokenResponse = tokenProvider.generateToken(
+                TokenRequest.of(superAdmin.getUsername(), ROLE_SUPER_ADMIN)
+        );
+
+        refreshTokenRedisService.save(superAdmin.getUsername(), tokenResponse.refreshToken());
+
+        return SuperAdminLoginServiceResponse.of(
+                tokenResponse.accessToken(),
+                tokenResponse.refreshToken()
+        );
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/superadmin/service/dto/request/SuperAdminLoginServiceRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/superadmin/service/dto/request/SuperAdminLoginServiceRequest.java
@@ -1,0 +1,10 @@
+package org.project.ttokttok.domain.superadmin.service.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record SuperAdminLoginServiceRequest(
+        String username,
+        String password
+) {
+}

--- a/src/main/java/org/project/ttokttok/domain/superadmin/service/dto/response/SuperAdminLoginServiceResponse.java
+++ b/src/main/java/org/project/ttokttok/domain/superadmin/service/dto/response/SuperAdminLoginServiceResponse.java
@@ -1,0 +1,16 @@
+package org.project.ttokttok.domain.superadmin.service.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record SuperAdminLoginServiceResponse(
+        String accessToken,
+        String refreshToken
+) {
+    public static SuperAdminLoginServiceResponse of(String accessToken, String refreshToken) {
+        return SuperAdminLoginServiceResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/org/project/ttokttok/global/auth/jwt/filter/JwtAuthenticationManager.java
+++ b/src/main/java/org/project/ttokttok/global/auth/jwt/filter/JwtAuthenticationManager.java
@@ -3,6 +3,8 @@ package org.project.ttokttok.global.auth.jwt.filter;
 import lombok.RequiredArgsConstructor;
 import org.project.ttokttok.domain.admin.exception.AdminNotFoundException;
 import org.project.ttokttok.domain.admin.repository.AdminRepository;
+import org.project.ttokttok.domain.superadmin.exception.SuperAdminNotFoundException;
+import org.project.ttokttok.domain.superadmin.repository.SuperAdminRepository;
 import org.project.ttokttok.domain.user.repository.UserRepository;
 import org.project.ttokttok.global.auth.jwt.exception.InvalidRoleException;
 import org.project.ttokttok.global.entity.Role;
@@ -22,16 +24,20 @@ public class JwtAuthenticationManager {
 
     private final UserRepository userRepository;
     private final AdminRepository adminRepository;
+    private final SuperAdminRepository superAdminRepository;
 
     private final String ROLE_USER = "ROLE_USER";
     private final String ROLE_ADMIN = "ROLE_ADMIN";
-    
+    private final String ROLE_SUPER_ADMIN = "ROLE_SUPER_ADMIN";
+
     public Authentication getAuthentication(String email, String role) {
         Object principal = switch (role) {
             case ROLE_USER -> userRepository.findByEmail(email)
                     .orElseThrow(() -> new RuntimeException("User not found"));
             case ROLE_ADMIN -> adminRepository.findByUsername(email)
                     .orElseThrow(AdminNotFoundException::new);
+            case ROLE_SUPER_ADMIN -> superAdminRepository.findByUsername(email)
+                    .orElseThrow(SuperAdminNotFoundException::new);
             default -> throw new InvalidRoleException();
         };
 

--- a/src/main/java/org/project/ttokttok/global/auth/security/SecurityConfig.java
+++ b/src/main/java/org/project/ttokttok/global/auth/security/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.project.ttokttok.global.auth.jwt.service.TokenProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -69,6 +70,8 @@ public class SecurityConfig {
                                 .requestMatchers(ALLOW_URLS.getEndPoints()).permitAll() // JWT를 가질 수 없는 요청은 허용
                                 .requestMatchers(SWAGGER_URLS.getEndPoints()).permitAll()
                                 .requestMatchers("/api/clubs/**").permitAll() // 동아리 조회는 비로그인 사용자도 가능
+                                .requestMatchers(HttpMethod.GET, "/api/notices", "/api/notices/**").permitAll() // 공지 조회는 비로그인 사용자도 가능
+                                .requestMatchers("/api/super-admin/**").hasRole("SUPER_ADMIN") // 운영자 전용 (공지 작성 등)
                                 .requestMatchers("/api/admin/**").hasRole("ADMIN") // ADMIN 권한이 필요한 요청은 검증
                                 .anyRequest().authenticated() // 나머지 요청은 인증 필요
                 )

--- a/src/main/java/org/project/ttokttok/global/auth/security/SecurityWhiteList.java
+++ b/src/main/java/org/project/ttokttok/global/auth/security/SecurityWhiteList.java
@@ -22,7 +22,8 @@ public enum SecurityWhiteList {
             "/api/user/auth/re-issue",
             "/api/admin/auth/re-issue",
             "/health",
-            "/api/admin/auth/join"
+            "/api/admin/auth/join",
+            "/api/super-admin/login"
     }),
 
     SWAGGER_URLS(new String[]{

--- a/src/main/java/org/project/ttokttok/global/entity/Role.java
+++ b/src/main/java/org/project/ttokttok/global/entity/Role.java
@@ -2,5 +2,6 @@ package org.project.ttokttok.global.entity;
 
 public enum Role { // 사용자 역할 구분용 -> 액세스 토큰에 사용
     ROLE_USER,
-    ROLE_ADMIN
+    ROLE_ADMIN,
+    ROLE_SUPER_ADMIN // 서비스 운영/유지보수 팀 (전역 공지사항 작성 권한)
 }

--- a/src/main/java/org/project/ttokttok/global/exception/ErrorMessage.java
+++ b/src/main/java/org/project/ttokttok/global/exception/ErrorMessage.java
@@ -87,7 +87,14 @@ public enum ErrorMessage {
     // FCM 에러 메시지
     FCM_FIELD_BLANK("FCM 토큰에 저장할 필드가 비어 있습니다.", HttpStatus.BAD_REQUEST),
     FCM_EMAIL_BLANK("FCM 토큰 내 저장 시도된 이메일이 비어 있습니다.", HttpStatus.BAD_REQUEST),
-    FCM_TOKEN_BLANK("FCM 토큰 내 저장 시도된 토큰 값이 비어 있습니다.", HttpStatus.BAD_REQUEST);
+    FCM_TOKEN_BLANK("FCM 토큰 내 저장 시도된 토큰 값이 비어 있습니다.", HttpStatus.BAD_REQUEST),
+
+    // 운영자(슈퍼 관리자) 에러 메시지
+    SUPER_ADMIN_NOT_FOUND("운영자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    SUPER_ADMIN_PASSWORD_NOT_MATCH("비밀번호가 틀렸습니다.", HttpStatus.UNAUTHORIZED),
+
+    // 공지사항 에러 메시지
+    NOTICE_NOT_FOUND("공지사항을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/resources/db/migration/V21__create_super_admin_table.sql
+++ b/src/main/resources/db/migration/V21__create_super_admin_table.sql
@@ -1,0 +1,16 @@
+-- 서비스 운영/유지보수 팀(ROLE_SUPER_ADMIN) 계정 테이블
+CREATE TABLE super_admins
+(
+    id         VARCHAR(36)  NOT NULL PRIMARY KEY,
+    username   VARCHAR(255) NOT NULL,
+    password   VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_super_admins_username UNIQUE (username)
+);
+
+-- 운영자 시드 계정 1개.
+-- 비밀번호 해시는 기존 mock admin 시드와 동일한 값이므로, 로그인 비밀번호도 mock admin 계정과 동일합니다.
+-- (updated_at 은 JPA Auditing(BaseTimeEntity)이 애플리케이션 레벨에서 갱신합니다.)
+INSERT INTO super_admins (id, username, password, created_at, updated_at) VALUES
+('11111111-1111-4111-8111-111111111111', 'ttok_operator', '$2a$10$HwEfHk9L3AqdL2zhRzLi7e7g/fSdNNgOH/fbrCwdan/Ed.5su7gRC', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);

--- a/src/main/resources/db/migration/V21__create_super_admin_table.sql
+++ b/src/main/resources/db/migration/V21__create_super_admin_table.sql
@@ -9,8 +9,6 @@ CREATE TABLE super_admins
     CONSTRAINT uk_super_admins_username UNIQUE (username)
 );
 
--- 운영자 시드 계정 1개.
--- 비밀번호 해시는 기존 mock admin 시드와 동일한 값이므로, 로그인 비밀번호도 mock admin 계정과 동일합니다.
--- (updated_at 은 JPA Auditing(BaseTimeEntity)이 애플리케이션 레벨에서 갱신합니다.)
-INSERT INTO super_admins (id, username, password, created_at, updated_at) VALUES
-('11111111-1111-4111-8111-111111111111', 'ttok_operator', '$2a$10$HwEfHk9L3AqdL2zhRzLi7e7g/fSdNNgOH/fbrCwdan/Ed.5su7gRC', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+-- 운영자 계정은 자격증명을 저장소(git)에 커밋하지 않기 위해 여기서 시드하지 않는다.
+-- 앱 시작 시 SUPER_ADMIN_USERNAME / SUPER_ADMIN_PASSWORD 환경변수(시크릿)를 읽어
+-- SuperAdminBootstrap 이 계정이 없을 때만 멱등적으로 생성한다.

--- a/src/main/resources/db/migration/V22__create_notice_table.sql
+++ b/src/main/resources/db/migration/V22__create_notice_table.sql
@@ -4,6 +4,7 @@ CREATE TABLE notices
     id         VARCHAR(36)  NOT NULL PRIMARY KEY,
     title      VARCHAR(255) NOT NULL,
     content    TEXT         NOT NULL,
+    created_by VARCHAR(255) NOT NULL,
     view_count INTEGER      NOT NULL DEFAULT 0,
     created_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP

--- a/src/main/resources/db/migration/V22__create_notice_table.sql
+++ b/src/main/resources/db/migration/V22__create_notice_table.sql
@@ -8,3 +8,6 @@ CREATE TABLE notices
     created_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+
+-- 목록 조회 정렬(createdAt DESC, id DESC) 및 페이지네이션 성능을 위한 인덱스
+CREATE INDEX idx_notices_created_at_id ON notices (created_at DESC, id DESC);

--- a/src/main/resources/db/migration/V22__create_notice_table.sql
+++ b/src/main/resources/db/migration/V22__create_notice_table.sql
@@ -1,0 +1,10 @@
+-- 서비스 전역 공지사항 테이블 (특정 동아리에 종속되지 않음, 텍스트 전용)
+CREATE TABLE notices
+(
+    id         VARCHAR(36)  NOT NULL PRIMARY KEY,
+    title      VARCHAR(255) NOT NULL,
+    content    TEXT         NOT NULL,
+    view_count INTEGER      NOT NULL DEFAULT 0,
+    created_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/src/test/java/org/project/ttokttok/domain/notice/controller/NoticeAdminControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/notice/controller/NoticeAdminControllerTest.java
@@ -1,0 +1,40 @@
+package org.project.ttokttok.domain.notice.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.domain.notice.controller.dto.request.CreateNoticeRequest;
+import org.project.ttokttok.domain.notice.controller.dto.response.NoticeCreateResponse;
+import org.project.ttokttok.domain.notice.service.NoticeAdminService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NoticeAdminControllerTest {
+
+    private final NoticeAdminService noticeAdminService = mock(NoticeAdminService.class);
+    private final NoticeAdminController noticeAdminController = new NoticeAdminController(noticeAdminService);
+
+    @Test
+    @DisplayName("공지 저장 요청 시 201과 생성된 공지 ID를 반환한다.")
+    void createNotice() {
+        // given
+        when(noticeAdminService.createNotice(any())).thenReturn("notice-1");
+        CreateNoticeRequest request = new CreateNoticeRequest("제목", "내용");
+
+        // when
+        ResponseEntity<NoticeCreateResponse> response =
+                noticeAdminController.createNotice("ttok_operator", request);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().noticeId()).isEqualTo("notice-1");
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/notice/controller/NoticeUserControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/notice/controller/NoticeUserControllerTest.java
@@ -1,0 +1,56 @@
+package org.project.ttokttok.domain.notice.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.domain.notice.controller.dto.response.NoticeDetailResponse;
+import org.project.ttokttok.domain.notice.controller.dto.response.NoticeListResponse;
+import org.project.ttokttok.domain.notice.service.NoticeUserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NoticeUserControllerTest {
+
+    private final NoticeUserService noticeUserService = mock(NoticeUserService.class);
+    private final NoticeUserController noticeUserController = new NoticeUserController(noticeUserService);
+
+    @Test
+    @DisplayName("목록 조회 요청 시 200과 목록 응답을 반환한다.")
+    void getNotices() {
+        // given
+        NoticeListResponse listResponse = NoticeListResponse.of(1, 1, 0, List.of());
+        when(noticeUserService.getNotices(1, 10, null)).thenReturn(listResponse);
+
+        // when
+        ResponseEntity<NoticeListResponse> response = noticeUserController.getNotices(1, 10, null);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(listResponse);
+    }
+
+    @Test
+    @DisplayName("상세 조회 요청 시 200과 상세 응답을 반환한다.")
+    void getNoticeDetail() {
+        // given
+        NoticeDetailResponse detailResponse =
+                new NoticeDetailResponse("notice-1", "제목", "내용", LocalDateTime.now(), 1);
+        when(noticeUserService.getNoticeDetail("notice-1")).thenReturn(detailResponse);
+
+        // when
+        ResponseEntity<NoticeDetailResponse> response = noticeUserController.getNoticeDetail("notice-1");
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(detailResponse);
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/notice/controller/NoticeUserControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/notice/controller/NoticeUserControllerTest.java
@@ -43,7 +43,7 @@ class NoticeUserControllerTest {
     void getNoticeDetail() {
         // given
         NoticeDetailResponse detailResponse =
-                new NoticeDetailResponse("notice-1", "제목", "내용", LocalDateTime.now(), 1);
+                new NoticeDetailResponse("notice-1", "제목", "내용", "ttok_operator", LocalDateTime.now(), 1);
         when(noticeUserService.getNoticeDetail("notice-1")).thenReturn(detailResponse);
 
         // when

--- a/src/test/java/org/project/ttokttok/domain/notice/domain/NoticeTest.java
+++ b/src/test/java/org/project/ttokttok/domain/notice/domain/NoticeTest.java
@@ -1,0 +1,61 @@
+package org.project.ttokttok.domain.notice.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NoticeTest {
+
+    @Nested
+    @DisplayName("create()")
+    class Create {
+
+        @Test
+        @DisplayName("제목과 내용으로 공지를 생성하면 조회수는 0으로 초기화된다.")
+        void createSuccess() {
+            // when
+            Notice notice = Notice.create("제목", "내용");
+
+            // then
+            assertThat(notice.getTitle()).isEqualTo("제목");
+            assertThat(notice.getContent()).isEqualTo("내용");
+            assertThat(notice.getViewCount()).isZero();
+        }
+
+        @Test
+        @DisplayName("제목이 공백이면 예외가 발생한다.")
+        void createBlankTitle() {
+            assertThatThrownBy(() -> Notice.create("   ", "내용"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("내용이 null이면 예외가 발생한다.")
+        void createNullContent() {
+            assertThatThrownBy(() -> Notice.create("제목", null))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("increaseViewCount()")
+    class IncreaseViewCount {
+
+        @Test
+        @DisplayName("호출할 때마다 조회수가 1씩 증가한다.")
+        void increase() {
+            // given
+            Notice notice = Notice.create("제목", "내용");
+
+            // when
+            notice.increaseViewCount();
+            notice.increaseViewCount();
+
+            // then
+            assertThat(notice.getViewCount()).isEqualTo(2);
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/notice/domain/NoticeTest.java
+++ b/src/test/java/org/project/ttokttok/domain/notice/domain/NoticeTest.java
@@ -14,28 +14,29 @@ class NoticeTest {
     class Create {
 
         @Test
-        @DisplayName("제목과 내용으로 공지를 생성하면 조회수는 0으로 초기화된다.")
+        @DisplayName("제목과 내용으로 공지를 생성하면 조회수는 0으로 초기화되고 작성자가 설정된다.")
         void createSuccess() {
             // when
-            Notice notice = Notice.create("제목", "내용");
+            Notice notice = Notice.create("제목", "내용", "ttok_operator");
 
             // then
             assertThat(notice.getTitle()).isEqualTo("제목");
             assertThat(notice.getContent()).isEqualTo("내용");
+            assertThat(notice.getCreatedBy()).isEqualTo("ttok_operator");
             assertThat(notice.getViewCount()).isZero();
         }
 
         @Test
         @DisplayName("제목이 공백이면 예외가 발생한다.")
         void createBlankTitle() {
-            assertThatThrownBy(() -> Notice.create("   ", "내용"))
+            assertThatThrownBy(() -> Notice.create("   ", "내용", "ttok_operator"))
                     .isInstanceOf(IllegalArgumentException.class);
         }
 
         @Test
         @DisplayName("내용이 null이면 예외가 발생한다.")
         void createNullContent() {
-            assertThatThrownBy(() -> Notice.create("제목", null))
+            assertThatThrownBy(() -> Notice.create("제목", null, "ttok_operator"))
                     .isInstanceOf(IllegalArgumentException.class);
         }
     }

--- a/src/test/java/org/project/ttokttok/domain/notice/domain/NoticeTest.java
+++ b/src/test/java/org/project/ttokttok/domain/notice/domain/NoticeTest.java
@@ -39,23 +39,4 @@ class NoticeTest {
                     .isInstanceOf(IllegalArgumentException.class);
         }
     }
-
-    @Nested
-    @DisplayName("increaseViewCount()")
-    class IncreaseViewCount {
-
-        @Test
-        @DisplayName("호출할 때마다 조회수가 1씩 증가한다.")
-        void increase() {
-            // given
-            Notice notice = Notice.create("제목", "내용");
-
-            // when
-            notice.increaseViewCount();
-            notice.increaseViewCount();
-
-            // then
-            assertThat(notice.getViewCount()).isEqualTo(2);
-        }
-    }
 }

--- a/src/test/java/org/project/ttokttok/domain/notice/repository/NoticeRepositoryTest.java
+++ b/src/test/java/org/project/ttokttok/domain/notice/repository/NoticeRepositoryTest.java
@@ -54,4 +54,19 @@ class NoticeRepositoryTest implements RepositoryTestSupport {
         assertThat(response.totalCount()).isEqualTo(3);
         assertThat(response.content()).hasSize(1);
     }
+
+    @Test
+    @DisplayName("increaseViewCount는 조회수를 DB에서 원자적으로 1 증가시킨다.")
+    void increaseViewCount() {
+        // given
+        Notice saved = noticeRepository.save(Notice.create("조회수 테스트", "내용"));
+
+        // when
+        int updated = noticeRepository.increaseViewCount(saved.getId());
+        Notice reloaded = noticeRepository.findById(saved.getId()).orElseThrow();
+
+        // then
+        assertThat(updated).isEqualTo(1);
+        assertThat(reloaded.getViewCount()).isEqualTo(1);
+    }
 }

--- a/src/test/java/org/project/ttokttok/domain/notice/repository/NoticeRepositoryTest.java
+++ b/src/test/java/org/project/ttokttok/domain/notice/repository/NoticeRepositoryTest.java
@@ -17,9 +17,9 @@ class NoticeRepositoryTest implements RepositoryTestSupport {
 
     @BeforeEach
     void setUp() {
-        noticeRepository.save(Notice.create("공지 A 안내", "내용 A"));
-        noticeRepository.save(Notice.create("공지 B 안내", "내용 B"));
-        noticeRepository.save(Notice.create("이벤트 C", "내용 C"));
+        noticeRepository.save(Notice.create("공지 A 안내", "내용 A", "ttok_operator"));
+        noticeRepository.save(Notice.create("공지 B 안내", "내용 B", "ttok_operator"));
+        noticeRepository.save(Notice.create("이벤트 C", "내용 C", "ttok_operator"));
     }
 
     @Test
@@ -59,7 +59,7 @@ class NoticeRepositoryTest implements RepositoryTestSupport {
     @DisplayName("increaseViewCount는 조회수를 DB에서 원자적으로 1 증가시킨다.")
     void increaseViewCount() {
         // given
-        Notice saved = noticeRepository.save(Notice.create("조회수 테스트", "내용"));
+        Notice saved = noticeRepository.save(Notice.create("조회수 테스트", "내용", "ttok_operator"));
 
         // when
         int updated = noticeRepository.increaseViewCount(saved.getId());

--- a/src/test/java/org/project/ttokttok/domain/notice/repository/NoticeRepositoryTest.java
+++ b/src/test/java/org/project/ttokttok/domain/notice/repository/NoticeRepositoryTest.java
@@ -1,0 +1,57 @@
+package org.project.ttokttok.domain.notice.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.notice.domain.Notice;
+import org.project.ttokttok.domain.notice.repository.dto.NoticePageQueryResponse;
+import org.project.ttokttok.support.RepositoryTestSupport;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NoticeRepositoryTest implements RepositoryTestSupport {
+
+    @Autowired
+    private NoticeRepository noticeRepository;
+
+    @BeforeEach
+    void setUp() {
+        noticeRepository.save(Notice.create("공지 A 안내", "내용 A"));
+        noticeRepository.save(Notice.create("공지 B 안내", "내용 B"));
+        noticeRepository.save(Notice.create("이벤트 C", "내용 C"));
+    }
+
+    @Test
+    @DisplayName("keyword 없이 조회하면 페이지 크기만큼 반환하고 전체 개수를 함께 반환한다.")
+    void searchNoticesWithoutKeyword() {
+        // when
+        NoticePageQueryResponse response = noticeRepository.searchNotices(1, 2, null);
+
+        // then
+        assertThat(response.totalCount()).isEqualTo(3);
+        assertThat(response.content()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("keyword로 제목을 부분 검색하면 일치하는 공지만 반환한다.")
+    void searchNoticesWithKeyword() {
+        // when
+        NoticePageQueryResponse response = noticeRepository.searchNotices(1, 10, "공지");
+
+        // then
+        assertThat(response.totalCount()).isEqualTo(2);
+        assertThat(response.content()).allMatch(notice -> notice.getTitle().contains("공지"));
+    }
+
+    @Test
+    @DisplayName("두 번째 페이지를 조회하면 offset이 적용되어 나머지 공지를 반환한다.")
+    void searchNoticesSecondPage() {
+        // when
+        NoticePageQueryResponse response = noticeRepository.searchNotices(2, 2, null);
+
+        // then
+        assertThat(response.totalCount()).isEqualTo(3);
+        assertThat(response.content()).hasSize(1);
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/notice/service/NoticeAdminServiceTest.java
+++ b/src/test/java/org/project/ttokttok/domain/notice/service/NoticeAdminServiceTest.java
@@ -1,0 +1,41 @@
+package org.project.ttokttok.domain.notice.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.domain.notice.domain.Notice;
+import org.project.ttokttok.domain.notice.repository.NoticeRepository;
+import org.project.ttokttok.domain.notice.service.dto.request.CreateNoticeServiceRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NoticeAdminServiceTest {
+
+    private final NoticeRepository noticeRepository = mock(NoticeRepository.class);
+    private final NoticeAdminService noticeAdminService = new NoticeAdminService(noticeRepository);
+
+    @Test
+    @DisplayName("공지사항 저장에 성공하면 저장된 공지의 ID를 반환한다.")
+    void createNoticeSuccess() {
+        // given
+        CreateNoticeServiceRequest request =
+                new CreateNoticeServiceRequest("ttok_operator", "공지 제목", "공지 내용");
+
+        Notice saved = mock(Notice.class);
+        when(saved.getId()).thenReturn("notice-1");
+        when(noticeRepository.save(any(Notice.class))).thenReturn(saved);
+
+        // when
+        String noticeId = noticeAdminService.createNotice(request);
+
+        // then
+        assertThat(noticeId).isEqualTo("notice-1");
+        verify(noticeRepository).save(any(Notice.class));
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/notice/service/NoticeUserServiceTest.java
+++ b/src/test/java/org/project/ttokttok/domain/notice/service/NoticeUserServiceTest.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -78,35 +79,37 @@ class NoticeUserServiceTest {
     class GetNoticeDetail {
 
         @Test
-        @DisplayName("상세 조회 시 조회수를 증가시키고 상세 응답을 반환한다.")
+        @DisplayName("상세 조회 시 조회수를 원자적으로 증가시키고 증가된 상세 응답을 반환한다.")
         void getNoticeDetailSuccess() {
             // given
             Notice notice = mock(Notice.class);
             when(notice.getId()).thenReturn("notice-1");
             when(notice.getTitle()).thenReturn("제목");
             when(notice.getContent()).thenReturn("내용");
-            when(notice.getViewCount()).thenReturn(1);
+            when(notice.getViewCount()).thenReturn(2); // 증가 후 재조회된 값
+            when(noticeRepository.increaseViewCount("notice-1")).thenReturn(1);
             when(noticeRepository.findById("notice-1")).thenReturn(Optional.of(notice));
 
             // when
             NoticeDetailResponse response = noticeUserService.getNoticeDetail("notice-1");
 
             // then
-            verify(notice).increaseViewCount();
+            verify(noticeRepository).increaseViewCount("notice-1");
             assertThat(response.noticeId()).isEqualTo("notice-1");
             assertThat(response.content()).isEqualTo("내용");
-            assertThat(response.viewCount()).isEqualTo(1);
+            assertThat(response.viewCount()).isEqualTo(2);
         }
 
         @Test
-        @DisplayName("존재하지 않는 공지를 조회하면 예외가 발생한다.")
+        @DisplayName("존재하지 않는 공지를 조회하면 예외가 발생하고 재조회하지 않는다.")
         void getNoticeDetailNotFound() {
             // given
-            when(noticeRepository.findById("missing")).thenReturn(Optional.empty());
+            when(noticeRepository.increaseViewCount("missing")).thenReturn(0);
 
             // when & then
             assertThatThrownBy(() -> noticeUserService.getNoticeDetail("missing"))
                     .isInstanceOf(NoticeNotFoundException.class);
+            verify(noticeRepository, never()).findById("missing");
         }
     }
 }

--- a/src/test/java/org/project/ttokttok/domain/notice/service/NoticeUserServiceTest.java
+++ b/src/test/java/org/project/ttokttok/domain/notice/service/NoticeUserServiceTest.java
@@ -72,6 +72,24 @@ class NoticeUserServiceTest {
             assertThat(response.totalPage()).isEqualTo(3); // ceil(21 / 10)
             assertThat(response.totalCount()).isEqualTo(21);
         }
+
+        @Test
+        @DisplayName("page가 1 미만이면 1로, size가 상한(100)을 초과하면 100으로 보정하여 조회한다.")
+        void getNoticesClampsPageAndSize() {
+            // given
+            NoticePageQueryResponse queryResponse = NoticePageQueryResponse.builder()
+                    .content(List.of())
+                    .totalCount(0L)
+                    .build();
+            when(noticeRepository.searchNotices(1, 100, null)).thenReturn(queryResponse);
+
+            // when
+            NoticeListResponse response = noticeUserService.getNotices(0, 1000, null);
+
+            // then
+            assertThat(response.currentPage()).isEqualTo(1);
+            verify(noticeRepository).searchNotices(1, 100, null);
+        }
     }
 
     @Nested

--- a/src/test/java/org/project/ttokttok/domain/notice/service/NoticeUserServiceTest.java
+++ b/src/test/java/org/project/ttokttok/domain/notice/service/NoticeUserServiceTest.java
@@ -1,0 +1,112 @@
+package org.project.ttokttok.domain.notice.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.domain.notice.controller.dto.response.NoticeDetailResponse;
+import org.project.ttokttok.domain.notice.controller.dto.response.NoticeListResponse;
+import org.project.ttokttok.domain.notice.domain.Notice;
+import org.project.ttokttok.domain.notice.exception.NoticeNotFoundException;
+import org.project.ttokttok.domain.notice.repository.NoticeRepository;
+import org.project.ttokttok.domain.notice.repository.dto.NoticePageQueryResponse;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NoticeUserServiceTest {
+
+    private final NoticeRepository noticeRepository = mock(NoticeRepository.class);
+    private final NoticeUserService noticeUserService = new NoticeUserService(noticeRepository);
+
+    @Nested
+    @DisplayName("getNotices()")
+    class GetNotices {
+
+        @Test
+        @DisplayName("목록 조회 시 페이지 정보와 공지 요약 목록을 반환한다.")
+        void getNoticesSuccess() {
+            // given
+            Notice notice1 = Notice.create("제목1", "내용1");
+            Notice notice2 = Notice.create("제목2", "내용2");
+            NoticePageQueryResponse queryResponse = NoticePageQueryResponse.builder()
+                    .content(List.of(notice1, notice2))
+                    .totalCount(2L)
+                    .build();
+            when(noticeRepository.searchNotices(1, 10, null)).thenReturn(queryResponse);
+
+            // when
+            NoticeListResponse response = noticeUserService.getNotices(1, 10, null);
+
+            // then
+            assertThat(response.currentPage()).isEqualTo(1);
+            assertThat(response.totalPage()).isEqualTo(1);
+            assertThat(response.totalCount()).isEqualTo(2);
+            assertThat(response.notices()).hasSize(2);
+            assertThat(response.notices().get(0).title()).isEqualTo("제목1");
+        }
+
+        @Test
+        @DisplayName("총 건수가 페이지 크기보다 많으면 전체 페이지 수가 올림 계산된다.")
+        void getNoticesTotalPage() {
+            // given
+            NoticePageQueryResponse queryResponse = NoticePageQueryResponse.builder()
+                    .content(List.of())
+                    .totalCount(21L)
+                    .build();
+            when(noticeRepository.searchNotices(1, 10, "검색어")).thenReturn(queryResponse);
+
+            // when
+            NoticeListResponse response = noticeUserService.getNotices(1, 10, "검색어");
+
+            // then
+            assertThat(response.totalPage()).isEqualTo(3); // ceil(21 / 10)
+            assertThat(response.totalCount()).isEqualTo(21);
+        }
+    }
+
+    @Nested
+    @DisplayName("getNoticeDetail()")
+    class GetNoticeDetail {
+
+        @Test
+        @DisplayName("상세 조회 시 조회수를 증가시키고 상세 응답을 반환한다.")
+        void getNoticeDetailSuccess() {
+            // given
+            Notice notice = mock(Notice.class);
+            when(notice.getId()).thenReturn("notice-1");
+            when(notice.getTitle()).thenReturn("제목");
+            when(notice.getContent()).thenReturn("내용");
+            when(notice.getViewCount()).thenReturn(1);
+            when(noticeRepository.findById("notice-1")).thenReturn(Optional.of(notice));
+
+            // when
+            NoticeDetailResponse response = noticeUserService.getNoticeDetail("notice-1");
+
+            // then
+            verify(notice).increaseViewCount();
+            assertThat(response.noticeId()).isEqualTo("notice-1");
+            assertThat(response.content()).isEqualTo("내용");
+            assertThat(response.viewCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 공지를 조회하면 예외가 발생한다.")
+        void getNoticeDetailNotFound() {
+            // given
+            when(noticeRepository.findById("missing")).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> noticeUserService.getNoticeDetail("missing"))
+                    .isInstanceOf(NoticeNotFoundException.class);
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/notice/service/NoticeUserServiceTest.java
+++ b/src/test/java/org/project/ttokttok/domain/notice/service/NoticeUserServiceTest.java
@@ -36,8 +36,8 @@ class NoticeUserServiceTest {
         @DisplayName("목록 조회 시 페이지 정보와 공지 요약 목록을 반환한다.")
         void getNoticesSuccess() {
             // given
-            Notice notice1 = Notice.create("제목1", "내용1");
-            Notice notice2 = Notice.create("제목2", "내용2");
+            Notice notice1 = Notice.create("제목1", "내용1", "ttok_operator");
+            Notice notice2 = Notice.create("제목2", "내용2", "ttok_operator");
             NoticePageQueryResponse queryResponse = NoticePageQueryResponse.builder()
                     .content(List.of(notice1, notice2))
                     .totalCount(2L)
@@ -104,6 +104,7 @@ class NoticeUserServiceTest {
             when(notice.getId()).thenReturn("notice-1");
             when(notice.getTitle()).thenReturn("제목");
             when(notice.getContent()).thenReturn("내용");
+            when(notice.getCreatedBy()).thenReturn("ttok_operator");
             when(notice.getViewCount()).thenReturn(2); // 증가 후 재조회된 값
             when(noticeRepository.increaseViewCount("notice-1")).thenReturn(1);
             when(noticeRepository.findById("notice-1")).thenReturn(Optional.of(notice));
@@ -115,6 +116,7 @@ class NoticeUserServiceTest {
             verify(noticeRepository).increaseViewCount("notice-1");
             assertThat(response.noticeId()).isEqualTo("notice-1");
             assertThat(response.content()).isEqualTo("내용");
+            assertThat(response.createdBy()).isEqualTo("ttok_operator");
             assertThat(response.viewCount()).isEqualTo(2);
         }
 

--- a/src/test/java/org/project/ttokttok/domain/superadmin/bootstrap/SuperAdminBootstrapTest.java
+++ b/src/test/java/org/project/ttokttok/domain/superadmin/bootstrap/SuperAdminBootstrapTest.java
@@ -1,0 +1,71 @@
+package org.project.ttokttok.domain.superadmin.bootstrap;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.domain.superadmin.domain.SuperAdmin;
+import org.project.ttokttok.domain.superadmin.repository.SuperAdminRepository;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SuperAdminBootstrapTest {
+
+    private final SuperAdminRepository superAdminRepository = mock(SuperAdminRepository.class);
+    private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    @Test
+    @DisplayName("자격증명이 주어지고 계정이 없으면 운영자 계정을 생성한다.")
+    void createsWhenAbsent() {
+        // given
+        when(superAdminRepository.findByUsername("ttok_operator")).thenReturn(Optional.empty());
+        SuperAdminBootstrap bootstrap = new SuperAdminBootstrap(
+                superAdminRepository, passwordEncoder, "ttok_operator", "rawPassword");
+
+        // when
+        bootstrap.run(null);
+
+        // then
+        verify(superAdminRepository).save(any(SuperAdmin.class));
+    }
+
+    @Test
+    @DisplayName("자격증명이 비어 있으면 아무 것도 하지 않는다.")
+    void skipsWhenCredentialsBlank() {
+        // given
+        SuperAdminBootstrap bootstrap = new SuperAdminBootstrap(
+                superAdminRepository, passwordEncoder, "", "");
+
+        // when
+        bootstrap.run(null);
+
+        // then
+        verify(superAdminRepository, never()).save(any(SuperAdmin.class));
+        verify(superAdminRepository, never()).findByUsername(any());
+    }
+
+    @Test
+    @DisplayName("동일 username 운영자가 이미 존재하면 생성하지 않는다.")
+    void skipsWhenAlreadyExists() {
+        // given
+        when(superAdminRepository.findByUsername("ttok_operator"))
+                .thenReturn(Optional.of(mock(SuperAdmin.class)));
+        SuperAdminBootstrap bootstrap = new SuperAdminBootstrap(
+                superAdminRepository, passwordEncoder, "ttok_operator", "rawPassword");
+
+        // when
+        bootstrap.run(null);
+
+        // then
+        verify(superAdminRepository, never()).save(any(SuperAdmin.class));
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/superadmin/controller/SuperAdminAuthControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/superadmin/controller/SuperAdminAuthControllerTest.java
@@ -1,0 +1,43 @@
+package org.project.ttokttok.domain.superadmin.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.domain.superadmin.controller.dto.request.SuperAdminLoginRequest;
+import org.project.ttokttok.domain.superadmin.controller.dto.response.SuperAdminLoginResponse;
+import org.project.ttokttok.domain.superadmin.service.SuperAdminAuthService;
+import org.project.ttokttok.domain.superadmin.service.dto.response.SuperAdminLoginServiceResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SuperAdminAuthControllerTest {
+
+    private final SuperAdminAuthService superAdminAuthService = mock(SuperAdminAuthService.class);
+    private final SuperAdminAuthController superAdminAuthController =
+            new SuperAdminAuthController(superAdminAuthService);
+
+    @Test
+    @DisplayName("운영자 로그인 요청 시 200과 액세스/리프레시 토큰을 반환한다.")
+    void login() {
+        // given
+        when(superAdminAuthService.login(any()))
+                .thenReturn(SuperAdminLoginServiceResponse.of("access-token", "refresh-token"));
+        SuperAdminLoginRequest request = new SuperAdminLoginRequest("ttok_operator", "rawPassword");
+
+        // when
+        ResponseEntity<SuperAdminLoginResponse> response = superAdminAuthController.login(request);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().accessToken()).isEqualTo("access-token");
+        assertThat(response.getBody().refreshToken()).isEqualTo("refresh-token");
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/superadmin/domain/SuperAdminTest.java
+++ b/src/test/java/org/project/ttokttok/domain/superadmin/domain/SuperAdminTest.java
@@ -1,0 +1,48 @@
+package org.project.ttokttok.domain.superadmin.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.superadmin.exception.SuperAdminPasswordNotMatchException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SuperAdminTest {
+
+    private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    @Test
+    @DisplayName("운영자 계정을 생성하면 아이디가 설정된다.")
+    void createSuccess() {
+        // when
+        SuperAdmin superAdmin = SuperAdmin.create("ttok_operator", passwordEncoder.encode("rawPassword"));
+
+        // then
+        assertThat(superAdmin.getUsername()).isEqualTo("ttok_operator");
+    }
+
+    @Test
+    @DisplayName("올바른 비밀번호로 검증하면 예외가 발생하지 않는다.")
+    void validatePasswordSuccess() {
+        // given
+        SuperAdmin superAdmin = SuperAdmin.create("ttok_operator", passwordEncoder.encode("rawPassword"));
+
+        // when & then
+        assertThatCode(() -> superAdmin.validatePassword("rawPassword", passwordEncoder))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("잘못된 비밀번호로 검증하면 예외가 발생한다.")
+    void validatePasswordMismatch() {
+        // given
+        SuperAdmin superAdmin = SuperAdmin.create("ttok_operator", passwordEncoder.encode("rawPassword"));
+
+        // when & then
+        assertThatThrownBy(() -> superAdmin.validatePassword("wrongPassword", passwordEncoder))
+                .isInstanceOf(SuperAdminPasswordNotMatchException.class);
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/superadmin/service/SuperAdminAuthServiceTest.java
+++ b/src/test/java/org/project/ttokttok/domain/superadmin/service/SuperAdminAuthServiceTest.java
@@ -1,0 +1,96 @@
+package org.project.ttokttok.domain.superadmin.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.domain.superadmin.domain.SuperAdmin;
+import org.project.ttokttok.domain.superadmin.exception.SuperAdminNotFoundException;
+import org.project.ttokttok.domain.superadmin.exception.SuperAdminPasswordNotMatchException;
+import org.project.ttokttok.domain.superadmin.repository.SuperAdminRepository;
+import org.project.ttokttok.domain.superadmin.service.dto.request.SuperAdminLoginServiceRequest;
+import org.project.ttokttok.domain.superadmin.service.dto.response.SuperAdminLoginServiceResponse;
+import org.project.ttokttok.global.auth.jwt.dto.response.TokenResponse;
+import org.project.ttokttok.global.auth.jwt.service.TokenProvider;
+import org.project.ttokttok.infrastructure.redis.service.RefreshTokenRedisService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SuperAdminAuthServiceTest {
+
+    private final PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
+    private final SuperAdminRepository superAdminRepository = mock(SuperAdminRepository.class);
+    private final TokenProvider tokenProvider = mock(TokenProvider.class);
+    private final RefreshTokenRedisService refreshTokenRedisService = mock(RefreshTokenRedisService.class);
+    private final SuperAdminAuthService superAdminAuthService =
+            new SuperAdminAuthService(passwordEncoder, superAdminRepository, tokenProvider, refreshTokenRedisService);
+
+    @Test
+    @DisplayName("운영자 로그인에 성공하면 토큰을 반환하고 리프레시 토큰을 저장한다.")
+    void loginSuccess() {
+        // given
+        SuperAdmin superAdmin = mock(SuperAdmin.class);
+        when(superAdmin.getUsername()).thenReturn("ttok_operator");
+        when(superAdminRepository.findByUsername("ttok_operator")).thenReturn(Optional.of(superAdmin));
+        when(tokenProvider.generateToken(any())).thenReturn(TokenResponse.of("access-token", "refresh-token"));
+
+        SuperAdminLoginServiceRequest request = SuperAdminLoginServiceRequest.builder()
+                .username("ttok_operator")
+                .password("rawPassword")
+                .build();
+
+        // when
+        SuperAdminLoginServiceResponse response = superAdminAuthService.login(request);
+
+        // then
+        assertThat(response.accessToken()).isEqualTo("access-token");
+        assertThat(response.refreshToken()).isEqualTo("refresh-token");
+        verify(superAdmin).validatePassword("rawPassword", passwordEncoder);
+        verify(refreshTokenRedisService).save("ttok_operator", "refresh-token");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 운영자로 로그인하면 예외가 발생한다.")
+    void loginNotFound() {
+        // given
+        when(superAdminRepository.findByUsername("missing")).thenReturn(Optional.empty());
+
+        SuperAdminLoginServiceRequest request = SuperAdminLoginServiceRequest.builder()
+                .username("missing")
+                .password("rawPassword")
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> superAdminAuthService.login(request))
+                .isInstanceOf(SuperAdminNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("비밀번호가 일치하지 않으면 예외가 발생한다.")
+    void loginPasswordMismatch() {
+        // given
+        SuperAdmin superAdmin = mock(SuperAdmin.class);
+        doThrow(new SuperAdminPasswordNotMatchException())
+                .when(superAdmin).validatePassword("wrongPassword", passwordEncoder);
+        when(superAdminRepository.findByUsername("ttok_operator")).thenReturn(Optional.of(superAdmin));
+
+        SuperAdminLoginServiceRequest request = SuperAdminLoginServiceRequest.builder()
+                .username("ttok_operator")
+                .password("wrongPassword")
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> superAdminAuthService.login(request))
+                .isInstanceOf(SuperAdminPasswordNotMatchException.class);
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용
- 서비스 전역 **공지사항** 저장/목록/상세 API 신규 구현 (`domain/notice`, 특정 동아리에 종속되지 않는 전역 엔티티, 텍스트 전용)
  - 저장 `POST /api/super-admin/notices` (운영자 전용)
  - 목록 `GET /api/notices` (페이지 번호 + `totalCount` + 제목 `keyword` 검색, 비로그인 공개)
  - 상세 `GET /api/notices/{noticeId}` (조회 시 조회수 증가, 비로그인 공개)
- 공지 작성 주체가 동아리 관리자가 아니므로 **운영자 전용 역할 `ROLE_SUPER_ADMIN` 신설** 및 별도 `SuperAdmin` 계정/로그인(`POST /api/super-admin/login`) 추가
  - `SecurityConfig`: `/api/super-admin/**` → `hasRole("SUPER_ADMIN")`, `/api/notices` GET → 공개
- **Swagger 문서**, **DB 마이그레이션**(`super_admins`, `notices` — `db/migration/V21`, `V22`) 포함

### 🔒 프로덕션 리뷰 반영 (추가 커밋)
운영 배포 관점(성능/동시성/보안/관측) 리뷰 후 아래를 반영했습니다.
- **[동시성] 조회수 원자적 증가**: `viewCount++`(read-modify-write) → `@Modifying UPDATE ... view_count + 1`로 변경해 동시 조회 시 조회수 유실 제거.
- **[보안/안정성] 목록 파라미터 검증**: 공개 엔드포인트의 `page`는 최소 1, `size`는 1~100으로 clamp(음수/0/과대 size로 인한 5xx·대량조회 방지).
- **[성능] 인덱스 추가**: `notices(created_at DESC, id DESC)` 인덱스로 정렬/페이지네이션 비용 완화.
- **[관측/보안] 작성자 추적**: `notices.created_by`(운영자 username) 저장 + 생성 감사 로그.
- **[보안] 운영자 자격증명 비커밋화**: 저장소에 있던 운영자 시드(공개 해시)를 제거하고, 앱 시작 시 `SUPER_ADMIN_USERNAME`/`SUPER_ADMIN_PASSWORD` 환경변수로 계정을 멱등 생성하는 `SuperAdminBootstrap`으로 전환.

---

## 🔍 관련 이슈
- 해결한 이슈 번호: #331

---

## ✅ 체크리스트
- [ ] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요? (`bash maintenance/verify.sh` 그린 — 전체 테스트 + JaCoCo 80% 커버리지 게이트 통과)
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항
- **운영자 계정 발급 (필수)**: 시드가 제거되었으므로 배포 환경에 `SUPER_ADMIN_USERNAME` / `SUPER_ADMIN_PASSWORD`(시크릿)를 주입해야 운영자 계정이 생성됩니다. 미설정 시 부트스트랩은 건너뛰며(로컬/CI 안전), 계정이 없으면 공지 작성이 불가합니다. 로컬 개발은 `application-dev.yml`(gitignored)에 `super.admin.username/password`로 넣으면 됩니다.
- ⚠️ **Flyway 주의**: dev 프로파일은 `classpath:db/seed`만 스캔하고 `db/migration`은 baseline(10) 처리됩니다. 신규 테이블 DDL은 tracked 위치인 `db/migration`(V21·V22)에 두었으므로, **dev에 실제 반영하려면** 마이그레이션을 수동 실행하거나 dev Flyway location에 `db/migration`을 포함해야 합니다. (테스트는 `ddl-auto: create-drop`로 검증됨)
- **범위 밖(후속 이슈 권장)**: 공지 수정·삭제 API, 본문 XSS sanitize 정책(H1), 로그인 브루트포스 방어(H4), Redis 장애 시 degrade 전략(H3).
- **커밋 구성**: ①운영자 역할/인증 기반 ②공지 기능 ③단위 테스트 ④조회수 원자화 ⑤page/size 검증 ⑥인덱스 ⑦작성자/감사로그 ⑧운영자 부트스트랩.
