### PR TITLE
Google OAuth 로그인 기능 추가 (feat/#335 -> develop)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	// Google ID 토큰 검증 (JWKS 기반, resource-server 스타터는 필터체인 오염 방지를 위해 미사용)
+	implementation 'org.springframework.security:spring-security-oauth2-jose'
+
 	//Querydsl
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"

--- a/src/main/java/org/project/ttokttok/domain/user/controller/UserOAuthController.java
+++ b/src/main/java/org/project/ttokttok/domain/user/controller/UserOAuthController.java
@@ -1,0 +1,64 @@
+package org.project.ttokttok.domain.user.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.project.ttokttok.domain.user.controller.docs.UserOAuthDocs;
+import org.project.ttokttok.domain.user.controller.dto.request.GoogleLoginRequest;
+import org.project.ttokttok.domain.user.controller.dto.request.GoogleOnboardingCompleteRequest;
+import org.project.ttokttok.domain.user.controller.dto.response.ApiResponse;
+import org.project.ttokttok.domain.user.controller.dto.response.GoogleLoginResponse;
+import org.project.ttokttok.domain.user.controller.dto.response.LoginResponse;
+import org.project.ttokttok.domain.user.service.GoogleOAuthService;
+import org.project.ttokttok.domain.user.service.dto.response.GoogleLoginServiceResponse;
+import org.project.ttokttok.domain.user.service.dto.response.LoginServiceResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/user/auth/oauth")
+@RequiredArgsConstructor
+public class UserOAuthController implements UserOAuthDocs {
+
+    private final GoogleOAuthService googleOAuthService;
+
+    /**
+     * 구글 로그인 API
+     * 구글 ID 토큰을 검증하고 로그인(기존/자동연동) 또는 온보딩 안내(신규)를 처리합니다.
+     */
+    @Override
+    @PostMapping("/google")
+    public ResponseEntity<ApiResponse<GoogleLoginResponse>> googleLogin(
+            @RequestBody @Valid GoogleLoginRequest request) {
+
+        GoogleLoginServiceResponse serviceResponse = googleOAuthService.login(request.idToken());
+
+        String message = serviceResponse.needsOnboarding()
+                ? "약관 동의가 필요합니다."
+                : "로그인에 성공했습니다.";
+
+        return ResponseEntity.ok(
+                ApiResponse.success(message, GoogleLoginResponse.from(serviceResponse))
+        );
+    }
+
+    /**
+     * 구글 온보딩 완료 API
+     * 약관 동의 및 이름 입력을 받아 회원가입을 완료하고 토큰을 발급합니다.
+     */
+    @Override
+    @PostMapping("/google/complete")
+    public ResponseEntity<ApiResponse<LoginResponse>> completeOnboarding(
+            @RequestBody @Valid GoogleOnboardingCompleteRequest request) {
+
+        LoginServiceResponse serviceResponse = googleOAuthService.completeOnboarding(request.toServiceRequest());
+
+        return ResponseEntity.ok(
+                ApiResponse.success("회원가입 및 로그인에 성공했습니다.", LoginResponse.from(serviceResponse))
+        );
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/user/controller/docs/UserOAuthDocs.java
+++ b/src/main/java/org/project/ttokttok/domain/user/controller/docs/UserOAuthDocs.java
@@ -1,0 +1,74 @@
+package org.project.ttokttok.domain.user.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.project.ttokttok.domain.user.controller.dto.request.GoogleLoginRequest;
+import org.project.ttokttok.domain.user.controller.dto.request.GoogleOnboardingCompleteRequest;
+import org.project.ttokttok.domain.user.controller.dto.response.ApiResponse;
+import org.project.ttokttok.domain.user.controller.dto.response.GoogleLoginResponse;
+import org.project.ttokttok.domain.user.controller.dto.response.LoginResponse;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "[사용자] 구글 OAuth 인증", description = "구글 ID 토큰 기반 로그인 및 온보딩(약관 동의) API")
+public interface UserOAuthDocs {
+
+    @Operation(
+            summary = "구글 로그인",
+            description = """
+                    프론트엔드가 Google Identity Services 로 발급받은 구글 ID 토큰을 검증하고 로그인을 처리합니다.
+
+                    - 기존 사용자(또는 이메일 일치로 자동 연동된 사용자): needsOnboarding=false + 액세스/리프레시 토큰 반환
+                    - 신규 사용자: needsOnboarding=true + 온보딩 토큰(10분 유효) 반환 → 약관 동의 후 완료 API 호출 필요
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "로그인 성공 또는 온보딩 필요 (needsOnboarding 필드로 구분)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "구글 계정의 이메일이 검증되지 않음"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "유효하지 않은 구글 ID 토큰 (서명/만료/발급자/대상 불일치)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "이미 다른 구글 계정과 연동된 이메일"
+            )
+    })
+    ResponseEntity<ApiResponse<GoogleLoginResponse>> googleLogin(@Valid GoogleLoginRequest request);
+
+    @Operation(
+            summary = "구글 온보딩 완료 (약관 동의 후 가입)",
+            description = """
+                    구글 로그인 응답으로 받은 온보딩 토큰과 약관 동의, 이름을 받아 회원가입을 완료하고 토큰을 발급합니다.
+
+                    - 온보딩 토큰은 10분간 유효하며 일회성입니다 (재요청 시 이미 가입된 경우 정상 로그인 처리)
+                    - 만료 시 구글 로그인부터 다시 시작해야 합니다
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "가입 완료 및 로그인 성공 (기존 로그인 응답과 동일)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "약관 미동의 또는 이름 유효성 검사 실패"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "온보딩 토큰이 만료되었거나 유효하지 않음"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "이미 처리된 가입 요청 (계정 없음 - 이상 상태)"
+            )
+    })
+    ResponseEntity<ApiResponse<LoginResponse>> completeOnboarding(@Valid GoogleOnboardingCompleteRequest request);
+}

--- a/src/main/java/org/project/ttokttok/domain/user/controller/dto/request/GoogleLoginRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/user/controller/dto/request/GoogleLoginRequest.java
@@ -1,0 +1,12 @@
+package org.project.ttokttok.domain.user.controller.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "구글 로그인 요청")
+public record GoogleLoginRequest(
+        @Schema(description = "구글 ID 토큰 (Google Identity Services 발급)", example = "eyJhbGciOiJSUzI1NiIs...")
+        @NotBlank(message = "구글 ID 토큰은 필수입니다.")
+        String idToken
+) {
+}

