### PR TITLE
gitignore된 로컬 전용 설정 파일 보호 rule 추가 (chore/#333 -> develop)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,6 +215,7 @@ Detailed, situational rules live under [`rules/`](rules/) — common agent rules
 - **Commit messages** → [`rules/agent/commit-message.md`](rules/agent/commit-message.md)
 - **Branches** → [`rules/agent/branch-naming.md`](rules/agent/branch-naming.md)
 - **PR titles** → [`rules/agent/pr-title.md`](rules/agent/pr-title.md)
+- **Protected local-only files** → [`rules/agent/protected-local-files.md`](rules/agent/protected-local-files.md)
 
 ---
 
@@ -225,6 +226,7 @@ Detailed, situational rules live under [`rules/`](rules/) — common agent rules
 3. **No Primitive Obsession** - avoid overusing primitive types; use Value Objects.
 4. **No tight coupling** - keep loose coupling through interfaces.
 5. **No business logic in Controllers.**
+6. **Never delete gitignored local-only config** - do not delete/move/overwrite/`git clean` `application*.yml`, Firebase `*.json`, or `db/seed/**` (unrecoverable from git). See [`rules/agent/protected-local-files.md`](rules/agent/protected-local-files.md).
 
 ---
 

--- a/rules/agent/protected-local-files.md
+++ b/rules/agent/protected-local-files.md
@@ -1,0 +1,17 @@
+# Rule: Protected Local-Only Config Files
+
+> Indexed from [`AGENTS.md`](../../AGENTS.md). These files are `.gitignore`d and exist only on disk (and in the CI / GitHub Actions secret store). Git never versions them, so a deletion is **unrecoverable** via git history.
+
+## Never delete, move, overwrite, or `git clean` these
+
+- `src/main/resources/application.yml`, `application-local.yml`, `application-dev.yml`, `application-prod.yml`
+- `src/test/resources/application.yml`, `application-*.yml`
+- the Firebase service-account `*.json` key (e.g. `src/main/resources/*firebase*.json`)
+- `src/main/resources/db/seed/**`
+
+## Rules
+
+- Treat these files as **read-only** unless the user explicitly asks to change them.
+- When restoring or copying them (e.g. into a git worktree), only copy **in**, and **refuse to overwrite** an existing target.
+- If one appears missing, **investigate first** — it may be absent from `src` by design and materialized at CI build time from a GitHub Actions secret — rather than assuming loss or recreating it blindly.
+- Never edit `.gitignore` to make these trackable; they stay untracked by design (secrets / local fixtures).


### PR DESCRIPTION
## ✨ 작업 내용
- gitignore된 **로컬 전용 설정 파일**의 실수 삭제 방지 rule 추가
  - `rules/agent/protected-local-files.md`(English) 신규 — 보호 대상(`application*.yml`, Firebase `*.json`, `db/seed/**`)과 금지 행위(삭제·이동·덮어쓰기·`git clean`), "없어 보이면 조사 먼저" 지침 명시
  - `AGENTS.md` Git Conventions rule 인덱스 및 Prohibitions에 포인터 연결
- Swagger/DB 변경 없음 (문서 전용)

---

## 🔍 관련 이슈
- 해결한 이슈 번호: #333

---

## ✅ 체크리스트
- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요? (`bash maintenance/verify.sh` 그린 — 문서 전용 변경)
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항
- 이 파일들은 git에 버전 관리되지 않아 삭제 시 복구가 불가능하며, 실제로는 CI(GitHub Actions) 시크릿에서 빌드 시 생성되기도 하므로 "손실로 단정하지 말고 조사 먼저" 지침을 포함했습니다.
- 런타임 코드 영향 없음.