--- a/src/main/java/org/project/ttokttok/domain/user/controller/dto/request/GoogleOnboardingCompleteRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/user/controller/dto/request/GoogleOnboardingCompleteRequest.java
@@ -1,0 +1,25 @@
+package org.project.ttokttok.domain.user.controller.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import org.project.ttokttok.domain.user.service.dto.request.GoogleOnboardingCompleteServiceRequest;
+
+@Schema(description = "구글 온보딩 완료 요청 (약관 동의 + 이름 입력)")
+public record GoogleOnboardingCompleteRequest(
+        @Schema(description = "구글 로그인 응답으로 받은 온보딩 토큰 (10분 유효)")
+        @NotBlank(message = "온보딩 토큰은 필수입니다.")
+        String onboardingToken,
+
+        @Schema(description = "약관 동의 여부 (true 필수)", example = "true")
+        boolean termsAgreed,
+
+        @Schema(description = "사용자 이름 (2~10자)", example = "김철수")
+        @NotBlank(message = "이름은 필수입니다.")
+        @Size(min = 2, max = 10, message = "이름은 2자 이상 10자 이하여야 합니다.")
+        String name
+) {
+    public GoogleOnboardingCompleteServiceRequest toServiceRequest() {
+        return GoogleOnboardingCompleteServiceRequest.of(onboardingToken, termsAgreed, name);
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/user/controller/dto/response/GoogleLoginResponse.java
+++ b/src/main/java/org/project/ttokttok/domain/user/controller/dto/response/GoogleLoginResponse.java
@@ -1,0 +1,47 @@
+package org.project.ttokttok.domain.user.controller.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import org.project.ttokttok.domain.user.service.dto.response.GoogleLoginServiceResponse;
+import org.project.ttokttok.domain.user.service.dto.response.UserServiceResponse;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "구글 로그인 응답 (needsOnboarding 값에 따라 로그인 완료 또는 온보딩 필요)")
+public record GoogleLoginResponse(
+        @Schema(description = "온보딩(약관 동의) 필요 여부", example = "false")
+        boolean needsOnboarding,
+
+        @Schema(description = "액세스 토큰 (로그인 완료 시)")
+        String accessToken,
+
+        @Schema(description = "리프레시 토큰 (로그인 완료 시)")
+        String refreshToken,
+
+        @Schema(description = "사용자 정보 (로그인 완료 시)")
+        UserResponse user,
+
+        @Schema(description = "온보딩 토큰 (온보딩 필요 시, 10분 유효)")
+        String onboardingToken,
+
+        @Schema(description = "구글 계정 이메일 (온보딩 필요 시)")
+        String email,
+
+        @Schema(description = "구글 프로필 이름 제안값 (온보딩 필요 시, 없을 수 있음)")
+        String suggestedName
+) {
+    public static GoogleLoginResponse from(final GoogleLoginServiceResponse serviceResponse) {
+        UserServiceResponse serviceUser = serviceResponse.user();
+
+        return GoogleLoginResponse.builder()
+                .needsOnboarding(serviceResponse.needsOnboarding())
+                .accessToken(serviceResponse.accessToken())
+                .refreshToken(serviceResponse.refreshToken())
+                .user(serviceUser == null ? null : UserResponse.from(serviceUser))
+                .onboardingToken(serviceResponse.onboardingToken())
+                .email(serviceResponse.email())
+                .suggestedName(serviceResponse.suggestedName())
+                .build();
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/user/domain/User.java
+++ b/src/main/java/org/project/ttokttok/domain/user/domain/User.java
@@ -5,6 +5,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.project.ttokttok.domain.user.domain.enums.AuthProvider;
+import org.project.ttokttok.domain.user.exception.GoogleAccountConflictException;
 import org.project.ttokttok.global.entity.BaseTimeEntity;
 
 /**
@@ -12,7 +14,10 @@ import org.project.ttokttok.global.entity.BaseTimeEntity;
  * 객체의 불변성을 유지하고 의미 있는 비즈니스 메서드를 통해 상태를 관리합니다.
  */
 @Entity
-@Table(name = "users")
+@Table(name = "users", uniqueConstraints = {
+        // 동일 구글 계정(sub)이 두 사용자 행에 연결되는 것을 방지 (Flyway V23와 동일, H2 테스트 스키마용)
+        @UniqueConstraint(name = "uk_users_provider_provider_id", columnNames = {"provider", "provider_id"})
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseTimeEntity {
@@ -25,7 +30,8 @@ public class User extends BaseTimeEntity {
     @Column(unique = true, nullable = false, updatable = false)
     private String email;
 
-    @Column(nullable = false)
+    // OAuth 전용 계정은 비밀번호가 없으므로 NULL 허용 (V23 마이그레이션)
+    @Column
     private String password;
 
     @Column(nullable = false)
@@ -37,10 +43,19 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private boolean termsAgreed;
 
+    // 인증 제공자 (LOCAL: 이메일+비밀번호, GOOGLE: 구글 OAuth)
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private AuthProvider provider = AuthProvider.LOCAL;
+
+    // 구글 sub (불변 식별자). 이메일은 구글 측에서 변경될 수 있으므로 sub 로 식별한다.
+    @Column(name = "provider_id")
+    private String providerId;
+
     @Builder(access = AccessLevel.PRIVATE)
-    private User(String email, String password, String name, boolean isEmailVerified, boolean termsAgreed) {
-        validateEmail(email);
-        validatePassword(password);
+    private User(String email, String password, String name, boolean isEmailVerified,
+                 boolean termsAgreed, AuthProvider provider, String providerId) {
+        validateEmailFormat(email);
         validateName(name);
 
         this.email = email;
@@ -48,12 +63,14 @@ public class User extends BaseTimeEntity {
         this.name = name;
         this.isEmailVerified = isEmailVerified;
         this.termsAgreed = termsAgreed;
+        this.provider = provider;
+        this.providerId = providerId;
     }
 
     /**
-     * 회원가입을 위한 정적 팩토리 메서드
-     * 
-     * @param email 가입 이메일
+     * 회원가입을 위한 정적 팩토리 메서드 (이메일+비밀번호 가입)
+     *
+     * @param email 가입 이메일 (상명대 이메일만 허용)
      * @param encodedPassword 암호화된 비밀번호
      * @param name 사용자 이름
      * @param termsAgreed 약관 동의 여부
@@ -63,19 +80,74 @@ public class User extends BaseTimeEntity {
         if (!termsAgreed) {
             throw new IllegalArgumentException("약관 동의가 필요합니다.");
         }
-        
+        validateSangmyungEmail(email);
+        validatePassword(encodedPassword);
+
         return User.builder()
                 .email(email)
                 .password(encodedPassword)
                 .name(name)
                 .isEmailVerified(true) // 가입 시점에 인증 완료 상태여야 함
                 .termsAgreed(true)
+                .provider(AuthProvider.LOCAL)
                 .build();
     }
 
     /**
+     * 구글 OAuth 가입을 위한 정적 팩토리 메서드
+     * 구글이 이메일을 검증하므로 도메인 제한 없이 허용하고, 비밀번호는 존재하지 않는다.
+     *
+     * @param email 구글 계정 이메일 (email_verified=true 검증 완료 전제)
+     * @param name 사용자 이름 (온보딩 화면에서 입력받은 값)
+     * @param providerId 구글 sub (불변 식별자)
+     * @return 생성된 User 객체
+     */
+    public static User signUpWithGoogle(String email, String name, String providerId) {
+        if (providerId == null || providerId.isBlank()) {
+            throw new IllegalArgumentException("구글 식별자(sub)는 필수입니다.");
+        }
+
+        return User.builder()
+                .email(email)
+                .password(null) // OAuth 전용 계정
+                .name(name)
+                .isEmailVerified(true) // 구글이 이메일 검증을 보증
+                .termsAgreed(true) // 온보딩 완료 API 에서 동의 검증 후 호출
+                .provider(AuthProvider.GOOGLE)
+                .providerId(providerId)
+                .build();
+    }
+
+    /**
+     * 기존 계정에 구글 계정을 연동한다. (같은 sub 재연동은 멱등 처리)
+     *
+     * @param sub 구글 sub (불변 식별자)
+     * @throws GoogleAccountConflictException 이미 다른 구글 계정과 연동된 경우
+     */
+    public void linkGoogle(String sub) {
+        if (this.providerId != null) {
+            if (this.providerId.equals(sub)) {
+                return; // 이미 같은 구글 계정과 연동됨 (멱등)
+            }
+            throw new GoogleAccountConflictException();
+        }
+
+        this.provider = AuthProvider.GOOGLE;
+        this.providerId = sub;
+        // 구글 검증 이메일 기반 연동이므로 미인증 상태라면 방어적으로 인증 처리
+        this.isEmailVerified = true;
+    }
+
+    /**
+     * OAuth 전용 계정 여부 (비밀번호 로그인 불가)
+     */
+    public boolean isOAuthOnly() {
+        return this.password == null;
+    }
+
+    /**
      * 비밀번호 업데이트 비즈니스 메서드
-     * 
+     *
      * @param encodedPassword 암호화된 새 비밀번호
      */
     public void updatePassword(String encodedPassword) {
@@ -95,18 +167,23 @@ public class User extends BaseTimeEntity {
 
     // --- 내부 검증 로직 (Rich Domain Model의 핵심) ---
 
-    private void validateEmail(String email) {
+    private static void validateEmailFormat(String email) {
         if (email == null || email.isBlank()) {
             throw new IllegalArgumentException("이메일은 필수입니다.");
         }
-    
+    }
+
+    // 이메일+비밀번호 가입 경로에만 적용되는 상명대 도메인 제한
+    private static void validateSangmyungEmail(String email) {
+        validateEmailFormat(email);
+
         // 나중에 수정 - 상명대 이메일 정규식
         if (!email.toLowerCase().endsWith("@sangmyung.kr")) {
             throw new IllegalArgumentException("올바른 이메일 형식이 아닙니다.");
         }
     }
 
-    private void validatePassword(String password) {
+    private static void validatePassword(String password) {
         if (password == null || password.isBlank()) {
             throw new IllegalArgumentException("비밀번호는 필수입니다.");
         }

--- a/src/main/java/org/project/ttokttok/domain/user/domain/enums/AuthProvider.java
+++ b/src/main/java/org/project/ttokttok/domain/user/domain/enums/AuthProvider.java
@@ -1,0 +1,10 @@
+package org.project.ttokttok.domain.user.domain.enums;
+
+/**
+ * 사용자 계정의 인증 제공자
+ * LOCAL: 이메일+비밀번호 가입, GOOGLE: Google OAuth 가입/연동
+ */
+public enum AuthProvider {
+    LOCAL,
+    GOOGLE
+}

--- a/src/main/java/org/project/ttokttok/domain/user/exception/GoogleAccountConflictException.java
+++ b/src/main/java/org/project/ttokttok/domain/user/exception/GoogleAccountConflictException.java
@@ -1,0 +1,10 @@
+package org.project.ttokttok.domain.user.exception;
+
+import org.project.ttokttok.global.exception.ErrorMessage;
+import org.project.ttokttok.global.exception.exception.CustomException;
+
+public class GoogleAccountConflictException extends CustomException {
+    public GoogleAccountConflictException() {
+        super(ErrorMessage.GOOGLE_ACCOUNT_CONFLICT);
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/user/exception/OAuthOnlyAccountException.java
+++ b/src/main/java/org/project/ttokttok/domain/user/exception/OAuthOnlyAccountException.java
@@ -1,0 +1,10 @@
+package org.project.ttokttok.domain.user.exception;
+
+import org.project.ttokttok.global.exception.ErrorMessage;
+import org.project.ttokttok.global.exception.exception.CustomException;
+
+public class OAuthOnlyAccountException extends CustomException {
+    public OAuthOnlyAccountException() {
+        super(ErrorMessage.OAUTH_ONLY_ACCOUNT);
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/user/exception/OnboardingAlreadyCompletedException.java
+++ b/src/main/java/org/project/ttokttok/domain/user/exception/OnboardingAlreadyCompletedException.java
@@ -1,0 +1,10 @@
+package org.project.ttokttok.domain.user.exception;
+
+import org.project.ttokttok.global.exception.ErrorMessage;
+import org.project.ttokttok.global.exception.exception.CustomException;
+
+public class OnboardingAlreadyCompletedException extends CustomException {
+    public OnboardingAlreadyCompletedException() {
+        super(ErrorMessage.ONBOARDING_ALREADY_COMPLETED);
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/project/ttokttok/domain/user/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package org.project.ttokttok.domain.user.repository;
 
 import org.project.ttokttok.domain.user.domain.User;
+import org.project.ttokttok.domain.user.domain.enums.AuthProvider;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +9,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, String> {
     Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
+    Optional<User> findByProviderAndProviderId(AuthProvider provider, String providerId);
 }

--- a/src/main/java/org/project/ttokttok/domain/user/service/GoogleAccountWriter.java
+++ b/src/main/java/org/project/ttokttok/domain/user/service/GoogleAccountWriter.java
@@ -1,0 +1,68 @@
+package org.project.ttokttok.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.project.ttokttok.domain.user.domain.User;
+import org.project.ttokttok.domain.user.domain.enums.AuthProvider;
+import org.project.ttokttok.domain.user.repository.UserRepository;
+import org.project.ttokttok.global.auth.jwt.service.OnboardingTokenProvider.OnboardingClaims;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * 구글 계정 생성/연동 DB 쓰기 전용 컴포넌트
+ *
+ * 오케스트레이터({@link GoogleOAuthService})와 분리된 별도 빈으로 둠으로써
+ * 각 메서드가 독립된 트랜잭션 경계를 갖는다. 이 경계 덕분에:
+ * 1) 유니크 제약 위반 시 {@code saveAndFlush}가 이 트랜잭션 안에서 예외를 확정 발생시키고,
+ * 2) 해당 트랜잭션이 롤백된 뒤 예외가 호출부로 전파되어,
+ * 3) 오케스트레이터가 트랜잭션 밖에서 catch 후 새 트랜잭션으로 승자(winner)를 재조회할 수 있다.
+ *
+ * (self-invocation 은 프록시를 우회해 새 트랜잭션이 열리지 않으므로 반드시 별도 빈이어야 한다.)
+ */
+@Component
+@RequiredArgsConstructor
+public class GoogleAccountWriter {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 온보딩 완료 시점에 구글 계정을 생성한다. (트랜잭션 경계 = 이 메서드)
+     * 토큰 발급과 완료 사이의 상태 변화를 재확인한다: 이미 가입됐으면 그 계정, 같은 이메일의
+     * 로컬 계정이 생겼으면 자동 연동, 아니면 신규 가입.
+     *
+     * @throws DataIntegrityViolationException 동시 가입 경쟁 시 (호출부에서 멱등 복구)
+     */
+    @Transactional
+    public User createGoogleUser(OnboardingClaims claims, String name) {
+        Optional<User> bySub = userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, claims.sub());
+        if (bySub.isPresent()) {
+            return bySub.get();
+        }
+
+        Optional<User> byEmail = userRepository.findByEmail(claims.email());
+        if (byEmail.isPresent()) {
+            User existing = byEmail.get();
+            existing.linkGoogle(claims.sub());
+            return userRepository.saveAndFlush(existing);
+        }
+
+        return userRepository.saveAndFlush(User.signUpWithGoogle(claims.email(), name, claims.sub()));
+    }
+
+    /**
+     * 기존 이메일 계정에 구글 계정을 연동한다. (트랜잭션 경계 = 이 메서드)
+     * 관리 상태 엔티티를 다루기 위해 트랜잭션 내부에서 재조회 후 연동한다.
+     *
+     * @throws DataIntegrityViolationException 병렬 연동 경쟁 시 (호출부에서 멱등 복구)
+     */
+    @Transactional
+    public User autoLink(String email, String sub) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalStateException("연동 대상 사용자가 존재하지 않습니다: " + email));
+        user.linkGoogle(sub); // 다른 sub 와 이미 연동 시 GoogleAccountConflictException
+        return userRepository.saveAndFlush(user);
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/user/service/GoogleOAuthService.java
+++ b/src/main/java/org/project/ttokttok/domain/user/service/GoogleOAuthService.java
@@ -23,27 +23,29 @@ import org.project.ttokttok.infrastructure.redis.service.OnboardingTokenRedisSer
 import org.project.ttokttok.infrastructure.redis.service.RefreshTokenRedisService;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 import static org.project.ttokttok.global.entity.Role.ROLE_USER;
 
 /**
- * 구글 OAuth 로그인 서비스
+ * 구글 OAuth 로그인 오케스트레이터
  *
- * 1) 구글 ID 토큰 검증 후 sub(불변 식별자) 우선, email 차선으로 사용자를 조회하여 로그인/자동연동 처리
- * 2) 신규 사용자는 계정을 만들지 않고 10분 TTL 온보딩 토큰 발급 (약관 동의 화면으로 유도)
- * 3) 온보딩 완료 시 SETNX(jti) + DB 유니크 제약 + 멱등 재조회의 3중 방어로
- *    재생(replay)/동시 요청(두 탭) 경쟁을 "로그인 성공"으로 수렴시킨다
+ * 이 클래스는 <b>트랜잭션을 열지 않는다</b>. 외부 호출(ID 토큰 검증)과 조회를 트랜잭션 밖에서 수행하여
+ * DB 커넥션이 네트워크 대기에 묶이지 않게 하고(P1-2), DB 쓰기는 별도 트랜잭션 빈
+ * {@link GoogleAccountWriter}에 위임한다. 유니크 제약 위반은 writer 트랜잭션이 롤백된 뒤
+ * 이 클래스의 catch(트랜잭션 밖)로 전파되므로, 새 트랜잭션으로 승자(winner)를 재조회해 멱등 처리한다(P1-1).
+ *
+ * 동시성 방어: SETNX(jti) + DB 유니크 제약 + DataIntegrityViolationException 멱등 재조회의 3중 방어로
+ * 재생(replay)/동시 요청(두 탭) 경쟁을 "로그인 성공"으로 수렴시킨다.
  */
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class GoogleOAuthService {
 
     private final UserRepository userRepository;
+    private final GoogleAccountWriter googleAccountWriter;
     private final GoogleIdTokenVerifier googleIdTokenVerifier;
     private final TokenProvider tokenProvider;
     private final OnboardingTokenProvider onboardingTokenProvider;
@@ -58,7 +60,7 @@ public class GoogleOAuthService {
      * @throws GoogleEmailNotVerifiedException 구글 측 이메일 미검증 시 (자동 연동 = 계정 탈취 벡터 차단)
      */
     public GoogleLoginServiceResponse login(String idToken) {
-        // 1-1. 구글 ID 토큰 검증 (서명/iss/aud/exp)
+        // 1-1. 구글 ID 토큰 검증 (서명/iss/aud/exp) - 트랜잭션 밖 외부 호출
         GoogleUserInfo userInfo = googleIdTokenVerifier.verify(idToken);
 
         // 1-2. 미검증 이메일 거부 - 검증되지 않은 이메일로 자동 연동하면 계정 탈취 가능
@@ -67,13 +69,12 @@ public class GoogleOAuthService {
         // 1-3. sub 우선 조회 (구글 이메일이 변경되어도 로그인 유지)
         Optional<User> bySub = userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, userInfo.sub());
         if (bySub.isPresent()) {
-            return loginExistingUser(bySub.get());
+            return GoogleLoginServiceResponse.ofLogin(issueTokenResponse(bySub.get()), userServiceResponse(bySub.get()));
         }
 
         // 1-4. email 차선 조회 - 기존 계정이면 자동 연동
-        Optional<User> byEmail = userRepository.findByEmail(userInfo.email());
-        if (byEmail.isPresent()) {
-            return autoLink(byEmail.get(), userInfo.sub());
+        if (userRepository.findByEmail(userInfo.email()).isPresent()) {
+            return autoLink(userInfo.email(), userInfo.sub());
         }
 
         // 1-5. 신규 사용자 - 계정을 만들지 않고 온보딩 토큰 발급
@@ -102,35 +103,31 @@ public class GoogleOAuthService {
             return loginIfAlreadyCompleted(claims.sub());
         }
 
-        // 2-4. 토큰 발급 사이 상태 변화 재확인 후 가입 (동시성 방어)
-        User user = findOrSignUp(claims, request.name());
+        // 2-4. 계정 생성 위임 (트랜잭션 경계는 writer). 동시 가입 경쟁은 catch 에서 멱등 복구
+        // 충돌 후 sub 로 승자가 조회되면 멱등 로그인, 조회되지 않으면 이메일을 다른 계정이 선점한 것 → 충돌
+        User user;
+        try {
+            user = googleAccountWriter.createGoogleUser(claims, request.name());
+        } catch (DataIntegrityViolationException e) {
+            user = recoverBySub(claims.sub(), GoogleAccountConflictException::new);
+        }
 
         log.info("구글 온보딩 가입 완료: {}", user.getEmail());
         return issueTokens(user);
     }
 
-    // 기존 사용자 로그인 처리
-    private GoogleLoginServiceResponse loginExistingUser(User user) {
-        LoginServiceResponse login = issueTokens(user);
-        log.info("구글 로그인 성공: {}", user.getEmail());
-        return GoogleLoginServiceResponse.ofLogin(
-                TokenResponse.of(login.accessToken(), login.refreshToken()), login.user());
-    }
-
-    // 기존 이메일 계정에 구글 계정 자동 연동
-    private GoogleLoginServiceResponse autoLink(User user, String sub) {
+    // 기존 이메일 계정에 구글 계정 자동 연동 (writer 트랜잭션 밖에서 충돌 복구)
+    private GoogleLoginServiceResponse autoLink(String email, String sub) {
+        User user;
         try {
-            user.linkGoogle(sub); // 다른 sub 와 이미 연동 시 GoogleAccountConflictException
-            userRepository.save(user);
+            user = googleAccountWriter.autoLink(email, sub);
         } catch (DataIntegrityViolationException e) {
             // 병렬 연동 경쟁 - 유니크 제약 충돌 시 sub 로 재조회하여 멱등 처리
-            return userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, sub)
-                    .map(this::loginExistingUser)
-                    .orElseThrow(GoogleAccountConflictException::new);
+            user = recoverBySub(sub, GoogleAccountConflictException::new);
         }
 
         log.info("구글 계정 자동 연동 완료: {}", user.getEmail());
-        return loginExistingUser(user);
+        return GoogleLoginServiceResponse.ofLogin(issueTokenResponse(user), userServiceResponse(user));
     }
 
     // 신규 사용자 온보딩 시작 (계정 미생성)
@@ -142,46 +139,28 @@ public class GoogleOAuthService {
 
     // 이미 사용된 온보딩 토큰 - 가입이 완료됐다면 멱등 로그인, 아니면 이상 상태
     private LoginServiceResponse loginIfAlreadyCompleted(String sub) {
+        return issueTokens(recoverBySub(sub, OnboardingAlreadyCompletedException::new));
+    }
+
+    // 유니크 제약 충돌 후 승자(winner)를 sub 로 재조회 (새 트랜잭션 = auto-commit 조회)
+    private User recoverBySub(String sub, java.util.function.Supplier<? extends RuntimeException> onMissing) {
         return userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, sub)
-                .map(this::issueTokens)
-                .orElseThrow(OnboardingAlreadyCompletedException::new);
-    }
-
-    // 온보딩 완료 시점의 상태를 재확인하고 필요 시 가입한다
-    private User findOrSignUp(OnboardingClaims claims, String name) {
-        // 이미 다른 요청이 가입을 끝냈다면 그 계정으로 (멱등)
-        Optional<User> bySub = userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, claims.sub());
-        if (bySub.isPresent()) {
-            return bySub.get();
-        }
-
-        // 온보딩 토큰 발급 사이에 같은 이메일의 로컬 계정이 생겼다면 자동 연동
-        Optional<User> byEmail = userRepository.findByEmail(claims.email());
-        if (byEmail.isPresent()) {
-            User existing = byEmail.get();
-            existing.linkGoogle(claims.sub());
-            return userRepository.save(existing);
-        }
-
-        return signUpNewUser(claims, name);
-    }
-
-    // 신규 가입 - DB 유니크 제약 경쟁 시 멱등 재조회
-    private User signUpNewUser(OnboardingClaims claims, String name) {
-        try {
-            return userRepository.save(User.signUpWithGoogle(claims.email(), name, claims.sub()));
-        } catch (DataIntegrityViolationException e) {
-            // 동시 가입 경쟁 패배 - 같은 sub 로 가입됐다면 멱등 로그인, 아니면 이메일 충돌
-            return userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, claims.sub())
-                    .orElseThrow(GoogleAccountConflictException::new);
-        }
+                .orElseThrow(onMissing);
     }
 
     // 자체 JWT 발급 + 리프레시 토큰 Redis 저장 (기존 login 과 동일)
     private LoginServiceResponse issueTokens(User user) {
+        return LoginServiceResponse.from(issueTokenResponse(user), userServiceResponse(user));
+    }
+
+    private TokenResponse issueTokenResponse(User user) {
         TokenResponse tokens = tokenProvider.generateToken(TokenRequest.of(user.getEmail(), ROLE_USER));
         refreshTokenRedisService.save(user.getEmail(), tokens.refreshToken());
-        return LoginServiceResponse.from(tokens, UserServiceResponse.from(user));
+        return tokens;
+    }
+
+    private UserServiceResponse userServiceResponse(User user) {
+        return UserServiceResponse.from(user);
     }
 
     private void validateEmailVerified(GoogleUserInfo userInfo) {

--- a/src/main/java/org/project/ttokttok/domain/user/service/GoogleOAuthService.java
+++ b/src/main/java/org/project/ttokttok/domain/user/service/GoogleOAuthService.java
@@ -1,0 +1,192 @@
+package org.project.ttokttok.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.project.ttokttok.domain.user.domain.User;
+import org.project.ttokttok.domain.user.domain.enums.AuthProvider;
+import org.project.ttokttok.domain.user.exception.GoogleAccountConflictException;
+import org.project.ttokttok.domain.user.exception.OnboardingAlreadyCompletedException;
+import org.project.ttokttok.domain.user.repository.UserRepository;
+import org.project.ttokttok.domain.user.service.dto.request.GoogleOnboardingCompleteServiceRequest;
+import org.project.ttokttok.domain.user.service.dto.response.GoogleLoginServiceResponse;
+import org.project.ttokttok.domain.user.service.dto.response.LoginServiceResponse;
+import org.project.ttokttok.domain.user.service.dto.response.UserServiceResponse;
+import org.project.ttokttok.global.auth.jwt.dto.request.TokenRequest;
+import org.project.ttokttok.global.auth.jwt.dto.response.TokenResponse;
+import org.project.ttokttok.global.auth.jwt.service.OnboardingTokenProvider;
+import org.project.ttokttok.global.auth.jwt.service.OnboardingTokenProvider.OnboardingClaims;
+import org.project.ttokttok.global.auth.jwt.service.TokenProvider;
+import org.project.ttokttok.global.auth.oauth.GoogleIdTokenVerifier;
+import org.project.ttokttok.global.auth.oauth.dto.GoogleUserInfo;
+import org.project.ttokttok.global.auth.oauth.exception.GoogleEmailNotVerifiedException;
+import org.project.ttokttok.infrastructure.redis.service.OnboardingTokenRedisService;
+import org.project.ttokttok.infrastructure.redis.service.RefreshTokenRedisService;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.project.ttokttok.global.entity.Role.ROLE_USER;
+
+/**
+ * 구글 OAuth 로그인 서비스
+ *
+ * 1) 구글 ID 토큰 검증 후 sub(불변 식별자) 우선, email 차선으로 사용자를 조회하여 로그인/자동연동 처리
+ * 2) 신규 사용자는 계정을 만들지 않고 10분 TTL 온보딩 토큰 발급 (약관 동의 화면으로 유도)
+ * 3) 온보딩 완료 시 SETNX(jti) + DB 유니크 제약 + 멱등 재조회의 3중 방어로
+ *    재생(replay)/동시 요청(두 탭) 경쟁을 "로그인 성공"으로 수렴시킨다
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class GoogleOAuthService {
+
+    private final UserRepository userRepository;
+    private final GoogleIdTokenVerifier googleIdTokenVerifier;
+    private final TokenProvider tokenProvider;
+    private final OnboardingTokenProvider onboardingTokenProvider;
+    private final OnboardingTokenRedisService onboardingTokenRedisService;
+    private final RefreshTokenRedisService refreshTokenRedisService;
+
+    /**
+     * 1. 구글 로그인 - 구글 ID 토큰을 검증하고 로그인 또는 온보딩을 안내합니다.
+     *
+     * @param idToken 프론트엔드가 전달한 구글 ID 토큰
+     * @return 로그인 결과 (토큰) 또는 온보딩 필요 응답 (온보딩 토큰)
+     * @throws GoogleEmailNotVerifiedException 구글 측 이메일 미검증 시 (자동 연동 = 계정 탈취 벡터 차단)
+     */
+    public GoogleLoginServiceResponse login(String idToken) {
+        // 1-1. 구글 ID 토큰 검증 (서명/iss/aud/exp)
+        GoogleUserInfo userInfo = googleIdTokenVerifier.verify(idToken);
+
+        // 1-2. 미검증 이메일 거부 - 검증되지 않은 이메일로 자동 연동하면 계정 탈취 가능
+        validateEmailVerified(userInfo);
+
+        // 1-3. sub 우선 조회 (구글 이메일이 변경되어도 로그인 유지)
+        Optional<User> bySub = userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, userInfo.sub());
+        if (bySub.isPresent()) {
+            return loginExistingUser(bySub.get());
+        }
+
+        // 1-4. email 차선 조회 - 기존 계정이면 자동 연동
+        Optional<User> byEmail = userRepository.findByEmail(userInfo.email());
+        if (byEmail.isPresent()) {
+            return autoLink(byEmail.get(), userInfo.sub());
+        }
+
+        // 1-5. 신규 사용자 - 계정을 만들지 않고 온보딩 토큰 발급
+        return startOnboarding(userInfo);
+    }
+
+    /**
+     * 2. 온보딩 완료 - 약관 동의 후 구글 계정으로 회원가입을 완료합니다.
+     *
+     * @param request 온보딩 완료 요청 (온보딩 토큰, 약관 동의, 이름)
+     * @return 로그인 결과 (기존 login 과 동일한 토큰 + 사용자 정보)
+     * @throws IllegalArgumentException 약관 미동의 시
+     * @throws OnboardingAlreadyCompletedException 이미 사용된 토큰인데 계정이 없는 이상 상태
+     */
+    public LoginServiceResponse completeOnboarding(GoogleOnboardingCompleteServiceRequest request) {
+        // 2-1. 약관 동의 필수
+        if (!request.termsAgreed()) {
+            throw new IllegalArgumentException("약관 동의가 필요합니다.");
+        }
+
+        // 2-2. 온보딩 토큰 검증 (서명/만료/token_type)
+        OnboardingClaims claims = onboardingTokenProvider.parse(request.onboardingToken());
+
+        // 2-3. jti 일회성 선점 - 패자(재생/두 탭)는 멱등 처리
+        if (!onboardingTokenRedisService.markUsed(claims.jti())) {
+            return loginIfAlreadyCompleted(claims.sub());
+        }
+
+        // 2-4. 토큰 발급 사이 상태 변화 재확인 후 가입 (동시성 방어)
+        User user = findOrSignUp(claims, request.name());
+
+        log.info("구글 온보딩 가입 완료: {}", user.getEmail());
+        return issueTokens(user);
+    }
+
+    // 기존 사용자 로그인 처리
+    private GoogleLoginServiceResponse loginExistingUser(User user) {
+        LoginServiceResponse login = issueTokens(user);
+        log.info("구글 로그인 성공: {}", user.getEmail());
+        return GoogleLoginServiceResponse.ofLogin(
+                TokenResponse.of(login.accessToken(), login.refreshToken()), login.user());
+    }
+
+    // 기존 이메일 계정에 구글 계정 자동 연동
+    private GoogleLoginServiceResponse autoLink(User user, String sub) {
+        try {
+            user.linkGoogle(sub); // 다른 sub 와 이미 연동 시 GoogleAccountConflictException
+            userRepository.save(user);
+        } catch (DataIntegrityViolationException e) {
+            // 병렬 연동 경쟁 - 유니크 제약 충돌 시 sub 로 재조회하여 멱등 처리
+            return userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, sub)
+                    .map(this::loginExistingUser)
+                    .orElseThrow(GoogleAccountConflictException::new);
+        }
+
+        log.info("구글 계정 자동 연동 완료: {}", user.getEmail());
+        return loginExistingUser(user);
+    }
+
+    // 신규 사용자 온보딩 시작 (계정 미생성)
+    private GoogleLoginServiceResponse startOnboarding(GoogleUserInfo userInfo) {
+        String onboardingToken = onboardingTokenProvider.generate(userInfo);
+        log.info("구글 신규 사용자 온보딩 시작: {}", userInfo.email());
+        return GoogleLoginServiceResponse.ofOnboarding(onboardingToken, userInfo.email(), userInfo.name());
+    }
+
+    // 이미 사용된 온보딩 토큰 - 가입이 완료됐다면 멱등 로그인, 아니면 이상 상태
+    private LoginServiceResponse loginIfAlreadyCompleted(String sub) {
+        return userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, sub)
+                .map(this::issueTokens)
+                .orElseThrow(OnboardingAlreadyCompletedException::new);
+    }
+
+    // 온보딩 완료 시점의 상태를 재확인하고 필요 시 가입한다
+    private User findOrSignUp(OnboardingClaims claims, String name) {
+        // 이미 다른 요청이 가입을 끝냈다면 그 계정으로 (멱등)
+        Optional<User> bySub = userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, claims.sub());
+        if (bySub.isPresent()) {
+            return bySub.get();
+        }
+
+        // 온보딩 토큰 발급 사이에 같은 이메일의 로컬 계정이 생겼다면 자동 연동
+        Optional<User> byEmail = userRepository.findByEmail(claims.email());
+        if (byEmail.isPresent()) {
+            User existing = byEmail.get();
+            existing.linkGoogle(claims.sub());
+            return userRepository.save(existing);
+        }
+
+        return signUpNewUser(claims, name);
+    }
+
+    // 신규 가입 - DB 유니크 제약 경쟁 시 멱등 재조회
+    private User signUpNewUser(OnboardingClaims claims, String name) {
+        try {
+            return userRepository.save(User.signUpWithGoogle(claims.email(), name, claims.sub()));
+        } catch (DataIntegrityViolationException e) {
+            // 동시 가입 경쟁 패배 - 같은 sub 로 가입됐다면 멱등 로그인, 아니면 이메일 충돌
+            return userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, claims.sub())
+                    .orElseThrow(GoogleAccountConflictException::new);
+        }
+    }
+
+    // 자체 JWT 발급 + 리프레시 토큰 Redis 저장 (기존 login 과 동일)
+    private LoginServiceResponse issueTokens(User user) {
+        TokenResponse tokens = tokenProvider.generateToken(TokenRequest.of(user.getEmail(), ROLE_USER));
+        refreshTokenRedisService.save(user.getEmail(), tokens.refreshToken());
+        return LoginServiceResponse.from(tokens, UserServiceResponse.from(user));
+    }
+
+    private void validateEmailVerified(GoogleUserInfo userInfo) {
+        if (userInfo.email() == null || userInfo.email().isBlank() || !userInfo.emailVerified()) {
+            throw new GoogleEmailNotVerifiedException();
+        }
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/user/service/UserAuthService.java
+++ b/src/main/java/org/project/ttokttok/domain/user/service/UserAuthService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.project.ttokttok.domain.user.domain.EmailVerification;
 import org.project.ttokttok.domain.user.domain.User;
+import org.project.ttokttok.domain.user.exception.OAuthOnlyAccountException;
 import org.project.ttokttok.domain.user.repository.EmailVerificationRepository;
 import org.project.ttokttok.domain.user.repository.UserRepository;
 import org.project.ttokttok.domain.user.service.dto.request.LoginServiceRequest;
@@ -150,7 +151,12 @@ public class UserAuthService {
         User user = userRepository.findByEmail(request.email())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
-        // 4-2. 비밀번호 검증
+        // 4-2. OAuth 전용 계정(비밀번호 없음)은 비밀번호 로그인 불가
+        if (user.isOAuthOnly()) {
+            throw new OAuthOnlyAccountException();
+        }
+
+        // 4-3. 비밀번호 검증
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {
             throw new IllegalArgumentException("비밀번호가 올바르지 않습니다.");
         }
@@ -193,6 +199,11 @@ public class UserAuthService {
         User user = userRepository.findByEmail(request.email())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
+        // OAuth 전용 계정은 비밀번호 재설정 불가 (구글 로그인 이용 안내)
+        if (user.isOAuthOnly()) {
+            throw new OAuthOnlyAccountException();
+        }
+
         user.updatePassword(passwordEncoder.encode(request.newPassword()));
         userRepository.save(user);
 
@@ -209,8 +220,12 @@ public class UserAuthService {
      * */
     public void sendPasswordResetCode(String email) {
         // 사용자 존재 확인
-        if (!userRepository.existsByEmail(email)) {
-            throw new IllegalArgumentException("존재하지 않는 사용자입니다.");
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        // OAuth 전용 계정은 비밀번호 재설정 코드 발송 불가 (구글 로그인 이용 안내)
+        if (user.isOAuthOnly()) {
+            throw new OAuthOnlyAccountException();
         }
 
         // 기존 미인증 코드들 만료 처리

--- a/src/main/java/org/project/ttokttok/domain/user/service/dto/request/GoogleOnboardingCompleteServiceRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/user/service/dto/request/GoogleOnboardingCompleteServiceRequest.java
@@ -1,0 +1,20 @@
+package org.project.ttokttok.domain.user.service.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record GoogleOnboardingCompleteServiceRequest(
+        String onboardingToken,
+        boolean termsAgreed,
+        String name
+) {
+    public static GoogleOnboardingCompleteServiceRequest of(final String onboardingToken,
+                                                            final boolean termsAgreed,
+                                                            final String name) {
+        return GoogleOnboardingCompleteServiceRequest.builder()
+                .onboardingToken(onboardingToken)
+                .termsAgreed(termsAgreed)
+                .name(name)
+                .build();
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/user/service/dto/response/GoogleLoginServiceResponse.java
+++ b/src/main/java/org/project/ttokttok/domain/user/service/dto/response/GoogleLoginServiceResponse.java
@@ -1,0 +1,40 @@
+package org.project.ttokttok.domain.user.service.dto.response;
+
+import lombok.Builder;
+import org.project.ttokttok.global.auth.jwt.dto.response.TokenResponse;
+
+/**
+ * 구글 로그인 서비스 응답
+ * needsOnboarding=false: 로그인 완료 (토큰 + 사용자 정보)
+ * needsOnboarding=true: 신규 사용자 - 약관 동의 필요 (온보딩 토큰 + 구글 프로필 힌트)
+ */
+@Builder
+public record GoogleLoginServiceResponse(
+        boolean needsOnboarding,
+        String accessToken,
+        String refreshToken,
+        UserServiceResponse user,
+        String onboardingToken,
+        String email,
+        String suggestedName
+) {
+    public static GoogleLoginServiceResponse ofLogin(final TokenResponse tokens, final UserServiceResponse user) {
+        return GoogleLoginServiceResponse.builder()
+                .needsOnboarding(false)
+                .accessToken(tokens.accessToken())
+                .refreshToken(tokens.refreshToken())
+                .user(user)
+                .build();
+    }
+
+    public static GoogleLoginServiceResponse ofOnboarding(final String onboardingToken,
+                                                          final String email,
+                                                          final String suggestedName) {
+        return GoogleLoginServiceResponse.builder()
+                .needsOnboarding(true)
+                .onboardingToken(onboardingToken)
+                .email(email)
+                .suggestedName(suggestedName)
+                .build();
+    }
+}

--- a/src/main/java/org/project/ttokttok/global/auth/jwt/exception/InvalidOnboardingTokenException.java
+++ b/src/main/java/org/project/ttokttok/global/auth/jwt/exception/InvalidOnboardingTokenException.java
@@ -1,0 +1,10 @@
+package org.project.ttokttok.global.auth.jwt.exception;
+
+import org.project.ttokttok.global.exception.ErrorMessage;
+import org.project.ttokttok.global.exception.exception.CustomException;
+
+public class InvalidOnboardingTokenException extends CustomException {
+    public InvalidOnboardingTokenException() {
+        super(ErrorMessage.INVALID_ONBOARDING_TOKEN);
+    }
+}

--- a/src/main/java/org/project/ttokttok/global/auth/jwt/exception/OnboardingTokenExpiredException.java
+++ b/src/main/java/org/project/ttokttok/global/auth/jwt/exception/OnboardingTokenExpiredException.java
@@ -1,0 +1,10 @@
+package org.project.ttokttok.global.auth.jwt.exception;
+
+import org.project.ttokttok.global.exception.ErrorMessage;
+import org.project.ttokttok.global.exception.exception.CustomException;
+
+public class OnboardingTokenExpiredException extends CustomException {
+    public OnboardingTokenExpiredException() {
+        super(ErrorMessage.ONBOARDING_TOKEN_EXPIRED);
+    }
+}

--- a/src/main/java/org/project/ttokttok/global/auth/jwt/service/OnboardingTokenProvider.java
+++ b/src/main/java/org/project/ttokttok/global/auth/jwt/service/OnboardingTokenProvider.java
@@ -1,0 +1,124 @@
+package org.project.ttokttok.global.auth.jwt.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.project.ttokttok.global.auth.jwt.exception.InvalidOnboardingTokenException;
+import org.project.ttokttok.global.auth.jwt.exception.OnboardingTokenExpiredException;
+import org.project.ttokttok.global.auth.oauth.dto.GoogleUserInfo;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.UUID;
+
+/**
+ * 구글 OAuth 2단계 온보딩용 단기 토큰 발급/검증 클래스
+ *
+ * 첫 구글 로그인(신규 사용자)과 온보딩 완료(약관 동의) 사이에서 검증된 구글 신원(sub, email)을
+ * 상태 없이 전달한다. token_type=onboarding 클레임으로 액세스 토큰과 구분되며,
+ * TokenProvider.validateToken 은 해당 클레임이 있는 토큰을 거부하므로 인증에 재사용될 수 없다.
+ */
+@Slf4j
+@Service
+public class OnboardingTokenProvider {
+
+    public static final String TOKEN_TYPE_CLAIM = "token_type";
+    public static final String TOKEN_TYPE_ONBOARDING = "onboarding";
+
+    // 온보딩 토큰 유효 시간 10분 (약관 동의 화면 체류 시간)
+    public static final long ONBOARDING_TOKEN_EXPIRY_TIME = 10 * 60 * 1000L;
+
+    private final String issuer;
+    private final Key key;
+
+    public OnboardingTokenProvider(@Value("${jwt.issuer}") String issuer,
+                                   @Value("${jwt.secret}") String secret) {
+        this.issuer = issuer;
+        this.key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
+    }
+
+    /**
+     * 검증된 구글 신원 정보로 온보딩 토큰을 발급한다.
+     *
+     * @param userInfo 구글 ID 토큰 검증 결과 (sub, email, name)
+     * @return 10분 TTL 의 온보딩 토큰 (jti 포함 - 일회성 사용 추적용)
+     */
+    public String generate(GoogleUserInfo userInfo) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + ONBOARDING_TOKEN_EXPIRY_TIME);
+
+        return Jwts.builder()
+                .setIssuer(issuer)
+                .setSubject(userInfo.sub())
+                .setId(UUID.randomUUID().toString()) // jti - 일회성 사용 추적
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .claim(TOKEN_TYPE_CLAIM, TOKEN_TYPE_ONBOARDING)
+                .claim("email", userInfo.email())
+                .claim("name", userInfo.name())
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    /**
+     * 온보딩 토큰을 검증하고 담긴 구글 신원 정보를 복원한다.
+     *
+     * @param token 온보딩 토큰
+     * @return 토큰에 담긴 구글 신원 정보 (jti 포함)
+     * @throws OnboardingTokenExpiredException 토큰 만료 시
+     * @throws InvalidOnboardingTokenException 서명 위조, 발급자 불일치, 타입 불일치 등
+     */
+    public OnboardingClaims parse(String token) {
+        Claims claims = parseClaims(token);
+        validateClaims(claims);
+
+        return new OnboardingClaims(
+                claims.getSubject(),
+                claims.get("email", String.class),
+                claims.get("name", String.class),
+                claims.getId()
+        );
+    }
+
+    private Claims parseClaims(String token) {
+        if (token == null || token.isBlank()) {
+            throw new InvalidOnboardingTokenException();
+        }
+
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            throw new OnboardingTokenExpiredException();
+        } catch (JwtException | IllegalArgumentException e) {
+            log.warn("온보딩 토큰 검증 실패: {}", e.getMessage());
+            throw new InvalidOnboardingTokenException();
+        }
+    }
+
+    private void validateClaims(Claims claims) {
+        // 액세스 토큰 등 다른 용도의 토큰이 온보딩 완료 API 에 재사용되는 것을 차단
+        if (!TOKEN_TYPE_ONBOARDING.equals(claims.get(TOKEN_TYPE_CLAIM, String.class))) {
+            throw new InvalidOnboardingTokenException();
+        }
+        if (!issuer.equals(claims.getIssuer())) {
+            throw new InvalidOnboardingTokenException();
+        }
+    }
+
+    /**
+     * 온보딩 토큰에서 복원한 구글 신원 정보
+     */
+    public record OnboardingClaims(String sub, String email, String name, String jti) {
+    }
+}

--- a/src/main/java/org/project/ttokttok/global/auth/jwt/service/TokenProvider.java
+++ b/src/main/java/org/project/ttokttok/global/auth/jwt/service/TokenProvider.java
@@ -63,6 +63,12 @@ public class TokenProvider {
             // 유효한 이슈어인지 검증
             isValidIssuer(jws.getBody().getIssuer());
 
+            // 용도가 지정된 토큰(예: 온보딩 토큰)은 액세스 토큰으로 사용 불가
+            if (jws.getBody().get("token_type") != null) {
+                log.warn("액세스 토큰이 아닌 용도의 토큰입니다.");
+                return false;
+            }
+
             return true;
         } catch (SecurityException | MalformedJwtException e) {
             log.warn("잘못된 JWT 토큰 입니다.", e);

--- a/src/main/java/org/project/ttokttok/global/auth/oauth/GoogleIdTokenVerifier.java
+++ b/src/main/java/org/project/ttokttok/global/auth/oauth/GoogleIdTokenVerifier.java
@@ -1,0 +1,48 @@
+package org.project.ttokttok.global.auth.oauth;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.project.ttokttok.global.auth.oauth.dto.GoogleUserInfo;
+import org.project.ttokttok.global.auth.oauth.exception.InvalidGoogleTokenException;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Component;
+
+/**
+ * 구글 ID 토큰 검증기
+ *
+ * JwtDecoder(서명/iss/aud/exp 검증)를 감싸 검증 실패를 도메인 예외로 변환하고
+ * 사용자 정보를 추출한다. 보안상 ID 토큰 원문은 절대 로깅하지 않는다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GoogleIdTokenVerifier {
+
+    private final JwtDecoder googleJwtDecoder;
+
+    /**
+     * 구글 ID 토큰을 검증하고 사용자 정보를 추출한다.
+     *
+     * @param idToken 프론트엔드가 전달한 구글 ID 토큰
+     * @return 검증된 구글 사용자 정보 (sub, email, emailVerified, name)
+     * @throws InvalidGoogleTokenException 서명 위조, 만료, iss/aud 불일치 등 모든 검증 실패
+     */
+    public GoogleUserInfo verify(String idToken) {
+        if (idToken == null || idToken.isBlank()) {
+            throw new InvalidGoogleTokenException();
+        }
+
+        try {
+            Jwt jwt = googleJwtDecoder.decode(idToken);
+            GoogleUserInfo userInfo = GoogleUserInfo.from(jwt);
+            log.debug("구글 ID 토큰 검증 성공: sub={}, email={}", userInfo.sub(), userInfo.email());
+            return userInfo;
+        } catch (JwtException e) {
+            // aud 불일치도 동일 메시지로 처리하여 공격자에게 실패 원인을 노출하지 않는다
+            log.warn("구글 ID 토큰 검증 실패: {}", e.getMessage());
+            throw new InvalidGoogleTokenException();
+        }
+    }
+}

--- a/src/main/java/org/project/ttokttok/global/auth/oauth/config/GoogleJwtDecoderConfig.java
+++ b/src/main/java/org/project/ttokttok/global/auth/oauth/config/GoogleJwtDecoderConfig.java
@@ -11,6 +11,8 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
 
 import java.time.Duration;
 import java.util.List;
@@ -32,12 +34,18 @@ public class GoogleJwtDecoderConfig {
     // 시계 오차 허용 범위
     private static final Duration CLOCK_SKEW = Duration.ofSeconds(60);
 
+    // 구글 JWKS 조회 타임아웃 - 무제한 대기로 인한 커넥션/스레드 고갈 방지
+    private static final int JWKS_CONNECT_TIMEOUT_MS = 2_000;
+    private static final int JWKS_READ_TIMEOUT_MS = 3_000;
+
     @Bean
     public JwtDecoder googleJwtDecoder(
             @Value("${google.oauth.jwk-set-uri}") String jwkSetUri,
             @Value("${google.oauth.client-id}") String clientId) {
 
-        NimbusJwtDecoder decoder = NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build();
+        NimbusJwtDecoder decoder = NimbusJwtDecoder.withJwkSetUri(jwkSetUri)
+                .restOperations(jwkSetRestTemplate())
+                .build();
 
         decoder.setJwtValidator(new DelegatingOAuth2TokenValidator<>(
                 new JwtTimestampValidator(CLOCK_SKEW),
@@ -46,6 +54,14 @@ public class GoogleJwtDecoderConfig {
         ));
 
         return decoder;
+    }
+
+    // 타임아웃이 설정된 RestTemplate - JWKS 엔드포인트 지연 시 무제한 블로킹 방지
+    private RestTemplate jwkSetRestTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(JWKS_CONNECT_TIMEOUT_MS);
+        factory.setReadTimeout(JWKS_READ_TIMEOUT_MS);
+        return new RestTemplate(factory);
     }
 
     private OAuth2TokenValidator<Jwt> googleIssuerValidator() {

--- a/src/main/java/org/project/ttokttok/global/auth/oauth/config/GoogleJwtDecoderConfig.java
+++ b/src/main/java/org/project/ttokttok/global/auth/oauth/config/GoogleJwtDecoderConfig.java
@@ -1,0 +1,71 @@
+package org.project.ttokttok.global.auth.oauth.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * 구글 ID 토큰 검증용 JwtDecoder 설정
+ *
+ * NimbusJwtDecoder 가 구글 JWKS(공개키) 를 가져와 서명을 검증하고(캐시/키 회전 내장, lazy 로딩),
+ * 커스텀 밸리데이터로 발급자(iss)와 대상(aud=우리 client-id)을 검증한다.
+ * aud 검증은 다른 앱용으로 발급된 구글 토큰의 재사용 공격을 차단한다.
+ */
+@Configuration
+public class GoogleJwtDecoderConfig {
+
+    // 구글 문서상 iss 는 두 형식이 모두 존재한다
+    private static final List<String> GOOGLE_ISSUERS =
+            List.of("https://accounts.google.com", "accounts.google.com");
+
+    // 시계 오차 허용 범위
+    private static final Duration CLOCK_SKEW = Duration.ofSeconds(60);
+
+    @Bean
+    public JwtDecoder googleJwtDecoder(
+            @Value("${google.oauth.jwk-set-uri}") String jwkSetUri,
+            @Value("${google.oauth.client-id}") String clientId) {
+
+        NimbusJwtDecoder decoder = NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build();
+
+        decoder.setJwtValidator(new DelegatingOAuth2TokenValidator<>(
+                new JwtTimestampValidator(CLOCK_SKEW),
+                googleIssuerValidator(),
+                audienceValidator(clientId)
+        ));
+
+        return decoder;
+    }
+
+    private OAuth2TokenValidator<Jwt> googleIssuerValidator() {
+        return jwt -> {
+            String issuer = jwt.getClaimAsString("iss");
+            if (issuer != null && GOOGLE_ISSUERS.contains(issuer)) {
+                return OAuth2TokenValidatorResult.success();
+            }
+            return OAuth2TokenValidatorResult.failure(
+                    new OAuth2Error("invalid_issuer", "구글이 발급한 토큰이 아닙니다.", null));
+        };
+    }
+
+    private OAuth2TokenValidator<Jwt> audienceValidator(String clientId) {
+        return jwt -> {
+            if (jwt.getAudience() != null && jwt.getAudience().contains(clientId)) {
+                return OAuth2TokenValidatorResult.success();
+            }
+            return OAuth2TokenValidatorResult.failure(
+                    new OAuth2Error("invalid_audience", "이 서비스용으로 발급된 토큰이 아닙니다.", null));
+        };
+    }
+}

--- a/src/main/java/org/project/ttokttok/global/auth/oauth/dto/GoogleUserInfo.java
+++ b/src/main/java/org/project/ttokttok/global/auth/oauth/dto/GoogleUserInfo.java
@@ -1,0 +1,29 @@
+package org.project.ttokttok.global.auth.oauth.dto;
+
+import lombok.Builder;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+/**
+ * 구글 ID 토큰 검증 후 추출한 사용자 정보
+ *
+ * @param sub 구글 불변 식별자 (이메일은 변경될 수 있으므로 sub 로 식별)
+ * @param email 구글 계정 이메일
+ * @param emailVerified 구글 측 이메일 검증 여부 (false 면 자동 연동 금지 - 계정 탈취 방지)
+ * @param name 구글 프로필 이름 (없을 수 있음)
+ */
+@Builder
+public record GoogleUserInfo(
+        String sub,
+        String email,
+        boolean emailVerified,
+        String name
+) {
+    public static GoogleUserInfo from(final Jwt jwt) {
+        return GoogleUserInfo.builder()
+                .sub(jwt.getSubject())
+                .email(jwt.getClaimAsString("email"))
+                .emailVerified(Boolean.TRUE.equals(jwt.getClaimAsBoolean("email_verified")))
+                .name(jwt.getClaimAsString("name"))
+                .build();
+    }
+}

--- a/src/main/java/org/project/ttokttok/global/auth/oauth/dto/GoogleUserInfo.java
+++ b/src/main/java/org/project/ttokttok/global/auth/oauth/dto/GoogleUserInfo.java
@@ -21,9 +21,14 @@ public record GoogleUserInfo(
     public static GoogleUserInfo from(final Jwt jwt) {
         return GoogleUserInfo.builder()
                 .sub(jwt.getSubject())
-                .email(jwt.getClaimAsString("email"))
+                .email(normalizeEmail(jwt.getClaimAsString("email")))
                 .emailVerified(Boolean.TRUE.equals(jwt.getClaimAsBoolean("email_verified")))
                 .name(jwt.getClaimAsString("name"))
                 .build();
+    }
+
+    // 이메일 대소문자 정규화 - 자동 연동 조회 미스로 인한 계정 중복 방지
+    private static String normalizeEmail(String email) {
+        return email == null ? null : email.toLowerCase();
     }
 }

--- a/src/main/java/org/project/ttokttok/global/auth/oauth/exception/GoogleEmailNotVerifiedException.java
+++ b/src/main/java/org/project/ttokttok/global/auth/oauth/exception/GoogleEmailNotVerifiedException.java
@@ -1,0 +1,10 @@
+package org.project.ttokttok.global.auth.oauth.exception;
+
+import org.project.ttokttok.global.exception.ErrorMessage;
+import org.project.ttokttok.global.exception.exception.CustomException;
+
+public class GoogleEmailNotVerifiedException extends CustomException {
+    public GoogleEmailNotVerifiedException() {
+        super(ErrorMessage.GOOGLE_EMAIL_NOT_VERIFIED);
+    }
+}

--- a/src/main/java/org/project/ttokttok/global/auth/oauth/exception/InvalidGoogleTokenException.java
+++ b/src/main/java/org/project/ttokttok/global/auth/oauth/exception/InvalidGoogleTokenException.java
@@ -1,0 +1,10 @@
+package org.project.ttokttok.global.auth.oauth.exception;
+
+import org.project.ttokttok.global.exception.ErrorMessage;
+import org.project.ttokttok.global.exception.exception.CustomException;
+
+public class InvalidGoogleTokenException extends CustomException {
+    public InvalidGoogleTokenException() {
+        super(ErrorMessage.INVALID_GOOGLE_TOKEN);
+    }
+}

--- a/src/main/java/org/project/ttokttok/global/auth/security/SecurityWhiteList.java
+++ b/src/main/java/org/project/ttokttok/global/auth/security/SecurityWhiteList.java
@@ -23,7 +23,9 @@ public enum SecurityWhiteList {
             "/api/admin/auth/re-issue",
             "/health",
             "/api/admin/auth/join",
-            "/api/super-admin/login"
+            "/api/super-admin/login",
+            "/api/user/auth/oauth/google",
+            "/api/user/auth/oauth/google/complete"
     }),
 
     SWAGGER_URLS(new String[]{

--- a/src/main/java/org/project/ttokttok/global/exception/ErrorMessage.java
+++ b/src/main/java/org/project/ttokttok/global/exception/ErrorMessage.java
@@ -94,7 +94,16 @@ public enum ErrorMessage {
     SUPER_ADMIN_PASSWORD_NOT_MATCH("비밀번호가 틀렸습니다.", HttpStatus.UNAUTHORIZED),
 
     // 공지사항 에러 메시지
-    NOTICE_NOT_FOUND("공지사항을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    NOTICE_NOT_FOUND("공지사항을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
+    // 구글 OAuth 에러 메시지
+    INVALID_GOOGLE_TOKEN("유효하지 않은 구글 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    GOOGLE_EMAIL_NOT_VERIFIED("구글 계정의 이메일 인증이 필요합니다.", HttpStatus.BAD_REQUEST),
+    GOOGLE_ACCOUNT_CONFLICT("이미 다른 구글 계정과 연동된 이메일입니다.", HttpStatus.CONFLICT),
+    OAUTH_ONLY_ACCOUNT("구글 로그인으로 가입된 계정입니다. 구글 로그인을 이용해주세요.", HttpStatus.CONFLICT),
+    INVALID_ONBOARDING_TOKEN("유효하지 않은 가입 세션입니다. 다시 로그인해주세요.", HttpStatus.UNAUTHORIZED),
+    ONBOARDING_TOKEN_EXPIRED("가입 세션이 만료되었습니다. 다시 로그인해주세요.", HttpStatus.UNAUTHORIZED),
+    ONBOARDING_ALREADY_COMPLETED("이미 처리된 가입 요청입니다.", HttpStatus.CONFLICT);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/org/project/ttokttok/infrastructure/redis/service/OnboardingTokenRedisService.java
+++ b/src/main/java/org/project/ttokttok/infrastructure/redis/service/OnboardingTokenRedisService.java
@@ -1,0 +1,42 @@
+package org.project.ttokttok.infrastructure.redis.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+import static org.project.ttokttok.global.auth.jwt.service.OnboardingTokenProvider.ONBOARDING_TOKEN_EXPIRY_TIME;
+
+/**
+ * 온보딩 토큰의 일회성 사용을 보장하는 Redis 서비스
+ *
+ * SETNX 로 jti 를 선점하여 재생(replay)과 동시 요청(두 탭) 경쟁을 원자적으로 판별한다.
+ * TTL 은 온보딩 토큰 수명과 동일하게 설정하여 토큰 만료 후 키가 자동 정리된다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OnboardingTokenRedisService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    // 온보딩 토큰 사용 여부 키 접두사
+    private static final String ONBOARDING_USED_KEY = "onboarding:used:";
+
+    /**
+     * 온보딩 토큰(jti)을 사용 처리한다.
+     *
+     * @param jti 온보딩 토큰의 jti 클레임
+     * @return 최초 사용이면 true, 이미 사용된 토큰이면 false
+     */
+    public boolean markUsed(String jti) {
+        Boolean acquired = redisTemplate.opsForValue().setIfAbsent(
+                ONBOARDING_USED_KEY + jti,
+                "used",
+                Duration.ofMillis(ONBOARDING_TOKEN_EXPIRY_TIME));
+
+        return Boolean.TRUE.equals(acquired);
+    }
+}

--- a/src/main/resources/db/migration/V23__add_oauth_columns_to_users.sql
+++ b/src/main/resources/db/migration/V23__add_oauth_columns_to_users.sql
@@ -1,0 +1,8 @@
+-- OAuth 지원: 비밀번호 NULL 허용 (소셜 전용 계정), 구글 식별자 컬럼 추가
+ALTER TABLE users ALTER COLUMN password DROP NOT NULL;
+
+ALTER TABLE users ADD COLUMN provider VARCHAR(20) NOT NULL DEFAULT 'LOCAL';
+ALTER TABLE users ADD COLUMN provider_id VARCHAR(255);
+
+-- 동일 구글 계정(sub)이 두 사용자 행에 연결되는 것을 방지 (NULL 값끼리는 충돌하지 않음)
+ALTER TABLE users ADD CONSTRAINT uk_users_provider_provider_id UNIQUE (provider, provider_id);

--- a/src/test/java/org/project/ttokttok/domain/user/controller/UserOAuthControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/user/controller/UserOAuthControllerTest.java
@@ -1,0 +1,158 @@
+package org.project.ttokttok.domain.user.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.user.service.GoogleOAuthService;
+import org.project.ttokttok.domain.user.service.dto.request.GoogleOnboardingCompleteServiceRequest;
+import org.project.ttokttok.domain.user.service.dto.response.GoogleLoginServiceResponse;
+import org.project.ttokttok.domain.user.service.dto.response.LoginServiceResponse;
+import org.project.ttokttok.domain.user.service.dto.response.UserServiceResponse;
+import org.project.ttokttok.global.annotationresolver.auth.AuthUserInfoResolver;
+import org.project.ttokttok.global.auth.jwt.dto.response.TokenResponse;
+import org.project.ttokttok.global.auth.jwt.exception.OnboardingTokenExpiredException;
+import org.project.ttokttok.global.auth.jwt.service.TokenProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserOAuthController.class)
+class UserOAuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private GoogleOAuthService googleOAuthService;
+
+    @MockitoBean
+    private TokenProvider tokenProvider;
+
+    @MockitoBean
+    private AuthUserInfoResolver authUserInfoResolver;
+
+    private static final String GMAIL = "user@gmail.com";
+
+    private UserServiceResponse userServiceResponse() {
+        return UserServiceResponse.builder()
+                .id("user-1").email(GMAIL).name("홍길동")
+                .isEmailVerified(true).termsAgreed(true).build();
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("구글 로그인 API는 기존 사용자면 토큰과 함께 200을 반환한다")
+    void googleLogin_existingUser_returnsTokens() throws Exception {
+        GoogleLoginServiceResponse serviceResponse = GoogleLoginServiceResponse.ofLogin(
+                TokenResponse.of("access-token", "refresh-token"), userServiceResponse());
+        given(googleOAuthService.login(any())).willReturn(serviceResponse);
+
+        mockMvc.perform(post("/api/user/auth/oauth/google").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"idToken\":\"google-id-token\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("로그인에 성공했습니다."))
+                .andExpect(jsonPath("$.data.needsOnboarding").value(false))
+                .andExpect(jsonPath("$.data.accessToken").value("access-token"))
+                .andExpect(jsonPath("$.data.user.email").value(GMAIL));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("구글 로그인 API는 신규 사용자면 온보딩 토큰과 함께 200을 반환한다")
+    void googleLogin_newUser_returnsOnboardingToken() throws Exception {
+        GoogleLoginServiceResponse serviceResponse = GoogleLoginServiceResponse.ofOnboarding(
+                "onboarding-token", GMAIL, "홍길동");
+        given(googleOAuthService.login(any())).willReturn(serviceResponse);
+
+        mockMvc.perform(post("/api/user/auth/oauth/google").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"idToken\":\"google-id-token\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("약관 동의가 필요합니다."))
+                .andExpect(jsonPath("$.data.needsOnboarding").value(true))
+                .andExpect(jsonPath("$.data.onboardingToken").value("onboarding-token"))
+                .andExpect(jsonPath("$.data.suggestedName").value("홍길동"))
+                .andExpect(jsonPath("$.data.accessToken").doesNotExist());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("idToken이 비어있으면 구글 로그인 API는 400을 반환한다")
+    void googleLogin_withBlankIdToken_returnsBadRequest() throws Exception {
+        mockMvc.perform(post("/api/user/auth/oauth/google").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"idToken\":\"\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("온보딩 완료 API는 200과 로그인 응답을 반환한다")
+    void completeOnboarding_returnsTokens() throws Exception {
+        LoginServiceResponse serviceResponse = LoginServiceResponse.from(
+                TokenResponse.of("access-token", "refresh-token"), userServiceResponse());
+        given(googleOAuthService.completeOnboarding(any(GoogleOnboardingCompleteServiceRequest.class)))
+                .willReturn(serviceResponse);
+
+        String body = "{\"onboardingToken\":\"onboarding-token\",\"termsAgreed\":true,\"name\":\"홍길동\"}";
+
+        mockMvc.perform(post("/api/user/auth/oauth/google/complete").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("회원가입 및 로그인에 성공했습니다."))
+                .andExpect(jsonPath("$.data.accessToken").value("access-token"))
+                .andExpect(jsonPath("$.data.user.email").value(GMAIL));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("이름이 1자면 온보딩 완료 API는 400을 반환한다")
+    void completeOnboarding_withShortName_returnsBadRequest() throws Exception {
+        String body = "{\"onboardingToken\":\"onboarding-token\",\"termsAgreed\":true,\"name\":\"김\"}";
+
+        mockMvc.perform(post("/api/user/auth/oauth/google/complete").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("이름이 11자면 온보딩 완료 API는 400을 반환한다")
+    void completeOnboarding_withLongName_returnsBadRequest() throws Exception {
+        String body = "{\"onboardingToken\":\"onboarding-token\",\"termsAgreed\":true,"
+                + "\"name\":\"열한글자가넘는이름입니다\"}";
+
+        mockMvc.perform(post("/api/user/auth/oauth/google/complete").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("온보딩 토큰이 만료됐으면 온보딩 완료 API는 401을 반환한다")
+    void completeOnboarding_withExpiredToken_returnsUnauthorized() throws Exception {
+        given(googleOAuthService.completeOnboarding(any(GoogleOnboardingCompleteServiceRequest.class)))
+                .willThrow(new OnboardingTokenExpiredException());
+
+        String body = "{\"onboardingToken\":\"expired-token\",\"termsAgreed\":true,\"name\":\"홍길동\"}";
+
+        mockMvc.perform(post("/api/user/auth/oauth/google/complete").with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/user/domain/UserOAuthTest.java
+++ b/src/test/java/org/project/ttokttok/domain/user/domain/UserOAuthTest.java
@@ -1,0 +1,133 @@
+package org.project.ttokttok.domain.user.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.user.domain.enums.AuthProvider;
+import org.project.ttokttok.domain.user.exception.GoogleAccountConflictException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * User 엔티티의 구글 OAuth 관련 도메인 로직 테스트
+ */
+class UserOAuthTest {
+
+    private static final String SUB = "google-sub-123";
+
+    @Nested
+    @DisplayName("signUpWithGoogle 정적 팩토리")
+    class SignUpWithGoogleTest {
+
+        @Test
+        @DisplayName("상명대 도메인이 아닌 이메일(gmail)로도 가입할 수 있다")
+        void signUpWithGoogle_withGmail_succeeds() {
+            // when
+            User user = User.signUpWithGoogle("user@gmail.com", "홍길동", SUB);
+
+            // then
+            assertThat(user.getEmail()).isEqualTo("user@gmail.com");
+            assertThat(user.getPassword()).isNull(); // OAuth 전용 계정
+            assertThat(user.isEmailVerified()).isTrue();
+            assertThat(user.isTermsAgreed()).isTrue();
+            assertThat(user.getProvider()).isEqualTo(AuthProvider.GOOGLE);
+            assertThat(user.getProviderId()).isEqualTo(SUB);
+            assertThat(user.isOAuthOnly()).isTrue();
+        }
+
+        @Test
+        @DisplayName("구글 sub가 없으면 예외를 던진다")
+        void signUpWithGoogle_withoutSub_throws() {
+            assertThatThrownBy(() -> User.signUpWithGoogle("user@gmail.com", "홍길동", null))
+                    .isInstanceOf(IllegalArgumentException.class);
+            assertThatThrownBy(() -> User.signUpWithGoogle("user@gmail.com", "홍길동", " "))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("이메일이 없으면 예외를 던진다")
+        void signUpWithGoogle_withoutEmail_throws() {
+            assertThatThrownBy(() -> User.signUpWithGoogle(null, "홍길동", SUB))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("기존 signUp 정적 팩토리 (회귀)")
+    class SignUpRegressionTest {
+
+        @Test
+        @DisplayName("여전히 상명대 이메일이 아니면 가입할 수 없다 (도메인 제한 유지)")
+        void signUp_withNonSangmyungEmail_stillRejected() {
+            assertThatThrownBy(() -> User.signUp("user@gmail.com", "encoded", "홍길동", true))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("올바른 이메일 형식이 아닙니다.");
+        }
+
+        @Test
+        @DisplayName("여전히 비밀번호 없이 가입할 수 없다")
+        void signUp_withoutPassword_stillRejected() {
+            assertThatThrownBy(() -> User.signUp("a@sangmyung.kr", null, "홍길동", true))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("비밀번호는 필수입니다.");
+        }
+
+        @Test
+        @DisplayName("정상 가입 시 LOCAL 프로바이더로 생성되며 OAuth 전용이 아니다")
+        void signUp_createsLocalUser() {
+            // when
+            User user = User.signUp("a@sangmyung.kr", "encoded", "홍길동", true);
+
+            // then
+            assertThat(user.getProvider()).isEqualTo(AuthProvider.LOCAL);
+            assertThat(user.getProviderId()).isNull();
+            assertThat(user.isOAuthOnly()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("linkGoogle 메서드")
+    class LinkGoogleTest {
+
+        @Test
+        @DisplayName("로컬 계정에 구글 계정을 연동하면 provider 정보가 설정되고 비밀번호는 유지된다")
+        void linkGoogle_onLocalAccount_linksAndKeepsPassword() {
+            // given
+            User user = User.signUp("a@sangmyung.kr", "encoded", "홍길동", true);
+
+            // when
+            user.linkGoogle(SUB);
+
+            // then
+            assertThat(user.getProvider()).isEqualTo(AuthProvider.GOOGLE);
+            assertThat(user.getProviderId()).isEqualTo(SUB);
+            assertThat(user.getPassword()).isEqualTo("encoded"); // 비밀번호 로그인 유지
+            assertThat(user.isEmailVerified()).isTrue();
+        }
+
+        @Test
+        @DisplayName("같은 sub로 다시 연동하면 아무 일도 일어나지 않는다 (멱등)")
+        void linkGoogle_sameSubTwice_isIdempotent() {
+            // given
+            User user = User.signUp("a@sangmyung.kr", "encoded", "홍길동", true);
+            user.linkGoogle(SUB);
+
+            // when & then (예외 없음)
+            user.linkGoogle(SUB);
+            assertThat(user.getProviderId()).isEqualTo(SUB);
+        }
+
+        @Test
+        @DisplayName("다른 sub와 이미 연동되어 있으면 GoogleAccountConflictException을 던진다")
+        void linkGoogle_differentSub_throwsConflict() {
+            // given
+            User user = User.signUp("a@sangmyung.kr", "encoded", "홍길동", true);
+            user.linkGoogle(SUB);
+
+            // when & then
+            assertThatThrownBy(() -> user.linkGoogle("different-sub"))
+                    .isInstanceOf(GoogleAccountConflictException.class);
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/user/service/GoogleOAuthConcurrencyIT.java
+++ b/src/test/java/org/project/ttokttok/domain/user/service/GoogleOAuthConcurrencyIT.java
@@ -1,0 +1,196 @@
+package org.project.ttokttok.domain.user.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.user.domain.User;
+import org.project.ttokttok.domain.user.domain.enums.AuthProvider;
+import org.project.ttokttok.domain.user.exception.GoogleAccountConflictException;
+import org.project.ttokttok.domain.user.repository.UserRepository;
+import org.project.ttokttok.domain.user.service.dto.request.GoogleOnboardingCompleteServiceRequest;
+import org.project.ttokttok.domain.user.service.dto.response.GoogleLoginServiceResponse;
+import org.project.ttokttok.domain.user.service.dto.response.LoginServiceResponse;
+import org.project.ttokttok.global.auth.jwt.dto.response.TokenResponse;
+import org.project.ttokttok.global.auth.jwt.service.OnboardingTokenProvider;
+import org.project.ttokttok.global.auth.jwt.service.OnboardingTokenProvider.OnboardingClaims;
+import org.project.ttokttok.global.auth.jwt.service.TokenProvider;
+import org.project.ttokttok.global.auth.oauth.GoogleIdTokenVerifier;
+import org.project.ttokttok.global.auth.oauth.dto.GoogleUserInfo;
+import org.project.ttokttok.infrastructure.redis.service.OnboardingTokenRedisService;
+import org.project.ttokttok.infrastructure.redis.service.RefreshTokenRedisService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * 구글 OAuth 동시성 통합 테스트 (실제 H2 커밋 발생 — {@code @Transactional} 미사용)
+ *
+ * P1-1 회귀 방지: 단위 테스트의 mock 경계는 "flush 시점 유니크 제약 위반 → 롤백 → 멱등 복구"를
+ * 재현하지 못한다. 이 테스트는 실제 트랜잭션 커밋/롤백을 발생시켜 그 경로를 검증한다.
+ * 구글/Redis 실호출을 피하기 위해 검증기·토큰 provider·Redis 서비스만 목으로 대체하고,
+ * DB(UserRepository/GoogleAccountWriter/GoogleOAuthService)는 실제 빈을 사용한다.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class GoogleOAuthConcurrencyIT {
+
+    @Autowired
+    private GoogleOAuthService googleOAuthService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @MockitoBean
+    private GoogleIdTokenVerifier googleIdTokenVerifier;
+
+    @MockitoBean
+    private OnboardingTokenProvider onboardingTokenProvider;
+
+    @MockitoBean
+    private OnboardingTokenRedisService onboardingTokenRedisService;
+
+    @MockitoBean
+    private TokenProvider tokenProvider;
+
+    @MockitoBean
+    private RefreshTokenRedisService refreshTokenRedisService;
+
+    private static final String SUB = "google-sub-123";
+    private static final String GMAIL = "user@gmail.com";
+    private static final String SMU_EMAIL = "202021000@sangmyung.kr";
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+        // 토큰 발급은 검증 대상이 아니므로 고정값 목 (Redis 미사용)
+        given(tokenProvider.generateToken(any())).willReturn(TokenResponse.of("access-token", "refresh-token"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAll();
+    }
+
+    private OnboardingClaims claims(String email) {
+        return new OnboardingClaims(SUB, email, "홍길동", "jti-1");
+    }
+
+    @Test
+    @DisplayName("동일 sub로 동시에 온보딩 완료해도 계정은 1개만 생성되고 두 요청 모두 토큰을 받는다")
+    void completeOnboarding_concurrentSameSub_createsSingleRowAndBothSucceed() throws Exception {
+        // given - 두 스레드가 같은 구글 계정으로 동시에 가입 완료 시도 (jti SETNX 는 통과했다고 가정)
+        given(onboardingTokenProvider.parse(any())).willReturn(claims(GMAIL));
+        given(onboardingTokenRedisService.markUsed(any())).willReturn(true);
+        GoogleOnboardingCompleteServiceRequest request =
+                GoogleOnboardingCompleteServiceRequest.of("onboarding-token", true, "홍길동");
+
+        int threads = 2;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch startGate = new CountDownLatch(1);
+
+        Callable<LoginServiceResponse> task = () -> {
+            startGate.await(); // 두 스레드를 최대한 동시에 출발시켜 flush 경쟁 유도
+            return googleOAuthService.completeOnboarding(request);
+        };
+
+        // when
+        Future<LoginServiceResponse> f1 = pool.submit(task);
+        Future<LoginServiceResponse> f2 = pool.submit(task);
+        startGate.countDown();
+
+        LoginServiceResponse r1 = f1.get();
+        LoginServiceResponse r2 = f2.get();
+        pool.shutdown();
+
+        // then - 500 없이 둘 다 토큰 발급, 그리고 계정은 정확히 1개 (유니크 제약 + 멱등 복구)
+        assertThat(r1.accessToken()).isNotBlank();
+        assertThat(r2.accessToken()).isNotBlank();
+        List<User> users = userRepository.findAll();
+        assertThat(users).hasSize(1);
+        assertThat(users.get(0).getProviderId()).isEqualTo(SUB);
+        assertThat(users.get(0).getProvider()).isEqualTo(AuthProvider.GOOGLE);
+    }
+
+    @Test
+    @DisplayName("이미 같은 sub 계정이 커밋돼 있으면 온보딩 완료는 멱등 로그인으로 수렴한다")
+    void completeOnboarding_winnerAlreadyCommitted_isIdempotent() {
+        // given - 승자 행을 먼저 커밋
+        userRepository.saveAndFlush(User.signUpWithGoogle(GMAIL, "홍길동", SUB));
+        given(onboardingTokenProvider.parse(any())).willReturn(claims(GMAIL));
+        given(onboardingTokenRedisService.markUsed(any())).willReturn(true);
+        GoogleOnboardingCompleteServiceRequest request =
+                GoogleOnboardingCompleteServiceRequest.of("onboarding-token", true, "홍길동");
+
+        // when
+        LoginServiceResponse response = googleOAuthService.completeOnboarding(request);
+
+        // then
+        assertThat(response.accessToken()).isNotBlank();
+        assertThat(userRepository.findAll()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("온보딩 완료 사이 같은 이메일 로컬 계정이 커밋돼 있으면 자동 연동되어 토큰을 발급한다")
+    void completeOnboarding_localAccountCommittedMeanwhile_autoLinks() {
+        // given - 같은 이메일의 로컬(비밀번호) 계정이 이미 커밋됨
+        userRepository.saveAndFlush(User.signUp(SMU_EMAIL, "encoded-password", "김철수", true));
+        given(onboardingTokenProvider.parse(any())).willReturn(claims(SMU_EMAIL));
+        given(onboardingTokenRedisService.markUsed(any())).willReturn(true);
+        GoogleOnboardingCompleteServiceRequest request =
+                GoogleOnboardingCompleteServiceRequest.of("onboarding-token", true, "김철수");
+
+        // when
+        LoginServiceResponse response = googleOAuthService.completeOnboarding(request);
+
+        // then - 새 행이 생기지 않고 기존 로컬 계정에 연동
+        assertThat(response.accessToken()).isNotBlank();
+        List<User> users = userRepository.findAll();
+        assertThat(users).hasSize(1);
+        assertThat(users.get(0).getProviderId()).isEqualTo(SUB);
+        assertThat(users.get(0).getPassword()).isNotNull(); // 비밀번호 로그인도 유지
+    }
+
+    @Test
+    @DisplayName("로그인 시 이메일 일치 로컬 계정은 실제로 연동되어 커밋된다")
+    void login_matchingLocalAccount_reallyLinksAndCommits() {
+        // given
+        userRepository.saveAndFlush(User.signUp(SMU_EMAIL, "encoded-password", "김철수", true));
+        given(googleIdTokenVerifier.verify(any())).willReturn(GoogleUserInfo.builder()
+                .sub(SUB).email(SMU_EMAIL).emailVerified(true).name("김철수").build());
+
+        // when
+        GoogleLoginServiceResponse response = googleOAuthService.login("id-token");
+
+        // then
+        assertThat(response.needsOnboarding()).isFalse();
+        User linked = userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, SUB).orElseThrow();
+        assertThat(linked.getEmail()).isEqualTo(SMU_EMAIL);
+    }
+
+    @Test
+    @DisplayName("이미 다른 구글 계정과 연동된 이메일이면 GoogleAccountConflictException을 던진다")
+    void login_emailOwnedByDifferentGoogleAccount_throwsConflict() {
+        // given - 같은 이메일이 다른 sub 의 구글 계정으로 이미 연동돼 커밋됨
+        userRepository.saveAndFlush(User.signUpWithGoogle(GMAIL, "홍길동", "other-sub"));
+        given(googleIdTokenVerifier.verify(any())).willReturn(GoogleUserInfo.builder()
+                .sub(SUB).email(GMAIL).emailVerified(true).name("홍길동").build());
+
+        // when & then
+        assertThatThrownBy(() -> googleOAuthService.login("id-token"))
+                .isInstanceOf(GoogleAccountConflictException.class);
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/user/service/GoogleOAuthServiceTest.java
+++ b/src/test/java/org/project/ttokttok/domain/user/service/GoogleOAuthServiceTest.java
@@ -1,0 +1,390 @@
+package org.project.ttokttok.domain.user.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.domain.user.domain.User;
+import org.project.ttokttok.domain.user.domain.enums.AuthProvider;
+import org.project.ttokttok.domain.user.exception.GoogleAccountConflictException;
+import org.project.ttokttok.domain.user.exception.OnboardingAlreadyCompletedException;
+import org.project.ttokttok.domain.user.repository.UserRepository;
+import org.project.ttokttok.domain.user.service.dto.request.GoogleOnboardingCompleteServiceRequest;
+import org.project.ttokttok.domain.user.service.dto.response.GoogleLoginServiceResponse;
+import org.project.ttokttok.domain.user.service.dto.response.LoginServiceResponse;
+import org.project.ttokttok.global.auth.jwt.dto.request.TokenRequest;
+import org.project.ttokttok.global.auth.jwt.dto.response.TokenResponse;
+import org.project.ttokttok.global.auth.jwt.service.OnboardingTokenProvider;
+import org.project.ttokttok.global.auth.jwt.service.OnboardingTokenProvider.OnboardingClaims;
+import org.project.ttokttok.global.auth.jwt.service.TokenProvider;
+import org.project.ttokttok.global.auth.oauth.GoogleIdTokenVerifier;
+import org.project.ttokttok.global.auth.oauth.dto.GoogleUserInfo;
+import org.project.ttokttok.global.auth.oauth.exception.GoogleEmailNotVerifiedException;
+import org.project.ttokttok.infrastructure.redis.service.OnboardingTokenRedisService;
+import org.project.ttokttok.infrastructure.redis.service.RefreshTokenRedisService;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class GoogleOAuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private GoogleIdTokenVerifier googleIdTokenVerifier;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @Mock
+    private OnboardingTokenProvider onboardingTokenProvider;
+
+    @Mock
+    private OnboardingTokenRedisService onboardingTokenRedisService;
+
+    @Mock
+    private RefreshTokenRedisService refreshTokenRedisService;
+
+    @InjectMocks
+    private GoogleOAuthService googleOAuthService;
+
+    private static final String ID_TOKEN = "google-id-token";
+    private static final String SUB = "google-sub-123";
+    private static final String GMAIL = "user@gmail.com";
+    private static final String SMU_EMAIL = "202021000@sangmyung.kr";
+
+    private GoogleUserInfo verifiedUserInfo;
+    private TokenResponse tokens;
+
+    @BeforeEach
+    void setUp() {
+        verifiedUserInfo = GoogleUserInfo.builder()
+                .sub(SUB).email(GMAIL).emailVerified(true).name("홍길동")
+                .build();
+        tokens = TokenResponse.of("access-token", "refresh-token");
+    }
+
+    private User googleUser() {
+        return User.signUpWithGoogle(GMAIL, "홍길동", SUB);
+    }
+
+    private User localUser() {
+        return User.signUp(SMU_EMAIL, "encoded-password", "김철수", true);
+    }
+
+    @Nested
+    @DisplayName("login 메서드")
+    class LoginTest {
+
+        @Test
+        @DisplayName("sub로 조회되는 기존 사용자는 바로 로그인 처리된다")
+        void login_existingUserBySub_returnsTokens() {
+            // given
+            given(googleIdTokenVerifier.verify(ID_TOKEN)).willReturn(verifiedUserInfo);
+            given(userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, SUB))
+                    .willReturn(Optional.of(googleUser()));
+            given(tokenProvider.generateToken(any(TokenRequest.class))).willReturn(tokens);
+
+            // when
+            GoogleLoginServiceResponse response = googleOAuthService.login(ID_TOKEN);
+
+            // then
+            assertThat(response.needsOnboarding()).isFalse();
+            assertThat(response.accessToken()).isEqualTo("access-token");
+            verify(refreshTokenRedisService).save(GMAIL, "refresh-token");
+        }
+
+        @Test
+        @DisplayName("구글 이메일이 바뀌어도 sub가 같으면 기존 계정으로 로그인된다")
+        void login_changedGoogleEmail_stillLogsInBySub() {
+            // given - 구글 측 이메일이 변경된 상황 (sub 는 불변)
+            GoogleUserInfo changedEmailInfo = GoogleUserInfo.builder()
+                    .sub(SUB).email("changed@gmail.com").emailVerified(true).name("홍길동")
+                    .build();
+            User existing = googleUser(); // 우리 DB 에는 기존 이메일로 저장됨
+            given(googleIdTokenVerifier.verify(ID_TOKEN)).willReturn(changedEmailInfo);
+            given(userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, SUB))
+                    .willReturn(Optional.of(existing));
+            given(tokenProvider.generateToken(any(TokenRequest.class))).willReturn(tokens);
+
+            // when
+            GoogleLoginServiceResponse response = googleOAuthService.login(ID_TOKEN);
+
+            // then - 우리 email 컬럼 기준으로 토큰 발급 (email 조회로 빠지지 않음)
+            assertThat(response.needsOnboarding()).isFalse();
+            assertThat(response.user().email()).isEqualTo(GMAIL);
+            verify(userRepository, never()).findByEmail(any());
+        }
+
+        @Test
+        @DisplayName("이메일이 일치하는 기존 로컬 계정은 자동 연동 후 로그인된다")
+        void login_matchingLocalAccount_autoLinksAndLogsIn() {
+            // given
+            GoogleUserInfo smuInfo = GoogleUserInfo.builder()
+                    .sub(SUB).email(SMU_EMAIL).emailVerified(true).name("김철수")
+                    .build();
+            User local = localUser();
+            given(googleIdTokenVerifier.verify(ID_TOKEN)).willReturn(smuInfo);
+            given(userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, SUB))
+                    .willReturn(Optional.empty());
+            given(userRepository.findByEmail(SMU_EMAIL)).willReturn(Optional.of(local));
+            given(userRepository.save(local)).willReturn(local);
+            given(tokenProvider.generateToken(any(TokenRequest.class))).willReturn(tokens);
+
+            // when
+            GoogleLoginServiceResponse response = googleOAuthService.login(ID_TOKEN);
+
+            // then
+            assertThat(response.needsOnboarding()).isFalse();
+            assertThat(local.getProviderId()).isEqualTo(SUB);
+            assertThat(local.getProvider()).isEqualTo(AuthProvider.GOOGLE);
+            assertThat(local.getPassword()).isNotNull(); // 비밀번호 로그인도 계속 가능
+            verify(refreshTokenRedisService).save(SMU_EMAIL, "refresh-token");
+        }
+
+        @Test
+        @DisplayName("이미 다른 구글 계정과 연동된 이메일이면 GoogleAccountConflictException을 던진다")
+        void login_emailLinkedToDifferentSub_throwsConflict() {
+            // given
+            User linkedToOther = googleUser(); // providerId = SUB
+            GoogleUserInfo otherSubInfo = GoogleUserInfo.builder()
+                    .sub("different-sub").email(GMAIL).emailVerified(true).name("홍길동")
+                    .build();
+            given(googleIdTokenVerifier.verify(ID_TOKEN)).willReturn(otherSubInfo);
+            given(userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, "different-sub"))
+                    .willReturn(Optional.empty());
+            given(userRepository.findByEmail(GMAIL)).willReturn(Optional.of(linkedToOther));
+
+            // when & then
+            assertThatThrownBy(() -> googleOAuthService.login(ID_TOKEN))
+                    .isInstanceOf(GoogleAccountConflictException.class);
+        }
+
+        @Test
+        @DisplayName("자동 연동 중 유니크 제약 충돌이 나면 sub로 재조회하여 멱등 로그인한다")
+        void login_autoLinkRace_recoversIdempotently() {
+            // given - 병렬 연동 경쟁에서 패배한 상황
+            GoogleUserInfo smuInfo = GoogleUserInfo.builder()
+                    .sub(SUB).email(SMU_EMAIL).emailVerified(true).name("김철수")
+                    .build();
+            User local = localUser();
+            User alreadyLinked = googleUser();
+            given(googleIdTokenVerifier.verify(ID_TOKEN)).willReturn(smuInfo);
+            given(userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, SUB))
+                    .willReturn(Optional.empty())            // 최초 조회 - 없음
+                    .willReturn(Optional.of(alreadyLinked)); // 충돌 후 재조회 - 있음
+            given(userRepository.findByEmail(SMU_EMAIL)).willReturn(Optional.of(local));
+            given(userRepository.save(local)).willThrow(new DataIntegrityViolationException("duplicate"));
+            given(tokenProvider.generateToken(any(TokenRequest.class))).willReturn(tokens);
+
+            // when
+            GoogleLoginServiceResponse response = googleOAuthService.login(ID_TOKEN);
+
+            // then
+            assertThat(response.needsOnboarding()).isFalse();
+        }
+
+        @Test
+        @DisplayName("신규 사용자는 계정을 만들지 않고 온보딩 토큰을 발급한다")
+        void login_newUser_returnsOnboardingTokenWithoutCreatingAccount() {
+            // given
+            given(googleIdTokenVerifier.verify(ID_TOKEN)).willReturn(verifiedUserInfo);
+            given(userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, SUB))
+                    .willReturn(Optional.empty());
+            given(userRepository.findByEmail(GMAIL)).willReturn(Optional.empty());
+            given(onboardingTokenProvider.generate(verifiedUserInfo)).willReturn("onboarding-token");
+
+            // when
+            GoogleLoginServiceResponse response = googleOAuthService.login(ID_TOKEN);
+
+            // then
+            assertThat(response.needsOnboarding()).isTrue();
+            assertThat(response.onboardingToken()).isEqualTo("onboarding-token");
+            assertThat(response.email()).isEqualTo(GMAIL);
+            assertThat(response.suggestedName()).isEqualTo("홍길동");
+            verify(userRepository, never()).save(any()); // 계정 미생성 검증
+            verify(refreshTokenRedisService, never()).save(any(), any());
+        }
+
+        @Test
+        @DisplayName("구글 측 이메일이 미검증이면 GoogleEmailNotVerifiedException을 던진다")
+        void login_unverifiedEmail_throwsNotVerified() {
+            // given - 미검증 이메일로 자동 연동하면 계정 탈취가 가능하므로 거부
+            GoogleUserInfo unverified = GoogleUserInfo.builder()
+                    .sub(SUB).email(GMAIL).emailVerified(false).name("홍길동")
+                    .build();
+            given(googleIdTokenVerifier.verify(ID_TOKEN)).willReturn(unverified);
+
+            // when & then
+            assertThatThrownBy(() -> googleOAuthService.login(ID_TOKEN))
+                    .isInstanceOf(GoogleEmailNotVerifiedException.class);
+        }
+
+        @Test
+        @DisplayName("이메일 클레임이 없으면 GoogleEmailNotVerifiedException을 던진다")
+        void login_missingEmail_throwsNotVerified() {
+            // given
+            GoogleUserInfo noEmail = GoogleUserInfo.builder()
+                    .sub(SUB).email(null).emailVerified(true).name("홍길동")
+                    .build();
+            given(googleIdTokenVerifier.verify(ID_TOKEN)).willReturn(noEmail);
+
+            // when & then
+            assertThatThrownBy(() -> googleOAuthService.login(ID_TOKEN))
+                    .isInstanceOf(GoogleEmailNotVerifiedException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("completeOnboarding 메서드")
+    class CompleteOnboardingTest {
+
+        private static final String ONBOARDING_TOKEN = "onboarding-token";
+        private static final String JTI = "jti-1";
+
+        private final GoogleOnboardingCompleteServiceRequest request =
+                GoogleOnboardingCompleteServiceRequest.of(ONBOARDING_TOKEN, true, "홍길동");
+
+        private final OnboardingClaims claims = new OnboardingClaims(SUB, GMAIL, "홍길동", JTI);
+
+        @Test
+        @DisplayName("정상 요청이면 계정을 생성하고 토큰을 발급한다")
+        void complete_withValidRequest_signsUpAndReturnsTokens() {
+            // given
+            given(onboardingTokenProvider.parse(ONBOARDING_TOKEN)).willReturn(claims);
+            given(onboardingTokenRedisService.markUsed(JTI)).willReturn(true);
+            given(userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, SUB))
+                    .willReturn(Optional.empty());
+            given(userRepository.findByEmail(GMAIL)).willReturn(Optional.empty());
+            given(userRepository.save(any(User.class))).willAnswer(inv -> inv.getArgument(0));
+            given(tokenProvider.generateToken(any(TokenRequest.class))).willReturn(tokens);
+
+            // when
+            LoginServiceResponse response = googleOAuthService.completeOnboarding(request);
+
+            // then
+            assertThat(response.accessToken()).isEqualTo("access-token");
+            assertThat(response.user().email()).isEqualTo(GMAIL);
+            verify(refreshTokenRedisService).save(GMAIL, "refresh-token");
+        }
+
+        @Test
+        @DisplayName("약관에 동의하지 않으면 IllegalArgumentException을 던진다")
+        void complete_withoutTermsAgreed_throwsIllegalArgument() {
+            // given
+            GoogleOnboardingCompleteServiceRequest noTerms =
+                    GoogleOnboardingCompleteServiceRequest.of(ONBOARDING_TOKEN, false, "홍길동");
+
+            // when & then
+            assertThatThrownBy(() -> googleOAuthService.completeOnboarding(noTerms))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("약관 동의가 필요합니다.");
+        }
+
+        @Test
+        @DisplayName("이미 사용된 토큰이라도 가입이 완료된 계정이 있으면 멱등 로그인한다")
+        void complete_replayAfterSignup_logsInIdempotently() {
+            // given - 두 탭에서 동시 제출한 상황의 패자
+            given(onboardingTokenProvider.parse(ONBOARDING_TOKEN)).willReturn(claims);
+            given(onboardingTokenRedisService.markUsed(JTI)).willReturn(false);
+            given(userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, SUB))
+                    .willReturn(Optional.of(googleUser()));
+            given(tokenProvider.generateToken(any(TokenRequest.class))).willReturn(tokens);
+
+            // when
+            LoginServiceResponse response = googleOAuthService.completeOnboarding(request);
+
+            // then
+            assertThat(response.accessToken()).isEqualTo("access-token");
+            verify(userRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("이미 사용된 토큰인데 계정이 없으면 OnboardingAlreadyCompletedException을 던진다")
+        void complete_replayWithoutAccount_throwsAlreadyCompleted() {
+            // given
+            given(onboardingTokenProvider.parse(ONBOARDING_TOKEN)).willReturn(claims);
+            given(onboardingTokenRedisService.markUsed(JTI)).willReturn(false);
+            given(userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, SUB))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> googleOAuthService.completeOnboarding(request))
+                    .isInstanceOf(OnboardingAlreadyCompletedException.class);
+        }
+
+        @Test
+        @DisplayName("온보딩 사이에 같은 이메일의 로컬 계정이 생겼으면 자동 연동한다")
+        void complete_localAccountCreatedMeanwhile_autoLinks() {
+            // given - 온보딩 토큰 발급과 완료 사이에 이메일 가입이 끝난 상황
+            OnboardingClaims smuClaims = new OnboardingClaims(SUB, SMU_EMAIL, "김철수", JTI);
+            User local = localUser();
+            given(onboardingTokenProvider.parse(ONBOARDING_TOKEN)).willReturn(smuClaims);
+            given(onboardingTokenRedisService.markUsed(JTI)).willReturn(true);
+            given(userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, SUB))
+                    .willReturn(Optional.empty());
+            given(userRepository.findByEmail(SMU_EMAIL)).willReturn(Optional.of(local));
+            given(userRepository.save(local)).willReturn(local);
+            given(tokenProvider.generateToken(any(TokenRequest.class))).willReturn(tokens);
+
+            // when
+            LoginServiceResponse response = googleOAuthService.completeOnboarding(request);
+
+            // then
+            assertThat(local.getProviderId()).isEqualTo(SUB);
+            assertThat(response.user().email()).isEqualTo(SMU_EMAIL);
+        }
+
+        @Test
+        @DisplayName("가입 저장 시 유니크 제약 충돌이 나면 sub로 재조회하여 멱등 처리한다")
+        void complete_signUpRace_recoversIdempotently() {
+            // given - 동시 가입 경쟁에서 저장에 실패한 상황
+            User winner = googleUser();
+            given(onboardingTokenProvider.parse(ONBOARDING_TOKEN)).willReturn(claims);
+            given(onboardingTokenRedisService.markUsed(JTI)).willReturn(true);
+            given(userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, SUB))
+                    .willReturn(Optional.empty())        // 저장 전 조회 - 없음
+                    .willReturn(Optional.of(winner));    // 충돌 후 재조회 - 있음
+            given(userRepository.findByEmail(GMAIL)).willReturn(Optional.empty());
+            given(userRepository.save(any(User.class)))
+                    .willThrow(new DataIntegrityViolationException("duplicate"));
+            given(tokenProvider.generateToken(any(TokenRequest.class))).willReturn(tokens);
+
+            // when
+            LoginServiceResponse response = googleOAuthService.completeOnboarding(request);
+
+            // then
+            assertThat(response.accessToken()).isEqualTo("access-token");
+        }
+
+        @Test
+        @DisplayName("유니크 제약 충돌 후 재조회에도 없으면 GoogleAccountConflictException을 던진다")
+        void complete_signUpRaceWithEmailConflict_throwsConflict() {
+            // given - 같은 이메일의 다른 계정이 선점한 상황 (unique(email) 충돌)
+            given(onboardingTokenProvider.parse(ONBOARDING_TOKEN)).willReturn(claims);
+            given(onboardingTokenRedisService.markUsed(JTI)).willReturn(true);
+            given(userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, SUB))
+                    .willReturn(Optional.empty());
+            given(userRepository.findByEmail(GMAIL)).willReturn(Optional.empty());
+            given(userRepository.save(any(User.class)))
+                    .willThrow(new DataIntegrityViolationException("duplicate"));
+
+            // when & then
+            assertThatThrownBy(() -> googleOAuthService.completeOnboarding(request))
+                    .isInstanceOf(GoogleAccountConflictException.class);
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/domain/user/service/GoogleOAuthServiceTest.java
+++ b/src/test/java/org/project/ttokttok/domain/user/service/GoogleOAuthServiceTest.java
@@ -44,6 +44,9 @@ class GoogleOAuthServiceTest {
     private UserRepository userRepository;
 
     @Mock
+    private GoogleAccountWriter googleAccountWriter;
+
+    @Mock
     private GoogleIdTokenVerifier googleIdTokenVerifier;
 
     @Mock
@@ -85,6 +88,12 @@ class GoogleOAuthServiceTest {
         return User.signUp(SMU_EMAIL, "encoded-password", "김철수", true);
     }
 
+    private User linkedLocalUser() {
+        User user = localUser();
+        user.linkGoogle(SUB);
+        return user;
+    }
+
     @Nested
     @DisplayName("login 메서드")
     class LoginTest {
@@ -105,6 +114,7 @@ class GoogleOAuthServiceTest {
             assertThat(response.needsOnboarding()).isFalse();
             assertThat(response.accessToken()).isEqualTo("access-token");
             verify(refreshTokenRedisService).save(GMAIL, "refresh-token");
+            verify(googleAccountWriter, never()).autoLink(any(), any());
         }
 
         @Test
@@ -136,12 +146,11 @@ class GoogleOAuthServiceTest {
             GoogleUserInfo smuInfo = GoogleUserInfo.builder()
                     .sub(SUB).email(SMU_EMAIL).emailVerified(true).name("김철수")
                     .build();
-            User local = localUser();
             given(googleIdTokenVerifier.verify(ID_TOKEN)).willReturn(smuInfo);
             given(userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, SUB))
                     .willReturn(Optional.empty());
-            given(userRepository.findByEmail(SMU_EMAIL)).willReturn(Optional.of(local));
-            given(userRepository.save(local)).willReturn(local);
+            given(userRepository.findByEmail(SMU_EMAIL)).willReturn(Optional.of(localUser()));
+            given(googleAccountWriter.autoLink(SMU_EMAIL, SUB)).willReturn(linkedLocalUser());
             given(tokenProvider.generateToken(any(TokenRequest.class))).willReturn(tokens);
 
             // when
@@ -149,24 +158,24 @@ class GoogleOAuthServiceTest {
 
             // then
             assertThat(response.needsOnboarding()).isFalse();
-            assertThat(local.getProviderId()).isEqualTo(SUB);
-            assertThat(local.getProvider()).isEqualTo(AuthProvider.GOOGLE);
-            assertThat(local.getPassword()).isNotNull(); // 비밀번호 로그인도 계속 가능
+            assertThat(response.user().email()).isEqualTo(SMU_EMAIL);
+            verify(googleAccountWriter).autoLink(SMU_EMAIL, SUB);
             verify(refreshTokenRedisService).save(SMU_EMAIL, "refresh-token");
         }
 
         @Test
         @DisplayName("이미 다른 구글 계정과 연동된 이메일이면 GoogleAccountConflictException을 던진다")
         void login_emailLinkedToDifferentSub_throwsConflict() {
-            // given
-            User linkedToOther = googleUser(); // providerId = SUB
+            // given - writer.autoLink 내부 linkGoogle 이 충돌 예외를 던진다
             GoogleUserInfo otherSubInfo = GoogleUserInfo.builder()
                     .sub("different-sub").email(GMAIL).emailVerified(true).name("홍길동")
                     .build();
             given(googleIdTokenVerifier.verify(ID_TOKEN)).willReturn(otherSubInfo);
             given(userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, "different-sub"))
                     .willReturn(Optional.empty());
-            given(userRepository.findByEmail(GMAIL)).willReturn(Optional.of(linkedToOther));
+            given(userRepository.findByEmail(GMAIL)).willReturn(Optional.of(googleUser()));
+            given(googleAccountWriter.autoLink(GMAIL, "different-sub"))
+                    .willThrow(new GoogleAccountConflictException());
 
             // when & then
             assertThatThrownBy(() -> googleOAuthService.login(ID_TOKEN))
@@ -176,18 +185,17 @@ class GoogleOAuthServiceTest {
         @Test
         @DisplayName("자동 연동 중 유니크 제약 충돌이 나면 sub로 재조회하여 멱등 로그인한다")
         void login_autoLinkRace_recoversIdempotently() {
-            // given - 병렬 연동 경쟁에서 패배한 상황
+            // given - 병렬 연동 경쟁에서 패배한 상황 (writer 가 DataIntegrityViolationException)
             GoogleUserInfo smuInfo = GoogleUserInfo.builder()
                     .sub(SUB).email(SMU_EMAIL).emailVerified(true).name("김철수")
                     .build();
-            User local = localUser();
-            User alreadyLinked = googleUser();
             given(googleIdTokenVerifier.verify(ID_TOKEN)).willReturn(smuInfo);
             given(userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, SUB))
-                    .willReturn(Optional.empty())            // 최초 조회 - 없음
-                    .willReturn(Optional.of(alreadyLinked)); // 충돌 후 재조회 - 있음
-            given(userRepository.findByEmail(SMU_EMAIL)).willReturn(Optional.of(local));
-            given(userRepository.save(local)).willThrow(new DataIntegrityViolationException("duplicate"));
+                    .willReturn(Optional.empty())              // 최초 조회 - 없음
+                    .willReturn(Optional.of(linkedLocalUser())); // 충돌 후 재조회 - 있음
+            given(userRepository.findByEmail(SMU_EMAIL)).willReturn(Optional.of(localUser()));
+            given(googleAccountWriter.autoLink(SMU_EMAIL, SUB))
+                    .willThrow(new DataIntegrityViolationException("duplicate"));
             given(tokenProvider.generateToken(any(TokenRequest.class))).willReturn(tokens);
 
             // when
@@ -195,6 +203,7 @@ class GoogleOAuthServiceTest {
 
             // then
             assertThat(response.needsOnboarding()).isFalse();
+            assertThat(response.accessToken()).isEqualTo("access-token");
         }
 
         @Test
@@ -215,7 +224,8 @@ class GoogleOAuthServiceTest {
             assertThat(response.onboardingToken()).isEqualTo("onboarding-token");
             assertThat(response.email()).isEqualTo(GMAIL);
             assertThat(response.suggestedName()).isEqualTo("홍길동");
-            verify(userRepository, never()).save(any()); // 계정 미생성 검증
+            verify(googleAccountWriter, never()).createGoogleUser(any(), any()); // 계정 미생성 검증
+            verify(googleAccountWriter, never()).autoLink(any(), any());
             verify(refreshTokenRedisService, never()).save(any(), any());
         }
 
@@ -266,10 +276,7 @@ class GoogleOAuthServiceTest {
             // given
             given(onboardingTokenProvider.parse(ONBOARDING_TOKEN)).willReturn(claims);
             given(onboardingTokenRedisService.markUsed(JTI)).willReturn(true);
-            given(userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, SUB))
-                    .willReturn(Optional.empty());
-            given(userRepository.findByEmail(GMAIL)).willReturn(Optional.empty());
-            given(userRepository.save(any(User.class))).willAnswer(inv -> inv.getArgument(0));
+            given(googleAccountWriter.createGoogleUser(claims, "홍길동")).willReturn(googleUser());
             given(tokenProvider.generateToken(any(TokenRequest.class))).willReturn(tokens);
 
             // when
@@ -309,7 +316,7 @@ class GoogleOAuthServiceTest {
 
             // then
             assertThat(response.accessToken()).isEqualTo("access-token");
-            verify(userRepository, never()).save(any());
+            verify(googleAccountWriter, never()).createGoogleUser(any(), any());
         }
 
         @Test
@@ -327,40 +334,34 @@ class GoogleOAuthServiceTest {
         }
 
         @Test
-        @DisplayName("온보딩 사이에 같은 이메일의 로컬 계정이 생겼으면 자동 연동한다")
-        void complete_localAccountCreatedMeanwhile_autoLinks() {
-            // given - 온보딩 토큰 발급과 완료 사이에 이메일 가입이 끝난 상황
+        @DisplayName("writer가 반환한 계정(온보딩 사이 자동 연동 등)으로 토큰을 발급한다")
+        void complete_writerReturnsLinkedAccount_issuesTokens() {
+            // given - 온보딩 토큰 발급과 완료 사이에 이메일 가입이 끝나 writer 가 연동 처리한 계정 반환
             OnboardingClaims smuClaims = new OnboardingClaims(SUB, SMU_EMAIL, "김철수", JTI);
-            User local = localUser();
+            GoogleOnboardingCompleteServiceRequest smuRequest =
+                    GoogleOnboardingCompleteServiceRequest.of(ONBOARDING_TOKEN, true, "김철수");
             given(onboardingTokenProvider.parse(ONBOARDING_TOKEN)).willReturn(smuClaims);
             given(onboardingTokenRedisService.markUsed(JTI)).willReturn(true);
-            given(userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, SUB))
-                    .willReturn(Optional.empty());
-            given(userRepository.findByEmail(SMU_EMAIL)).willReturn(Optional.of(local));
-            given(userRepository.save(local)).willReturn(local);
+            given(googleAccountWriter.createGoogleUser(smuClaims, "김철수")).willReturn(linkedLocalUser());
             given(tokenProvider.generateToken(any(TokenRequest.class))).willReturn(tokens);
 
             // when
-            LoginServiceResponse response = googleOAuthService.completeOnboarding(request);
+            LoginServiceResponse response = googleOAuthService.completeOnboarding(smuRequest);
 
             // then
-            assertThat(local.getProviderId()).isEqualTo(SUB);
             assertThat(response.user().email()).isEqualTo(SMU_EMAIL);
         }
 
         @Test
         @DisplayName("가입 저장 시 유니크 제약 충돌이 나면 sub로 재조회하여 멱등 처리한다")
         void complete_signUpRace_recoversIdempotently() {
-            // given - 동시 가입 경쟁에서 저장에 실패한 상황
-            User winner = googleUser();
+            // given - 동시 가입 경쟁에서 writer 저장이 실패한 상황
             given(onboardingTokenProvider.parse(ONBOARDING_TOKEN)).willReturn(claims);
             given(onboardingTokenRedisService.markUsed(JTI)).willReturn(true);
-            given(userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, SUB))
-                    .willReturn(Optional.empty())        // 저장 전 조회 - 없음
-                    .willReturn(Optional.of(winner));    // 충돌 후 재조회 - 있음
-            given(userRepository.findByEmail(GMAIL)).willReturn(Optional.empty());
-            given(userRepository.save(any(User.class)))
+            given(googleAccountWriter.createGoogleUser(claims, "홍길동"))
                     .willThrow(new DataIntegrityViolationException("duplicate"));
+            given(userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, SUB))
+                    .willReturn(Optional.of(googleUser())); // 충돌 후 재조회 - 승자 존재
             given(tokenProvider.generateToken(any(TokenRequest.class))).willReturn(tokens);
 
             // when
@@ -373,14 +374,13 @@ class GoogleOAuthServiceTest {
         @Test
         @DisplayName("유니크 제약 충돌 후 재조회에도 없으면 GoogleAccountConflictException을 던진다")
         void complete_signUpRaceWithEmailConflict_throwsConflict() {
-            // given - 같은 이메일의 다른 계정이 선점한 상황 (unique(email) 충돌)
+            // given - 같은 이메일을 다른 계정이 선점한 상황 (unique(email) 충돌, sub 로는 조회 안 됨)
             given(onboardingTokenProvider.parse(ONBOARDING_TOKEN)).willReturn(claims);
             given(onboardingTokenRedisService.markUsed(JTI)).willReturn(true);
+            given(googleAccountWriter.createGoogleUser(claims, "홍길동"))
+                    .willThrow(new DataIntegrityViolationException("duplicate"));
             given(userRepository.findByProviderAndProviderId(AuthProvider.GOOGLE, SUB))
                     .willReturn(Optional.empty());
-            given(userRepository.findByEmail(GMAIL)).willReturn(Optional.empty());
-            given(userRepository.save(any(User.class)))
-                    .willThrow(new DataIntegrityViolationException("duplicate"));
 
             // when & then
             assertThatThrownBy(() -> googleOAuthService.completeOnboarding(request))

--- a/src/test/java/org/project/ttokttok/domain/user/service/UserAuthServiceOAuthGuardTest.java
+++ b/src/test/java/org/project/ttokttok/domain/user/service/UserAuthServiceOAuthGuardTest.java
@@ -1,0 +1,101 @@
+package org.project.ttokttok.domain.user.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.domain.user.domain.User;
+import org.project.ttokttok.domain.user.exception.OAuthOnlyAccountException;
+import org.project.ttokttok.domain.user.repository.EmailVerificationRepository;
+import org.project.ttokttok.domain.user.repository.UserRepository;
+import org.project.ttokttok.domain.user.service.dto.request.LoginServiceRequest;
+import org.project.ttokttok.domain.user.service.dto.request.ResetPasswordServiceRequest;
+import org.project.ttokttok.global.auth.jwt.service.TokenProvider;
+import org.project.ttokttok.infrastructure.email.service.EmailService;
+import org.project.ttokttok.infrastructure.redis.service.RefreshTokenRedisService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * OAuth 전용 계정(비밀번호 없음)이 기존 비밀번호 기반 경로에 접근할 때의 가드 테스트
+ */
+@ExtendWith(MockitoExtension.class)
+class UserAuthServiceOAuthGuardTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private EmailVerificationRepository emailVerificationRepository;
+
+    @Mock
+    private EmailService emailService;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private RefreshTokenRedisService refreshTokenRedisService;
+
+    @InjectMocks
+    private UserAuthService userAuthService;
+
+    private static final String GMAIL = "user@gmail.com";
+
+    private User oauthOnlyUser() {
+        return User.signUpWithGoogle(GMAIL, "홍길동", "google-sub-123");
+    }
+
+    @Test
+    @DisplayName("OAuth 전용 계정으로 비밀번호 로그인을 시도하면 OAuthOnlyAccountException을 던진다 (NPE 아님)")
+    void login_withOAuthOnlyAccount_throwsOAuthOnlyException() {
+        // given
+        given(userRepository.findByEmail(GMAIL)).willReturn(Optional.of(oauthOnlyUser()));
+        LoginServiceRequest request = new LoginServiceRequest(GMAIL, "AnyPassword123!", false);
+
+        // when & then
+        assertThatThrownBy(() -> userAuthService.login(request))
+                .isInstanceOf(OAuthOnlyAccountException.class);
+        verify(passwordEncoder, never()).matches(any(), any()); // BCrypt 도달 전 차단
+    }
+
+    @Test
+    @DisplayName("OAuth 전용 계정으로 비밀번호 재설정 코드 발송을 시도하면 OAuthOnlyAccountException을 던진다")
+    void sendPasswordResetCode_withOAuthOnlyAccount_throwsOAuthOnlyException() {
+        // given
+        given(userRepository.findByEmail(GMAIL)).willReturn(Optional.of(oauthOnlyUser()));
+
+        // when & then
+        assertThatThrownBy(() -> userAuthService.sendPasswordResetCode(GMAIL))
+                .isInstanceOf(OAuthOnlyAccountException.class);
+        verify(emailService, never()).sendPasswordResetCode(any());
+    }
+
+    @Test
+    @DisplayName("OAuth 전용 계정으로 비밀번호 재설정을 시도하면 OAuthOnlyAccountException을 던진다")
+    void resetPassword_withOAuthOnlyAccount_throwsOAuthOnlyException() {
+        // given
+        given(emailVerificationRepository.existsByEmailAndCodeAndIsVerifiedTrue(GMAIL, "123456"))
+                .willReturn(true);
+        given(userRepository.findByEmail(GMAIL)).willReturn(Optional.of(oauthOnlyUser()));
+        ResetPasswordServiceRequest request = new ResetPasswordServiceRequest(
+                GMAIL, "123456", "NewPassword123!", "NewPassword123!");
+
+        // when & then
+        assertThatThrownBy(() -> userAuthService.resetPassword(request))
+                .isInstanceOf(OAuthOnlyAccountException.class);
+        verify(userRepository, never()).save(any());
+    }
+}

--- a/src/test/java/org/project/ttokttok/global/auth/jwt/service/OnboardingTokenProviderTest.java
+++ b/src/test/java/org/project/ttokttok/global/auth/jwt/service/OnboardingTokenProviderTest.java
@@ -1,0 +1,162 @@
+package org.project.ttokttok.global.auth.jwt.service;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.global.auth.jwt.exception.InvalidOnboardingTokenException;
+import org.project.ttokttok.global.auth.jwt.exception.OnboardingTokenExpiredException;
+import org.project.ttokttok.global.auth.oauth.dto.GoogleUserInfo;
+
+import java.security.Key;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OnboardingTokenProviderTest {
+
+    private static final String TEST_SECRET = "dGVzdFNlY3JldEtleUZvclRva2VuUHJvdmlkZXJUZXN0MTIzNDU2Nzg5MA==";
+    private static final String TEST_ISSUER = "test-issuer";
+
+    private OnboardingTokenProvider onboardingTokenProvider;
+    private Key key;
+
+    private static final GoogleUserInfo USER_INFO = GoogleUserInfo.builder()
+            .sub("google-sub-123")
+            .email("user@gmail.com")
+            .emailVerified(true)
+            .name("홍길동")
+            .build();
+
+    @BeforeEach
+    void setUp() {
+        onboardingTokenProvider = new OnboardingTokenProvider(TEST_ISSUER, TEST_SECRET);
+        key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(TEST_SECRET));
+    }
+
+    @Nested
+    @DisplayName("generate 메서드")
+    class GenerateTest {
+
+        @Test
+        @DisplayName("생성한 토큰을 파싱하면 구글 신원 정보가 그대로 복원된다")
+        void generate_thenParse_roundTrip() {
+            // given
+            String token = onboardingTokenProvider.generate(USER_INFO);
+
+            // when
+            OnboardingTokenProvider.OnboardingClaims claims = onboardingTokenProvider.parse(token);
+
+            // then
+            assertThat(claims.sub()).isEqualTo("google-sub-123");
+            assertThat(claims.email()).isEqualTo("user@gmail.com");
+            assertThat(claims.name()).isEqualTo("홍길동");
+            assertThat(claims.jti()).isNotBlank();
+        }
+
+        @Test
+        @DisplayName("생성할 때마다 서로 다른 jti가 부여된다")
+        void generate_eachToken_hasUniqueJti() {
+            // given
+            String token1 = onboardingTokenProvider.generate(USER_INFO);
+            String token2 = onboardingTokenProvider.generate(USER_INFO);
+
+            // when
+            String jti1 = onboardingTokenProvider.parse(token1).jti();
+            String jti2 = onboardingTokenProvider.parse(token2).jti();
+
+            // then
+            assertThat(jti1).isNotEqualTo(jti2);
+        }
+    }
+
+    @Nested
+    @DisplayName("parse 메서드")
+    class ParseTest {
+
+        @Test
+        @DisplayName("만료된 토큰이면 OnboardingTokenExpiredException을 던진다")
+        void parse_withExpiredToken_throwsExpired() {
+            // given
+            Date now = new Date();
+            String expiredToken = Jwts.builder()
+                    .setIssuer(TEST_ISSUER)
+                    .setSubject("google-sub-123")
+                    .setId("jti-1")
+                    .setIssuedAt(new Date(now.getTime() - 20 * 60 * 1000L))
+                    .setExpiration(new Date(now.getTime() - 1000L))
+                    .claim("token_type", "onboarding")
+                    .signWith(key, SignatureAlgorithm.HS256)
+                    .compact();
+
+            // when & then
+            assertThatThrownBy(() -> onboardingTokenProvider.parse(expiredToken))
+                    .isInstanceOf(OnboardingTokenExpiredException.class);
+        }
+
+        @Test
+        @DisplayName("서명이 위조된 토큰이면 InvalidOnboardingTokenException을 던진다")
+        void parse_withTamperedToken_throwsInvalid() {
+            // given
+            String token = onboardingTokenProvider.generate(USER_INFO);
+            String tampered = token.substring(0, token.length() - 4) + "abcd";
+
+            // when & then
+            assertThatThrownBy(() -> onboardingTokenProvider.parse(tampered))
+                    .isInstanceOf(InvalidOnboardingTokenException.class);
+        }
+
+        @Test
+        @DisplayName("token_type 클레임이 없는 액세스 토큰이면 InvalidOnboardingTokenException을 던진다")
+        void parse_withAccessToken_throwsInvalid() {
+            // given - 같은 키/이슈어로 서명된 액세스 토큰 (token_type 없음)
+            Date now = new Date();
+            String accessToken = Jwts.builder()
+                    .setIssuer(TEST_ISSUER)
+                    .setSubject("user@gmail.com")
+                    .setIssuedAt(now)
+                    .setExpiration(new Date(now.getTime() + 3600000L))
+                    .claim("role", "ROLE_USER")
+                    .signWith(key, SignatureAlgorithm.HS256)
+                    .compact();
+
+            // when & then
+            assertThatThrownBy(() -> onboardingTokenProvider.parse(accessToken))
+                    .isInstanceOf(InvalidOnboardingTokenException.class);
+        }
+
+        @Test
+        @DisplayName("발급자가 다른 토큰이면 InvalidOnboardingTokenException을 던진다")
+        void parse_withWrongIssuer_throwsInvalid() {
+            // given
+            Date now = new Date();
+            String wrongIssuerToken = Jwts.builder()
+                    .setIssuer("wrong-issuer")
+                    .setSubject("google-sub-123")
+                    .setId("jti-1")
+                    .setIssuedAt(now)
+                    .setExpiration(new Date(now.getTime() + 600000L))
+                    .claim("token_type", "onboarding")
+                    .signWith(key, SignatureAlgorithm.HS256)
+                    .compact();
+
+            // when & then
+            assertThatThrownBy(() -> onboardingTokenProvider.parse(wrongIssuerToken))
+                    .isInstanceOf(InvalidOnboardingTokenException.class);
+        }
+
+        @Test
+        @DisplayName("null 또는 빈 토큰이면 InvalidOnboardingTokenException을 던진다")
+        void parse_withNullOrBlank_throwsInvalid() {
+            assertThatThrownBy(() -> onboardingTokenProvider.parse(null))
+                    .isInstanceOf(InvalidOnboardingTokenException.class);
+            assertThatThrownBy(() -> onboardingTokenProvider.parse("  "))
+                    .isInstanceOf(InvalidOnboardingTokenException.class);
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/global/auth/jwt/service/TokenProviderTest.java
+++ b/src/test/java/org/project/ttokttok/global/auth/jwt/service/TokenProviderTest.java
@@ -127,6 +127,28 @@ class TokenProviderTest {
         }
 
         @Test
+        @DisplayName("token_type 클레임이 있는 토큰(온보딩 토큰 등)이면 false를 반환한다")
+        void validateToken_withTokenTypeClaim_returnsFalse() {
+            // given - 온보딩 토큰은 같은 키/이슈어로 서명되지만 액세스 토큰으로 사용될 수 없다
+            Date now = new Date();
+            String onboardingToken = Jwts.builder()
+                    .setIssuer(TEST_ISSUER)
+                    .setSubject("google-sub-123")
+                    .setIssuedAt(now)
+                    .setExpiration(new Date(now.getTime() + 600000L))
+                    .claim("token_type", "onboarding")
+                    .signWith(key, SignatureAlgorithm.HS256)
+                    .compact();
+            when(refreshTokenRedisService.isAccessTokenBlacklisted(onboardingToken)).thenReturn(false);
+
+            // when
+            boolean result = tokenProvider.validateToken(onboardingToken);
+
+            // then
+            assertThat(result).isFalse();
+        }
+
+        @Test
         @DisplayName("잘못된 issuer의 토큰이면 false를 반환한다")
         void validateToken_withInvalidIssuer_returnsFalse() {
             // given

--- a/src/test/java/org/project/ttokttok/global/auth/oauth/GoogleIdTokenVerifierTest.java
+++ b/src/test/java/org/project/ttokttok/global/auth/oauth/GoogleIdTokenVerifierTest.java
@@ -49,6 +49,25 @@ class GoogleIdTokenVerifierTest {
     }
 
     @Test
+    @DisplayName("이메일은 대소문자를 정규화하여 소문자로 반환한다")
+    void verify_normalizesEmailToLowerCase() {
+        // given - 자동 연동 조회 미스로 인한 계정 중복 방지
+        Jwt jwt = Jwt.withTokenValue("id-token")
+                .header("alg", "RS256")
+                .subject("google-sub-123")
+                .claim("email", "User@Gmail.COM")
+                .claim("email_verified", true)
+                .build();
+        given(googleJwtDecoder.decode("id-token")).willReturn(jwt);
+
+        // when
+        GoogleUserInfo userInfo = googleIdTokenVerifier.verify("id-token");
+
+        // then
+        assertThat(userInfo.email()).isEqualTo("user@gmail.com");
+    }
+
+    @Test
     @DisplayName("email_verified 클레임이 없으면 미검증으로 취급한다")
     void verify_withoutEmailVerifiedClaim_treatsAsUnverified() {
         // given

--- a/src/test/java/org/project/ttokttok/global/auth/oauth/GoogleIdTokenVerifierTest.java
+++ b/src/test/java/org/project/ttokttok/global/auth/oauth/GoogleIdTokenVerifierTest.java
@@ -1,0 +1,88 @@
+package org.project.ttokttok.global.auth.oauth;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.global.auth.oauth.dto.GoogleUserInfo;
+import org.project.ttokttok.global.auth.oauth.exception.InvalidGoogleTokenException;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class GoogleIdTokenVerifierTest {
+
+    @Mock
+    private JwtDecoder googleJwtDecoder;
+
+    @InjectMocks
+    private GoogleIdTokenVerifier googleIdTokenVerifier;
+
+    @Test
+    @DisplayName("유효한 ID 토큰이면 구글 사용자 정보를 추출한다")
+    void verify_withValidToken_returnsUserInfo() {
+        // given
+        Jwt jwt = Jwt.withTokenValue("id-token")
+                .header("alg", "RS256")
+                .subject("google-sub-123")
+                .claim("email", "user@gmail.com")
+                .claim("email_verified", true)
+                .claim("name", "홍길동")
+                .build();
+        given(googleJwtDecoder.decode("id-token")).willReturn(jwt);
+
+        // when
+        GoogleUserInfo userInfo = googleIdTokenVerifier.verify("id-token");
+
+        // then
+        assertThat(userInfo.sub()).isEqualTo("google-sub-123");
+        assertThat(userInfo.email()).isEqualTo("user@gmail.com");
+        assertThat(userInfo.emailVerified()).isTrue();
+        assertThat(userInfo.name()).isEqualTo("홍길동");
+    }
+
+    @Test
+    @DisplayName("email_verified 클레임이 없으면 미검증으로 취급한다")
+    void verify_withoutEmailVerifiedClaim_treatsAsUnverified() {
+        // given
+        Jwt jwt = Jwt.withTokenValue("id-token")
+                .header("alg", "RS256")
+                .subject("google-sub-123")
+                .claim("email", "user@gmail.com")
+                .build();
+        given(googleJwtDecoder.decode("id-token")).willReturn(jwt);
+
+        // when
+        GoogleUserInfo userInfo = googleIdTokenVerifier.verify("id-token");
+
+        // then
+        assertThat(userInfo.emailVerified()).isFalse();
+    }
+
+    @Test
+    @DisplayName("디코더 검증 실패(서명/만료/iss/aud)면 InvalidGoogleTokenException을 던진다")
+    void verify_withDecoderFailure_throwsInvalidGoogleToken() {
+        // given
+        given(googleJwtDecoder.decode("bad-token")).willThrow(new JwtException("invalid"));
+
+        // when & then
+        assertThatThrownBy(() -> googleIdTokenVerifier.verify("bad-token"))
+                .isInstanceOf(InvalidGoogleTokenException.class);
+    }
+
+    @Test
+    @DisplayName("null 또는 빈 토큰이면 InvalidGoogleTokenException을 던진다")
+    void verify_withNullOrBlank_throwsInvalidGoogleToken() {
+        assertThatThrownBy(() -> googleIdTokenVerifier.verify(null))
+                .isInstanceOf(InvalidGoogleTokenException.class);
+        assertThatThrownBy(() -> googleIdTokenVerifier.verify(" "))
+                .isInstanceOf(InvalidGoogleTokenException.class);
+    }
+}

--- a/src/test/java/org/project/ttokttok/infrastructure/redis/service/OnboardingTokenRedisServiceTest.java
+++ b/src/test/java/org/project/ttokttok/infrastructure/redis/service/OnboardingTokenRedisServiceTest.java
@@ -1,0 +1,63 @@
+package org.project.ttokttok.infrastructure.redis.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class OnboardingTokenRedisServiceTest {
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private OnboardingTokenRedisService onboardingTokenRedisService;
+
+    @BeforeEach
+    void setUp() {
+        onboardingTokenRedisService = new OnboardingTokenRedisService(redisTemplate);
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+    }
+
+    @Test
+    @DisplayName("최초 사용 시 true를 반환한다 (SETNX 선점 성공)")
+    void markUsed_firstTime_returnsTrue() {
+        // given
+        given(valueOperations.setIfAbsent(eq("onboarding:used:jti-1"), eq("used"), any(Duration.class)))
+                .willReturn(true);
+
+        // when
+        boolean result = onboardingTokenRedisService.markUsed("jti-1");
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("이미 사용된 jti면 false를 반환한다 (재생/동시 요청 차단)")
+    void markUsed_alreadyUsed_returnsFalse() {
+        // given
+        given(valueOperations.setIfAbsent(eq("onboarding:used:jti-1"), eq("used"), any(Duration.class)))
+                .willReturn(false);
+
+        // when
+        boolean result = onboardingTokenRedisService.markUsed("jti-1");
+
+        // then
+        assertThat(result).isFalse();
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용
- 기존 이메일+비밀번호 로그인을 유지한 채 **Google OAuth 로그인(ID 토큰 검증 방식)** 추가
  - `POST /api/user/auth/oauth/google` — 구글 ID 토큰 검증 후 로그인(기존/자동연동) 또는 온보딩 안내(신규)
  - `POST /api/user/auth/oauth/google/complete` — 약관 동의 + 이름 입력 후 가입 완료 및 토큰 발급
- ID 토큰 검증: `spring-security-oauth2-jose` (Google JWKS 서명 검증 + iss 2형식/aud(client-id) 커스텀 밸리데이터, 60초 clock skew, lazy 로딩)
- 식별자 모델: Google `sub`를 안정 식별자로 저장 — sub 우선 조회로 구글 이메일이 변경되어도 로그인 유지
- 자동 연동: `email_verified=true`인 구글 이메일이 기존 계정과 일치하면 자동 연동 (비밀번호 유지, 두 로그인 방식 공존). 미검증 이메일은 계정 탈취 벡터라 거부
- 2단계 온보딩: 신규 사용자는 계정을 만들지 않고 10분 TTL 온보딩 토큰 발급 → 동의 화면 후 가입 완료
- 동시성 방어 3중화: Redis SETNX(jti 일회성) + DB 유니크 제약 + `DataIntegrityViolationException` 시 멱등 재조회 → 재생/두 탭/병렬 가입 경쟁이 전부 로그인 성공으로 수렴
- 보안: 온보딩 토큰이 액세스 토큰으로 오용되지 않도록 `TokenProvider.validateToken`에서 `token_type` 클레임 거부 (역방향도 차단). ID 토큰 원문 로깅 금지
- 기존 경로 강화: OAuth 전용 계정(password NULL)의 비밀번호 로그인/재설정 시 `OAuthOnlyAccountException`(409)
- Swagger 문서: `UserOAuthDocs` 인터페이스 신규 작성 (요청/응답/에러 코드 명세)
- **DB 변경 있음**: `V23__add_oauth_columns_to_users.sql` — `users.password` NULL 허용, `provider`/`provider_id` 컬럼 추가, `(provider, provider_id)` 유니크 제약

---

## 🔍 관련 이슈
- 해결한 이슈 번호: #335

---

## ✅ 체크리스트
- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요?
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항
- **배포 전 필수**: GCP Console에서 OAuth 2.0 Web Client ID를 발급하고 dev/prod `application-*.yml`의 `google.oauth.client-id` placeholder를 교체해야 합니다 (yml은 gitignored — 서버에 수동 반영). Authorized JavaScript origins에 프론트 도메인 등록 필요, redirect URI는 불필요(GIS 토큰 플로우).
- 기존 이메일 가입의 `@sangmyung.kr` 제한은 그대로 유지됩니다 (회귀 테스트로 고정). 구글 로그인만 전체 구글 계정 허용.
- 리프레시 토큰/재발급/로그아웃은 email 키 기반이라 OAuth 사용자도 기존 플로우 무변경으로 동작합니다.
- `bash maintenance/verify.sh` 그린 (전체 테스트 + JaCoCo 80% 게이트 통과). 신규 테스트 7종 + `TokenProviderTest` 확장.
- 프론트엔드용 API 계약 문서는 별도 전달 예정.
