### PR TITLE
동아리 게시판 썸네일 업로드 및 인스타그램식 피드 응답 확장 (feat/#337 -> develop)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bash maintenance/verify.sh)"
+    ]
+  }
+}

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminController.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminController.java
@@ -14,8 +14,10 @@ import org.project.ttokttok.domain.clubboard.service.ClubBoardAdminService;
 import org.project.ttokttok.domain.clubboard.service.dto.request.DeleteBoardServiceRequest;
 import org.project.ttokttok.global.annotation.auth.AuthUserInfo;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Map;
 
@@ -33,20 +35,22 @@ public class ClubBoardAdminController {
 
     @Operation(
             summary = "게시글 생성",
-            description = "동아리 관리자가 게시판에 새 게시글을 작성합니다."
+            description = "동아리 관리자가 게시판에 새 게시글을 작성합니다. multipart/form-data로 request(JSON)와 thumbnail(대표 이미지, 필수)을 전송합니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "생성 성공"),
+            @ApiResponse(responseCode = "400", description = "썸네일 누락 또는 이미지 형식이 아님"),
             @ApiResponse(responseCode = "403", description = "해당 동아리의 관리자가 아님"),
             @ApiResponse(responseCode = "404", description = "동아리를 찾을 수 없음")
     })
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ClubBoardCreateResponse> createBoard(
             @Parameter(hidden = true) @AuthUserInfo String username,
             @Parameter(description = "동아리 ID", required = true) @PathVariable String clubId,
-            @RequestBody @Valid CreateBoardRequest request
+            @RequestPart("request") @Valid CreateBoardRequest request,
+            @RequestPart("thumbnail") MultipartFile thumbnail
     ) {
-        String boardId = clubBoardAdminService.createBoard(request.toServiceRequest(username, clubId));
+        String boardId = clubBoardAdminService.createBoard(request.toServiceRequest(username, clubId, thumbnail));
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new ClubBoardCreateResponse(boardId));
@@ -54,21 +58,27 @@ public class ClubBoardAdminController {
 
     @Operation(
             summary = "게시글 수정",
-            description = "동아리 관리자가 기존 게시글의 제목/내용을 수정합니다. 생략하거나 null인 필드는 기존 값을 유지합니다."
+            description = "동아리 관리자가 기존 게시글의 제목/내용/썸네일을 수정합니다. multipart/form-data로 request(JSON)와 thumbnail(대표 이미지)을 전송하며, 생략하거나 null인 필드는 기존 값을 유지합니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "썸네일이 이미지 형식이 아님"),
             @ApiResponse(responseCode = "403", description = "해당 동아리의 관리자가 아님"),
             @ApiResponse(responseCode = "404", description = "동아리 또는 게시글을 찾을 수 없음")
     })
-    @PatchMapping("/{boardId}")
+    @PatchMapping(value = "/{boardId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Map<String, String>> updateBoard(
             @Parameter(hidden = true) @AuthUserInfo String username,
             @Parameter(description = "동아리 ID", required = true) @PathVariable String clubId,
             @Parameter(description = "게시글 ID", required = true) @PathVariable String boardId,
-            @RequestBody ClubBoardUpdateRequest request
+            @RequestPart(value = "request", required = false) ClubBoardUpdateRequest request,
+            @RequestPart(value = "thumbnail", required = false) MultipartFile thumbnail
     ) {
-        clubBoardAdminService.updateBoard(request.toServiceRequest(username, clubId, boardId));
+        ClubBoardUpdateRequest safeRequest = request != null
+                ? request
+                : new ClubBoardUpdateRequest(null, null);
+
+        clubBoardAdminService.updateBoard(safeRequest.toServiceRequest(username, clubId, boardId, thumbnail));
 
         return ResponseEntity.ok()
                 .body(Map.of("message", "게시글이 수정되었습니다."));

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminController.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminController.java
@@ -1,12 +1,8 @@
 package org.project.ttokttok.domain.clubboard.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.project.ttokttok.domain.clubboard.controller.docs.ClubBoardAdminDocs;
 import org.project.ttokttok.domain.clubboard.controller.dto.request.ClubBoardUpdateRequest;
 import org.project.ttokttok.domain.clubboard.controller.dto.request.CreateBoardRequest;
 import org.project.ttokttok.domain.clubboard.controller.dto.response.ClubBoardCreateResponse;
@@ -24,29 +20,20 @@ import java.util.Map;
 /**
  * 동아리 게시판 관리 API 컨트롤러
  * 동아리 관리자가 게시글을 생성, 수정, 삭제할 수 있는 API들을 제공합니다.
+ * Swagger 문서는 {@link ClubBoardAdminDocs}에 분리되어 있습니다.
  */
-@Tag(name = "[관리자] 동아리 게시판 관리", description = "동아리 관리자가 게시판 게시글을 관리하는 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin/clubs/{clubId}/boards")
-public class ClubBoardAdminController {
+public class ClubBoardAdminController implements ClubBoardAdminDocs {
 
     private final ClubBoardAdminService clubBoardAdminService;
 
-    @Operation(
-            summary = "게시글 생성",
-            description = "동아리 관리자가 게시판에 새 게시글을 작성합니다. multipart/form-data로 request(JSON)와 thumbnail(대표 이미지, 필수)을 전송합니다."
-    )
-    @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "생성 성공"),
-            @ApiResponse(responseCode = "400", description = "썸네일 누락 또는 이미지 형식이 아님"),
-            @ApiResponse(responseCode = "403", description = "해당 동아리의 관리자가 아님"),
-            @ApiResponse(responseCode = "404", description = "동아리를 찾을 수 없음")
-    })
+    @Override
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ClubBoardCreateResponse> createBoard(
-            @Parameter(hidden = true) @AuthUserInfo String username,
-            @Parameter(description = "동아리 ID", required = true) @PathVariable String clubId,
+            @AuthUserInfo String username,
+            @PathVariable String clubId,
             @RequestPart("request") @Valid CreateBoardRequest request,
             @RequestPart("thumbnail") MultipartFile thumbnail
     ) {
@@ -56,21 +43,12 @@ public class ClubBoardAdminController {
                 .body(new ClubBoardCreateResponse(boardId));
     }
 
-    @Operation(
-            summary = "게시글 수정",
-            description = "동아리 관리자가 기존 게시글의 제목/내용/썸네일을 수정합니다. multipart/form-data로 request(JSON)와 thumbnail(대표 이미지)을 전송하며, 생략하거나 null인 필드는 기존 값을 유지합니다."
-    )
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "수정 성공"),
-            @ApiResponse(responseCode = "400", description = "썸네일이 이미지 형식이 아님"),
-            @ApiResponse(responseCode = "403", description = "해당 동아리의 관리자가 아님"),
-            @ApiResponse(responseCode = "404", description = "동아리 또는 게시글을 찾을 수 없음")
-    })
+    @Override
     @PatchMapping(value = "/{boardId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Map<String, String>> updateBoard(
-            @Parameter(hidden = true) @AuthUserInfo String username,
-            @Parameter(description = "동아리 ID", required = true) @PathVariable String clubId,
-            @Parameter(description = "게시글 ID", required = true) @PathVariable String boardId,
+            @AuthUserInfo String username,
+            @PathVariable String clubId,
+            @PathVariable String boardId,
             @RequestPart(value = "request", required = false) ClubBoardUpdateRequest request,
             @RequestPart(value = "thumbnail", required = false) MultipartFile thumbnail
     ) {
@@ -84,20 +62,12 @@ public class ClubBoardAdminController {
                 .body(Map.of("message", "게시글이 수정되었습니다."));
     }
 
-    @Operation(
-            summary = "게시글 삭제",
-            description = "동아리 관리자가 게시글을 삭제합니다."
-    )
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "삭제 성공"),
-            @ApiResponse(responseCode = "403", description = "해당 동아리의 관리자가 아님"),
-            @ApiResponse(responseCode = "404", description = "동아리 또는 게시글을 찾을 수 없음")
-    })
+    @Override
     @DeleteMapping("/{boardId}")
     public ResponseEntity<Map<String, String>> deleteBoard(
-            @Parameter(hidden = true) @AuthUserInfo String username,
-            @Parameter(description = "동아리 ID", required = true) @PathVariable String clubId,
-            @Parameter(description = "게시글 ID", required = true) @PathVariable String boardId
+            @AuthUserInfo String username,
+            @PathVariable String clubId,
+            @PathVariable String boardId
     ) {
         clubBoardAdminService.deleteBoard(new DeleteBoardServiceRequest(username, clubId, boardId));
 

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardUserController.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardUserController.java
@@ -1,12 +1,7 @@
 package org.project.ttokttok.domain.clubboard.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.project.ttokttok.domain.clubboard.controller.docs.ClubBoardUserDocs;
 import org.project.ttokttok.domain.clubboard.controller.dto.response.ClubBoardListResponse;
 import org.project.ttokttok.domain.clubboard.service.ClubBoardUserService;
 import org.springframework.http.ResponseEntity;
@@ -15,46 +10,33 @@ import org.springframework.web.bind.annotation.*;
 /**
  * 동아리 게시판 조회 API 컨트롤러
  * 사용자가 동아리 게시판을 조회할 수 있는 API들을 제공합니다.
+ * Swagger 문서는 {@link ClubBoardUserDocs}에 분리되어 있습니다.
  */
-@Slf4j
-@Tag(name = "[사용자] 동아리 게시판 조회", description = "사용자가 동아리 게시판을 조회하는 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/clubs/{clubId}/boards")
-public class ClubBoardUserController {
+public class ClubBoardUserController implements ClubBoardUserDocs {
 
     private final ClubBoardUserService clubBoardUserService;
 
     /**
      * 동아리 게시판 목록 조회 API
      * 특정 동아리의 게시판 목록을 커서 기반 무한스크롤로 조회합니다.
-     * 
+     *
      * @param clubId 동아리 ID
      * @param size 조회할 개수 (기본값: 20)
      * @param cursor 커서 (첫 요청시 생략)
      * @return 게시판 목록과 페이징 정보
      */
-    @Operation(
-            summary = "동아리 게시판 목록 조회",
-            description = "특정 동아리의 게시판 목록을 커서 기반 무한스크롤로 조회합니다. 최신순으로 정렬됩니다."
-    )
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "404", description = "동아리를 찾을 수 없음")
-    })
+    @Override
     @GetMapping
     public ResponseEntity<ClubBoardListResponse> getBoardList(
-            @Parameter(description = "동아리 ID", required = true)
             @PathVariable String clubId,
-            
-            @Parameter(description = "조회할 개수 (기본 20개)")
             @RequestParam(defaultValue = "20") int size,
-            
-            @Parameter(description = "무한스크롤 커서 (첫 요청시 생략)")
             @RequestParam(required = false) String cursor
     ) {
         ClubBoardListResponse response = clubBoardUserService.getBoardList(clubId, size, cursor);
-        
+
         return ResponseEntity.ok(response);
     }
-} 
+}

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardUserController.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardUserController.java
@@ -2,6 +2,7 @@ package org.project.ttokttok.domain.clubboard.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.project.ttokttok.domain.clubboard.controller.docs.ClubBoardUserDocs;
+import org.project.ttokttok.domain.clubboard.controller.dto.response.ClubBoardDetailResponse;
 import org.project.ttokttok.domain.clubboard.controller.dto.response.ClubBoardListResponse;
 import org.project.ttokttok.domain.clubboard.service.ClubBoardUserService;
 import org.springframework.http.ResponseEntity;
@@ -36,6 +37,25 @@ public class ClubBoardUserController implements ClubBoardUserDocs {
             @RequestParam(required = false) String cursor
     ) {
         ClubBoardListResponse response = clubBoardUserService.getBoardList(clubId, size, cursor);
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 동아리 게시판 상세 조회 API
+     * 게시글 단건의 상세 정보(본문 전문 포함)를 조회합니다.
+     *
+     * @param clubId 동아리 ID
+     * @param boardId 게시글 ID
+     * @return 게시글 상세 정보
+     */
+    @Override
+    @GetMapping("/{boardId}")
+    public ResponseEntity<ClubBoardDetailResponse> getBoardDetail(
+            @PathVariable String clubId,
+            @PathVariable String boardId
+    ) {
+        ClubBoardDetailResponse response = clubBoardUserService.getBoardDetail(clubId, boardId);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/docs/ClubBoardAdminDocs.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/docs/ClubBoardAdminDocs.java
@@ -1,0 +1,179 @@
+package org.project.ttokttok.domain.clubboard.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.SchemaProperty;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.project.ttokttok.domain.clubboard.controller.dto.request.ClubBoardUpdateRequest;
+import org.project.ttokttok.domain.clubboard.controller.dto.request.CreateBoardRequest;
+import org.project.ttokttok.domain.clubboard.controller.dto.response.ClubBoardCreateResponse;
+import org.project.ttokttok.global.exception.dto.ErrorResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Map;
+
+@Tag(name = "[관리자] 동아리 게시판 관리", description = "동아리 관리자가 게시판 게시글을 관리하는 API")
+public interface ClubBoardAdminDocs {
+
+    @Operation(
+            summary = "게시글 생성",
+            description = """
+                    동아리 관리자가 게시판에 새 게시글을 작성합니다.
+
+                    **요청 형식**: Multipart Form Data
+
+                    **요청 파라미터**:
+                    - `request`: JSON 형태의 게시글 정보 (CreateBoardRequest, 제목/내용 필수)
+                    - `thumbnail`: 대표(썸네일) 이미지 파일 (**필수**)
+
+                    *주의사항*:
+                    - 해당 동아리의 관리자만 작성 가능합니다.
+                    - 썸네일은 JPG, PNG, WEBP, GIF, HEIC 형식만 지원됩니다. (최대 20MB)
+                    - 업로드된 썸네일은 S3(board-images/)에 저장되며 목록 조회 응답의 thumbnailUrl로 내려갑니다.
+                    """
+    )
+    @RequestBody(
+            content = @Content(
+                    mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                    schemaProperties = {
+                            @SchemaProperty(name = "request", schema = @Schema(type = "string", format = "json", description = "게시글 생성 데이터 (title, content)")),
+                            @SchemaProperty(name = "thumbnail", schema = @Schema(type = "string", format = "binary", description = "대표(썸네일) 이미지 파일 (필수)"))
+                    }
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "생성 성공",
+                    content = @Content(schema = @Schema(implementation = ClubBoardCreateResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "썸네일 누락, 이미지 형식이 아님 또는 필수 필드 누락",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "해당 동아리의 관리자가 아님",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "동아리를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    ResponseEntity<ClubBoardCreateResponse> createBoard(
+            @Parameter(description = "인증된 관리자 이름", hidden = true)
+            String username,
+            @Parameter(description = "동아리 ID", required = true, example = "UUID")
+            String clubId,
+            @Schema(type = "string", format = "json", description = "게시글 생성 데이터")
+            CreateBoardRequest request,
+            @Schema(type = "string", format = "binary", description = "대표(썸네일) 이미지 파일 (JPG, PNG, WEBP, GIF, HEIC 지원, 최대 20MB)")
+            MultipartFile thumbnail
+    );
+
+    @Operation(
+            summary = "게시글 수정",
+            description = """
+                    동아리 관리자가 기존 게시글의 제목/내용/썸네일을 수정합니다.
+
+                    **요청 형식**: Multipart Form Data
+
+                    **요청 파라미터**:
+                    - `request`: JSON 형태의 수정 데이터 (선택, 생략하거나 null인 필드는 기존 값 유지)
+                    - `thumbnail`: 교체할 대표 이미지 파일 (선택, 전송 시 기존 이미지는 삭제됨)
+
+                    *주의사항*:
+                    - 해당 동아리의 관리자만 수정 가능합니다.
+                    - 썸네일만 보내 이미지 교체만 수행할 수도 있습니다.
+                    """
+    )
+    @RequestBody(
+            content = @Content(
+                    mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                    schemaProperties = {
+                            @SchemaProperty(name = "request", schema = @Schema(type = "string", format = "json", description = "게시글 수정 데이터 (title, content — 선택)")),
+                            @SchemaProperty(name = "thumbnail", schema = @Schema(type = "string", format = "binary", description = "교체할 대표 이미지 파일 (선택)"))
+                    }
+            )
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "수정 성공",
+                    content = @Content(schema = @Schema(implementation = Map.class, example = "{\"message\": \"게시글이 수정되었습니다.\"}"))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "썸네일이 이미지 형식이 아님",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "해당 동아리의 관리자가 아님",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "동아리 또는 게시글을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    ResponseEntity<Map<String, String>> updateBoard(
+            @Parameter(description = "인증된 관리자 이름", hidden = true)
+            String username,
+            @Parameter(description = "동아리 ID", required = true, example = "UUID")
+            String clubId,
+            @Parameter(description = "게시글 ID", required = true, example = "UUID")
+            String boardId,
+            @Schema(type = "string", format = "json", description = "게시글 수정 데이터 (선택)")
+            ClubBoardUpdateRequest request,
+            @Schema(type = "string", format = "binary", description = "교체할 대표 이미지 파일 (선택)")
+            MultipartFile thumbnail
+    );
+
+    @Operation(
+            summary = "게시글 삭제",
+            description = """
+                    동아리 관리자가 게시글을 삭제합니다.
+
+                    *주의사항*:
+                    - 해당 동아리의 관리자만 삭제 가능합니다.
+                    - 게시글에 연결된 S3 썸네일 파일도 함께 삭제됩니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "삭제 성공",
+                    content = @Content(schema = @Schema(implementation = Map.class, example = "{\"message\": \"게시글이 삭제되었습니다.\"}"))
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "해당 동아리의 관리자가 아님",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "동아리 또는 게시글을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    ResponseEntity<Map<String, String>> deleteBoard(
+            @Parameter(description = "인증된 관리자 이름", hidden = true)
+            String username,
+            @Parameter(description = "동아리 ID", required = true, example = "UUID")
+            String clubId,
+            @Parameter(description = "게시글 ID", required = true, example = "UUID")
+            String boardId
+    );
+}

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/docs/ClubBoardUserDocs.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/docs/ClubBoardUserDocs.java
@@ -1,0 +1,48 @@
+package org.project.ttokttok.domain.clubboard.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.project.ttokttok.domain.clubboard.controller.dto.response.ClubBoardListResponse;
+import org.project.ttokttok.global.exception.dto.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "[사용자] 동아리 게시판 조회", description = "사용자가 동아리 게시판을 조회하는 API")
+public interface ClubBoardUserDocs {
+
+    @Operation(
+            summary = "동아리 게시판 목록 조회",
+            description = """
+                    특정 동아리의 게시판 목록을 커서 기반 무한스크롤로 조회합니다. 최신순으로 정렬됩니다.
+
+                    **응답 필드**:
+                    - `thumbnailUrl`: 대표(썸네일) 이미지 URL — 썸네일 도입 이전의 레거시 게시글은 null
+                    - `hasImages`: 썸네일이 있거나 content에 이미지가 포함되어 있는지
+                    - `nextCursor`: 다음 페이지 요청 시 cursor 파라미터로 전달
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = ClubBoardListResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "동아리를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    ResponseEntity<ClubBoardListResponse> getBoardList(
+            @Parameter(description = "동아리 ID", required = true, example = "UUID")
+            String clubId,
+            @Parameter(description = "조회할 개수 (기본 20개)", example = "20")
+            int size,
+            @Parameter(description = "무한스크롤 커서 (첫 요청시 생략)")
+            String cursor
+    );
+}

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/docs/ClubBoardUserDocs.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/docs/ClubBoardUserDocs.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.project.ttokttok.domain.clubboard.controller.dto.response.ClubBoardDetailResponse;
 import org.project.ttokttok.domain.clubboard.controller.dto.response.ClubBoardListResponse;
 import org.project.ttokttok.global.exception.dto.ErrorResponse;
 import org.springframework.http.ResponseEntity;
@@ -15,13 +16,17 @@ import org.springframework.http.ResponseEntity;
 public interface ClubBoardUserDocs {
 
     @Operation(
-            summary = "동아리 게시판 목록 조회",
+            summary = "동아리 게시판 목록 조회 (썸네일 피드)",
             description = """
                     특정 동아리의 게시판 목록을 커서 기반 무한스크롤로 조회합니다. 최신순으로 정렬됩니다.
 
-                    **응답 필드**:
+                    인스타그램식 썸네일 피드용 API로, 각 항목은 최소 필드만 내려갑니다.
+                    본문 등 상세 정보는 상세 조회 API(GET /api/clubs/{clubId}/boards/{boardId})를 사용하세요.
+
+                    **응답 필드 (항목당)**:
+                    - `boardId`: 게시글 ID (상세 조회에 사용)
                     - `thumbnailUrl`: 대표(썸네일) 이미지 URL — 썸네일 도입 이전의 레거시 게시글은 null
-                    - `hasImages`: 썸네일이 있거나 content에 이미지가 포함되어 있는지
+                    - `createdAt`: 작성 시각
                     - `nextCursor`: 다음 페이지 요청 시 cursor 파라미터로 전달
                     """
     )
@@ -44,5 +49,36 @@ public interface ClubBoardUserDocs {
             int size,
             @Parameter(description = "무한스크롤 커서 (첫 요청시 생략)")
             String cursor
+    );
+
+    @Operation(
+            summary = "동아리 게시판 상세 조회",
+            description = """
+                    게시글 단건의 상세 정보를 조회합니다.
+
+                    **응답 필드**:
+                    - `boardId`, `title`, `content`(본문 전문), `thumbnailUrl`(레거시 게시글은 null), `clubName`, `createdAt`
+
+                    *주의사항*:
+                    - 요청한 동아리(clubId) 소속 게시글이 아니면 404가 반환됩니다.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = ClubBoardDetailResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "게시글을 찾을 수 없음 (해당 동아리 소속이 아닌 경우 포함)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    ResponseEntity<ClubBoardDetailResponse> getBoardDetail(
+            @Parameter(description = "동아리 ID", required = true, example = "UUID")
+            String clubId,
+            @Parameter(description = "게시글 ID", required = true, example = "UUID")
+            String boardId
     );
 }

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/docs/ClubBoardUserDocs.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/docs/ClubBoardUserDocs.java
@@ -45,7 +45,7 @@ public interface ClubBoardUserDocs {
     ResponseEntity<ClubBoardListResponse> getBoardList(
             @Parameter(description = "동아리 ID", required = true, example = "UUID")
             String clubId,
-            @Parameter(description = "조회할 개수 (기본 20개)", example = "20")
+            @Parameter(description = "조회할 개수 (기본 20개, 1~50 범위로 보정)", example = "20")
             int size,
             @Parameter(description = "무한스크롤 커서 (첫 요청시 생략)")
             String cursor

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/ClubBoardUpdateRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/ClubBoardUpdateRequest.java
@@ -2,6 +2,7 @@ package org.project.ttokttok.domain.clubboard.controller.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.project.ttokttok.domain.clubboard.service.dto.request.ClubBoardUpdateServiceRequest;
+import org.springframework.web.multipart.MultipartFile;
 
 public record ClubBoardUpdateRequest(
         @Schema(description = "선택적 필드 (생략 또는 null이면 기존 값 유지)", nullable = true, example = "값 또는 null")
@@ -10,13 +11,14 @@ public record ClubBoardUpdateRequest(
         @Schema(description = "선택적 필드 (생략 또는 null이면 기존 값 유지)", nullable = true, example = "값 또는 null")
         String content
 ) {
-    public ClubBoardUpdateServiceRequest toServiceRequest(String username, String clubId, String boardId) {
+    public ClubBoardUpdateServiceRequest toServiceRequest(String username, String clubId, String boardId, MultipartFile thumbnail) {
         return ClubBoardUpdateServiceRequest.builder()
                 .username(username)
                 .clubId(clubId)
                 .boardId(boardId)
                 .title(title)
                 .content(content)
+                .thumbnail(thumbnail)
                 .build();
     }
 }

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/CreateBoardRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/CreateBoardRequest.java
@@ -2,6 +2,7 @@ package org.project.ttokttok.domain.clubboard.controller.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import org.project.ttokttok.domain.clubboard.service.dto.request.CreateBoardServiceRequest;
+import org.springframework.web.multipart.MultipartFile;
 
 public record CreateBoardRequest(
         @NotBlank(message = "제목은 비어 있을 수 없습니다.")
@@ -10,7 +11,7 @@ public record CreateBoardRequest(
         @NotBlank(message = "내용은 비어 있을 수 없습니다.")
         String content
 ) {
-    public CreateBoardServiceRequest toServiceRequest(String username, String clubId) {
-        return new CreateBoardServiceRequest(username, clubId, title, content);
+    public CreateBoardServiceRequest toServiceRequest(String username, String clubId, MultipartFile thumbnail) {
+        return new CreateBoardServiceRequest(username, clubId, title, content, thumbnail);
     }
 }

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/response/ClubBoardDetailResponse.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/response/ClubBoardDetailResponse.java
@@ -1,0 +1,28 @@
+package org.project.ttokttok.domain.clubboard.controller.dto.response;
+
+import org.project.ttokttok.domain.clubboard.domain.ClubBoard;
+
+import java.time.LocalDateTime;
+
+/**
+ * 동아리 게시판 상세 조회 응답 DTO
+ */
+public record ClubBoardDetailResponse(
+        String boardId,
+        String title,
+        String content,
+        String thumbnailUrl,    // 대표(썸네일) 이미지 URL. 레거시 게시글은 null
+        String clubName,
+        LocalDateTime createdAt
+) {
+    public static ClubBoardDetailResponse from(ClubBoard board) {
+        return new ClubBoardDetailResponse(
+                board.getId(),
+                board.getTitle(),
+                board.getContent(),
+                board.getThumbnailUrl(),
+                board.getClub().getName(),
+                board.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/response/ClubBoardListResponse.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/response/ClubBoardListResponse.java
@@ -4,31 +4,28 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 /**
- * 동아리 게시판 목록 응답 DTO
+ * 동아리 게시판 목록 응답 DTO (인스타그램식 썸네일 피드)
+ * 본문 등 상세 정보는 상세 조회 API(ClubBoardDetailResponse)로 제공합니다.
  */
 public record ClubBoardListResponse(
         List<ClubBoardSummary> boards,
         boolean hasNext,
         String nextCursor
 ) {
-    
+
     /**
-     * 게시판 요약 정보 DTO
+     * 게시판 요약 정보 DTO — 피드 렌더링에 필요한 최소 필드만 포함
      */
     public record ClubBoardSummary(
             String boardId,
-            String title,
-            String content,
-            String clubName,
             String thumbnailUrl,    // 대표(썸네일) 이미지 URL. 레거시 게시글은 null
-            boolean hasImages,      // 썸네일이 있거나 content에 이미지가 포함되어 있는지
             LocalDateTime createdAt // 프론트에서 "19시간 전" 형식으로 변환
     ) {}
-    
+
     /**
      * 서비스 응답으로부터 컨트롤러 응답을 생성합니다.
      */
     public static ClubBoardListResponse of(List<ClubBoardSummary> boards, boolean hasNext, String nextCursor) {
         return new ClubBoardListResponse(boards, hasNext, nextCursor);
     }
-} 
+}

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/response/ClubBoardListResponse.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/response/ClubBoardListResponse.java
@@ -20,7 +20,8 @@ public record ClubBoardListResponse(
             String title,
             String content,
             String clubName,
-            boolean hasImages,      // content에 이미지가 포함되어 있는지
+            String thumbnailUrl,    // 대표(썸네일) 이미지 URL. 레거시 게시글은 null
+            boolean hasImages,      // 썸네일이 있거나 content에 이미지가 포함되어 있는지
             LocalDateTime createdAt // 프론트에서 "19시간 전" 형식으로 변환
     ) {}
     

--- a/src/main/java/org/project/ttokttok/domain/clubboard/domain/ClubBoard.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/domain/ClubBoard.java
@@ -33,14 +33,19 @@ public class ClubBoard extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
+    // 대표(썸네일) 이미지 URL. 레거시 게시글은 null 허용, 신규 생성 시에는 필수.
+    @Column(name = "thumbnail_url", length = 512)
+    private String thumbnailUrl;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "club_id", nullable = false, updatable = false)
     private Club club;
 
     @Builder
-    private ClubBoard(String title, String content, Club club) {
+    private ClubBoard(String title, String content, String thumbnailUrl, Club club) {
         this.title = title;
         this.content = content;
+        this.thumbnailUrl = thumbnailUrl;
         this.club = club;
     }
 
@@ -55,15 +60,22 @@ public class ClubBoard extends BaseTimeEntity {
         }
     }
 
+    public void updateThumbnailUrl(String thumbnailUrl) {
+        validateThumbnailUrl(thumbnailUrl);
+        this.thumbnailUrl = thumbnailUrl;
+    }
+
     // ------- 정적 메서드 -------
-    public static ClubBoard create(String title, String content, Club club) {
+    public static ClubBoard create(String title, String content, String thumbnailUrl, Club club) {
         validateTitle(title);
         validateContent(content);
+        validateThumbnailUrl(thumbnailUrl);
         validateClub(club);
 
         return ClubBoard.builder()
                 .title(title)
                 .content(content)
+                .thumbnailUrl(thumbnailUrl)
                 .club(club)
                 .build();
     }
@@ -84,6 +96,12 @@ public class ClubBoard extends BaseTimeEntity {
     private static void validateTitle(String title) {
         if (title == null || title.isBlank()) {
             throw new IllegalArgumentException("Title cannot be null or blank.");
+        }
+    }
+
+    private static void validateThumbnailUrl(String thumbnailUrl) {
+        if (thumbnailUrl == null || thumbnailUrl.isBlank()) {
+            throw new IllegalArgumentException("Thumbnail URL cannot be null or blank.");
         }
     }
 }

--- a/src/main/java/org/project/ttokttok/domain/clubboard/repository/ClubBoardRepository.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/repository/ClubBoardRepository.java
@@ -2,6 +2,16 @@ package org.project.ttokttok.domain.clubboard.repository;
 
 import org.project.ttokttok.domain.clubboard.domain.ClubBoard;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface ClubBoardRepository extends JpaRepository<ClubBoard, String>, ClubBoardCustomRepository {
+
+    /**
+     * 특정 동아리의 게시글 단건을 club과 함께 조회합니다. (상세 조회용, N+1 방지 fetch join)
+     */
+    @Query("select b from ClubBoard b join fetch b.club where b.id = :boardId and b.club.id = :clubId")
+    Optional<ClubBoard> findByIdAndClubIdWithClub(@Param("boardId") String boardId, @Param("clubId") String clubId);
 }

--- a/src/main/java/org/project/ttokttok/domain/clubboard/service/ClubBoardAdminService.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/service/ClubBoardAdminService.java
@@ -1,7 +1,9 @@
 package org.project.ttokttok.domain.clubboard.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.project.ttokttok.domain.club.domain.Club;
+import org.project.ttokttok.domain.club.exception.FileIsNotImageException;
 import org.project.ttokttok.domain.club.exception.NotClubAdminException;
 import org.project.ttokttok.domain.club.repository.ClubRepository;
 import org.project.ttokttok.domain.clubboard.domain.ClubBoard;
@@ -11,29 +13,45 @@ import org.project.ttokttok.domain.clubboard.repository.ClubBoardRepository;
 import org.project.ttokttok.domain.clubboard.service.dto.request.ClubBoardUpdateServiceRequest;
 import org.project.ttokttok.domain.clubboard.service.dto.request.CreateBoardServiceRequest;
 import org.project.ttokttok.domain.clubboard.service.dto.request.DeleteBoardServiceRequest;
+import org.project.ttokttok.infrastructure.s3.service.S3Service;
+import org.project.ttokttok.infrastructure.s3.support.AllowedFileTypes;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import static org.project.ttokttok.infrastructure.s3.enums.S3FileDirectory.BOARD_IMAGE;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ClubBoardAdminService {
 
     private final ClubRepository clubRepository;
     private final ClubBoardRepository clubBoardRepository;
+    private final S3Service s3Service;
 
-    // 게시글 생성
+    // 게시글 생성 (썸네일 이미지 필수)
     @Transactional
     public String createBoard(CreateBoardServiceRequest request) {
         Club club = validateClubAdmin(request.adminName(), request.clubId());
 
-        // 게시글 생성 로직
-        ClubBoard clubBoard = ClubBoard.create(request.title(), request.content(), club);
+        validateImage(request.thumbnail());
 
-        return clubBoardRepository.save(clubBoard)
-                .getId();
+        // S3 업로드를 먼저 수행하고, 이후 DB 저장이 실패하면 업로드본을 보상 삭제한다.
+        String thumbnailUrl = s3Service.uploadFile(request.thumbnail(), BOARD_IMAGE.getDirectoryName());
+
+        try {
+            ClubBoard clubBoard = ClubBoard.create(request.title(), request.content(), thumbnailUrl, club);
+
+            return clubBoardRepository.save(clubBoard)
+                    .getId();
+        } catch (RuntimeException e) {
+            deleteFileQuietly(thumbnailUrl);
+            throw e;
+        }
     }
 
-    // 게시글 수정 로직
+    // 게시글 수정 로직 (썸네일 교체 지원)
     @Transactional
     public void updateBoard(ClubBoardUpdateServiceRequest request) {
         Club club = validateClubAdmin(request.username(), request.clubId());
@@ -41,17 +59,62 @@ public class ClubBoardAdminService {
         ClubBoard clubBoard = findClubBoardOfClub(request.boardId(), club.getId());
 
         clubBoard.update(request.title(), request.content());
+
+        if (hasThumbnail(request.thumbnail())) {
+            replaceThumbnail(clubBoard, request.thumbnail());
+        }
     }
 
-    // 게시글 삭제 로직
+    // 게시글 삭제 로직 (S3 썸네일도 best-effort 삭제)
     @Transactional
     public void deleteBoard(DeleteBoardServiceRequest request) {
         Club club = validateClubAdmin(request.adminName(), request.clubId());
 
         ClubBoard clubBoard = findClubBoardOfClub(request.boardId(), club.getId());
 
+        String thumbnailUrl = clubBoard.getThumbnailUrl();
+
         // 게시글 삭제 로직
         clubBoardRepository.delete(clubBoard);
+
+        // S3 삭제 실패가 게시글 삭제를 막지 않도록 best-effort로 처리한다.
+        if (thumbnailUrl != null) {
+            deleteFileQuietly(thumbnailUrl);
+        }
+    }
+
+    private void replaceThumbnail(ClubBoard clubBoard, MultipartFile thumbnail) {
+        validateImage(thumbnail);
+
+        String oldThumbnailUrl = clubBoard.getThumbnailUrl();
+        String newThumbnailUrl = s3Service.uploadFile(thumbnail, BOARD_IMAGE.getDirectoryName());
+
+        clubBoard.updateThumbnailUrl(newThumbnailUrl);
+
+        // 교체 성공 시 기존 파일은 best-effort 삭제 (실패해도 요청은 성공 처리)
+        if (oldThumbnailUrl != null) {
+            deleteFileQuietly(oldThumbnailUrl);
+        }
+    }
+
+    private void deleteFileQuietly(String fileUrl) {
+        try {
+            s3Service.deleteFile(fileUrl);
+        } catch (RuntimeException e) {
+            log.warn("S3 썸네일 파일 삭제 실패 (best-effort): {}", fileUrl, e);
+        }
+    }
+
+    private boolean hasThumbnail(MultipartFile thumbnail) {
+        return thumbnail != null && !thumbnail.isEmpty();
+    }
+
+    private void validateImage(MultipartFile thumbnail) {
+        // 허용 이미지 형식은 AllowedFileTypes 단일 소스를 참조한다.
+        if (thumbnail == null || thumbnail.getContentType() == null
+                || !AllowedFileTypes.IMAGES.contains(thumbnail.getContentType())) {
+            throw new FileIsNotImageException();
+        }
     }
 
     private ClubBoard findClubBoardOfClub(String boardId, String clubId) {

--- a/src/main/java/org/project/ttokttok/domain/clubboard/service/ClubBoardAdminService.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/service/ClubBoardAdminService.java
@@ -1,7 +1,6 @@
 package org.project.ttokttok.domain.clubboard.service;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.project.ttokttok.domain.club.domain.Club;
 import org.project.ttokttok.domain.club.exception.FileIsNotImageException;
 import org.project.ttokttok.domain.club.exception.NotClubAdminException;
@@ -21,7 +20,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import static org.project.ttokttok.infrastructure.s3.enums.S3FileDirectory.BOARD_IMAGE;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ClubBoardAdminService {
@@ -37,18 +35,14 @@ public class ClubBoardAdminService {
 
         validateImage(request.thumbnail());
 
-        // S3 업로드를 먼저 수행하고, 이후 DB 저장이 실패하면 업로드본을 보상 삭제한다.
+        // S3 업로드 후 트랜잭션이 롤백되면(커밋 시점 실패 포함) 업로드본을 보상 삭제한다.
         String thumbnailUrl = s3Service.uploadFile(request.thumbnail(), BOARD_IMAGE.getDirectoryName());
+        s3Service.deleteFileOnRollback(thumbnailUrl);
 
-        try {
-            ClubBoard clubBoard = ClubBoard.create(request.title(), request.content(), thumbnailUrl, club);
+        ClubBoard clubBoard = ClubBoard.create(request.title(), request.content(), thumbnailUrl, club);
 
-            return clubBoardRepository.save(clubBoard)
-                    .getId();
-        } catch (RuntimeException e) {
-            deleteFileQuietly(thumbnailUrl);
-            throw e;
-        }
+        return clubBoardRepository.save(clubBoard)
+                .getId();
     }
 
     // 게시글 수정 로직 (썸네일 교체 지원)
@@ -77,9 +71,9 @@ public class ClubBoardAdminService {
         // 게시글 삭제 로직
         clubBoardRepository.delete(clubBoard);
 
-        // S3 삭제 실패가 게시글 삭제를 막지 않도록 best-effort로 처리한다.
+        // 커밋이 확정된 뒤에만 S3 파일을 삭제한다 — 롤백 시 DB가 참조하는 파일이 유실되지 않는다.
         if (thumbnailUrl != null) {
-            deleteFileQuietly(thumbnailUrl);
+            s3Service.deleteFileAfterCommit(thumbnailUrl);
         }
     }
 
@@ -88,20 +82,14 @@ public class ClubBoardAdminService {
 
         String oldThumbnailUrl = clubBoard.getThumbnailUrl();
         String newThumbnailUrl = s3Service.uploadFile(thumbnail, BOARD_IMAGE.getDirectoryName());
+        // 트랜잭션이 롤백되면 방금 업로드한 새 파일을 보상 삭제한다.
+        s3Service.deleteFileOnRollback(newThumbnailUrl);
 
         clubBoard.updateThumbnailUrl(newThumbnailUrl);
 
-        // 교체 성공 시 기존 파일은 best-effort 삭제 (실패해도 요청은 성공 처리)
+        // 기존 파일은 커밋이 확정된 뒤에만 삭제한다 (롤백 시 구 파일 보존).
         if (oldThumbnailUrl != null) {
-            deleteFileQuietly(oldThumbnailUrl);
-        }
-    }
-
-    private void deleteFileQuietly(String fileUrl) {
-        try {
-            s3Service.deleteFile(fileUrl);
-        } catch (RuntimeException e) {
-            log.warn("S3 썸네일 파일 삭제 실패 (best-effort): {}", fileUrl, e);
+            s3Service.deleteFileAfterCommit(oldThumbnailUrl);
         }
     }
 

--- a/src/main/java/org/project/ttokttok/domain/clubboard/service/ClubBoardUserService.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/service/ClubBoardUserService.java
@@ -3,9 +3,11 @@ package org.project.ttokttok.domain.clubboard.service;
 import lombok.RequiredArgsConstructor;
 import org.project.ttokttok.domain.club.exception.ClubNotFoundException;
 import org.project.ttokttok.domain.club.repository.ClubRepository;
+import org.project.ttokttok.domain.clubboard.controller.dto.response.ClubBoardDetailResponse;
 import org.project.ttokttok.domain.clubboard.controller.dto.response.ClubBoardListResponse;
 import org.project.ttokttok.domain.clubboard.controller.dto.response.ClubBoardListResponse.ClubBoardSummary;
 import org.project.ttokttok.domain.clubboard.domain.ClubBoard;
+import org.project.ttokttok.domain.clubboard.exception.ClubBoardNotFoundException;
 import org.project.ttokttok.domain.clubboard.repository.ClubBoardRepository;
 import org.springframework.stereotype.Service;
 
@@ -19,8 +21,8 @@ public class ClubBoardUserService {
     private final ClubRepository clubRepository;
 
     /**
-     * 동아리 게시판 목록을 커서 기반으로 조회합니다.
-     * 
+     * 동아리 게시판 목록을 커서 기반으로 조회합니다. (인스타그램식 썸네일 피드)
+     *
      * @param clubId 동아리 ID
      * @param size 조회할 개수
      * @param cursor 커서 (null이면 첫 페이지)
@@ -34,7 +36,7 @@ public class ClubBoardUserService {
 
         // 게시글 조회 (size + 1개를 조회하여 다음 페이지 존재 여부 확인)
         List<ClubBoard> boards = clubBoardRepository.findBoardsByClubIdWithCursor(clubId, size, cursor);
-        
+
         // 다음 페이지 존재 여부 확인
         boolean hasNext = boards.size() > size;
         if (hasNext) {
@@ -42,8 +44,8 @@ public class ClubBoardUserService {
         }
 
         // 다음 커서 설정
-        String nextCursor = hasNext && !boards.isEmpty() 
-            ? boards.get(boards.size() - 1).getId() 
+        String nextCursor = hasNext && !boards.isEmpty()
+            ? boards.get(boards.size() - 1).getId()
             : null;
 
         // DTO 변환
@@ -55,41 +57,28 @@ public class ClubBoardUserService {
     }
 
     /**
-     * ClubBoard 엔티티를 ClubBoardSummary DTO로 변환합니다.
+     * 동아리 게시판 게시글을 단건 상세 조회합니다.
+     *
+     * @param clubId 동아리 ID
+     * @param boardId 게시글 ID
+     * @return 게시글 상세 응답
+     */
+    public ClubBoardDetailResponse getBoardDetail(String clubId, String boardId) {
+        // 해당 동아리 소속 게시글만 조회된다 (다른 동아리의 boardId 접근 시 404)
+        ClubBoard board = clubBoardRepository.findByIdAndClubIdWithClub(boardId, clubId)
+                .orElseThrow(ClubBoardNotFoundException::new);
+
+        return ClubBoardDetailResponse.from(board);
+    }
+
+    /**
+     * ClubBoard 엔티티를 피드용 ClubBoardSummary DTO로 변환합니다.
      */
     private ClubBoardSummary toClubBoardSummary(ClubBoard board) {
         return new ClubBoardSummary(
                 board.getId(),
-                board.getTitle(),
-                board.getContent(),
-                board.getClub().getName(),
                 board.getThumbnailUrl(),
-                board.getThumbnailUrl() != null || hasImages(board.getContent()),
                 board.getCreatedAt()
         );
-    }
-
-    /**
-     * 게시글 내용에 이미지가 포함되어 있는지 확인합니다.
-     * HTML img 태그나 이미지 URL 패턴을 검사합니다.
-     */
-    private boolean hasImages(String content) {
-        if (content == null || content.isEmpty()) {
-            return false;
-        }
-        
-        // HTML img 태그 검사
-        if (content.toLowerCase().contains("<img")) {
-            return true;
-        }
-        
-        // 이미지 URL 패턴 검사 (board-images/ 경로 또는 일반적인 이미지 확장자)
-        String lowerContent = content.toLowerCase();
-        return lowerContent.contains("board-images/") ||
-               lowerContent.contains(".jpg") ||
-               lowerContent.contains(".jpeg") ||
-               lowerContent.contains(".png") ||
-               lowerContent.contains(".gif") ||
-               lowerContent.contains(".webp");
     }
 }

--- a/src/main/java/org/project/ttokttok/domain/clubboard/service/ClubBoardUserService.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/service/ClubBoardUserService.java
@@ -17,14 +17,19 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ClubBoardUserService {
 
+    // 한 페이지 최대 조회 개수 — 과도한 size 요청으로 인한 대량 조회(DoS) 방지
+    private static final int MAX_PAGE_SIZE = 50;
+    private static final int MIN_PAGE_SIZE = 1;
+
     private final ClubBoardRepository clubBoardRepository;
     private final ClubRepository clubRepository;
 
     /**
      * 동아리 게시판 목록을 커서 기반으로 조회합니다. (인스타그램식 썸네일 피드)
+     * size는 1~50 범위로 보정됩니다.
      *
      * @param clubId 동아리 ID
-     * @param size 조회할 개수
+     * @param size 조회할 개수 (1~50 범위로 클램프)
      * @param cursor 커서 (null이면 첫 페이지)
      * @return 게시판 목록 응답
      */
@@ -34,13 +39,15 @@ public class ClubBoardUserService {
             throw new ClubNotFoundException();
         }
 
+        int clampedSize = clampSize(size);
+
         // 게시글 조회 (size + 1개를 조회하여 다음 페이지 존재 여부 확인)
-        List<ClubBoard> boards = clubBoardRepository.findBoardsByClubIdWithCursor(clubId, size, cursor);
+        List<ClubBoard> boards = clubBoardRepository.findBoardsByClubIdWithCursor(clubId, clampedSize, cursor);
 
         // 다음 페이지 존재 여부 확인
-        boolean hasNext = boards.size() > size;
+        boolean hasNext = boards.size() > clampedSize;
         if (hasNext) {
-            boards = boards.subList(0, size); // 실제 반환할 개수만큼 자르기
+            boards = boards.subList(0, clampedSize); // 실제 반환할 개수만큼 자르기
         }
 
         // 다음 커서 설정
@@ -69,6 +76,13 @@ public class ClubBoardUserService {
                 .orElseThrow(ClubBoardNotFoundException::new);
 
         return ClubBoardDetailResponse.from(board);
+    }
+
+    /**
+     * 요청 size를 허용 범위(1~50)로 보정합니다.
+     */
+    private int clampSize(int size) {
+        return Math.min(Math.max(size, MIN_PAGE_SIZE), MAX_PAGE_SIZE);
     }
 
     /**

--- a/src/main/java/org/project/ttokttok/domain/clubboard/service/ClubBoardUserService.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/service/ClubBoardUserService.java
@@ -63,7 +63,8 @@ public class ClubBoardUserService {
                 board.getTitle(),
                 board.getContent(),
                 board.getClub().getName(),
-                hasImages(board.getContent()),
+                board.getThumbnailUrl(),
+                board.getThumbnailUrl() != null || hasImages(board.getContent()),
                 board.getCreatedAt()
         );
     }

--- a/src/main/java/org/project/ttokttok/domain/clubboard/service/dto/request/ClubBoardUpdateServiceRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/service/dto/request/ClubBoardUpdateServiceRequest.java
@@ -1,6 +1,7 @@
 package org.project.ttokttok.domain.clubboard.service.dto.request;
 
 import lombok.Builder;
+import org.springframework.web.multipart.MultipartFile;
 
 @Builder
 public record ClubBoardUpdateServiceRequest(
@@ -8,6 +9,7 @@ public record ClubBoardUpdateServiceRequest(
         String clubId,
         String boardId,
         String title,
-        String content
+        String content,
+        MultipartFile thumbnail
 ) {
 }

--- a/src/main/java/org/project/ttokttok/domain/clubboard/service/dto/request/CreateBoardServiceRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/service/dto/request/CreateBoardServiceRequest.java
@@ -1,9 +1,12 @@
 package org.project.ttokttok.domain.clubboard.service.dto.request;
 
+import org.springframework.web.multipart.MultipartFile;
+
 public record CreateBoardServiceRequest(
         String adminName,
         String clubId,
         String title,
-        String content
+        String content,
+        MultipartFile thumbnail
 ) {
 }

--- a/src/main/java/org/project/ttokttok/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/project/ttokttok/global/exception/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 
 import java.util.List;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 @Slf4j
 @RestControllerAdvice
@@ -76,6 +77,17 @@ public class GlobalExceptionHandler {
         ErrorResponse response = ErrorResponse.builder()
                 .statusCode(HttpStatus.BAD_REQUEST.value())
                 .details(message)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(response);
+    }
+
+    @ExceptionHandler(MissingServletRequestPartException.class)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestPart(MissingServletRequestPartException e) {
+        ErrorResponse response = ErrorResponse.builder()
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .details(String.format("필수 요청 파트 '%s'가 누락되었습니다.", e.getRequestPartName()))
                 .build();
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)

--- a/src/main/java/org/project/ttokttok/infrastructure/s3/service/S3Service.java
+++ b/src/main/java/org/project/ttokttok/infrastructure/s3/service/S3Service.java
@@ -1,9 +1,12 @@
 package org.project.ttokttok.infrastructure.s3.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.project.ttokttok.infrastructure.s3.exception.S3FileUploadException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -11,6 +14,7 @@ import software.amazon.awssdk.services.s3.model.*;
 
 import java.io.IOException;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class S3Service {
@@ -48,6 +52,50 @@ public class S3Service {
                 .bucket(bucketName)
                 .key(key)
                 .build());
+    }
+
+    /**
+     * 활성 트랜잭션이 있으면 커밋 이후에, 없으면 즉시 파일을 삭제한다.
+     * 커밋 실패로 롤백되면 파일을 삭제하지 않으므로, DB가 여전히 참조하는 파일이 유실되지 않는다.
+     * 삭제 실패는 best-effort로 로그만 남긴다.
+     */
+    public void deleteFileAfterCommit(String cloudFrontUrl) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    deleteFileQuietly(cloudFrontUrl);
+                }
+            });
+        } else {
+            deleteFileQuietly(cloudFrontUrl);
+        }
+    }
+
+    /**
+     * 활성 트랜잭션이 롤백되면 파일을 삭제한다(업로드 보상 정리).
+     * 커밋 여부가 불명확한 STATUS_UNKNOWN에서는 삭제하지 않는다 — 커밋된 데이터가 참조하는
+     * 파일을 지우는 최악의 시나리오를 피하기 위함이다. 트랜잭션이 없으면 no-op.
+     */
+    public void deleteFileOnRollback(String cloudFrontUrl) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCompletion(int status) {
+                    if (status == STATUS_ROLLED_BACK) {
+                        deleteFileQuietly(cloudFrontUrl);
+                    }
+                }
+            });
+        }
+    }
+
+    private void deleteFileQuietly(String cloudFrontUrl) {
+        try {
+            deleteFile(cloudFrontUrl);
+        } catch (RuntimeException e) {
+            log.warn("S3 파일 삭제 실패 (best-effort): {}", cloudFrontUrl, e);
+        }
     }
 
     private void validateFile(MultipartFile file) {

--- a/src/main/resources/db/migration/V24__add_thumbnail_url_to_club_boards.sql
+++ b/src/main/resources/db/migration/V24__add_thumbnail_url_to_club_boards.sql
@@ -1,0 +1,3 @@
+-- 게시판 인스타그램형 피드: 대표(썸네일) 이미지 URL 컬럼 추가
+-- 기존 텍스트 게시글은 NULL 유지 (신규 게시글부터 애플리케이션 레벨에서 필수)
+ALTER TABLE club_boards ADD COLUMN thumbnail_url VARCHAR(512);

--- a/src/main/resources/db/migration/V25__add_feed_index_to_club_boards.sql
+++ b/src/main/resources/db/migration/V25__add_feed_index_to_club_boards.sql
@@ -1,0 +1,4 @@
+-- 게시판 피드 커서 페이지네이션 쿼리용 복합 인덱스
+-- (WHERE club_id = ? ORDER BY created_at DESC, id DESC LIMIT n)
+-- PostgreSQL은 FK에 자동 인덱스를 만들지 않으므로 명시적으로 생성한다. (notices의 V22 인덱스와 동일 패턴)
+CREATE INDEX idx_club_boards_club_id_created_at_id ON club_boards (club_id, created_at DESC, id DESC);

--- a/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminControllerTest.java
@@ -15,17 +15,27 @@ import org.project.ttokttok.domain.clubboard.domain.ClubBoard;
 import org.project.ttokttok.domain.clubboard.repository.ClubBoardRepository;
 import org.project.ttokttok.global.entity.Role;
 import org.project.ttokttok.infrastructure.jwt.JwtFactory;
+import org.project.ttokttok.infrastructure.s3.service.S3Service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import static org.hamcrest.Matchers.notNullValue;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -34,6 +44,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 class ClubBoardAdminControllerTest {
+
+    private static final String THUMBNAIL_URL = "https://cdn.example.com/board-images/uuid_thumb.png";
 
     @Autowired
     private ClubRepository clubRepository;
@@ -52,6 +64,9 @@ class ClubBoardAdminControllerTest {
 
     @Autowired
     private JwtFactory jwtFactory;
+
+    @MockitoBean
+    private S3Service s3Service;
 
     private Club myClub;
     private String myAccessToken;
@@ -76,19 +91,47 @@ class ClubBoardAdminControllerTest {
 
         myAccessToken = jwtFactory.generateValidToken(myAdmin.getUsername(), Role.ROLE_ADMIN);
         otherAccessToken = jwtFactory.generateValidToken(otherAdmin.getUsername(), Role.ROLE_ADMIN);
+
+        given(s3Service.uploadFile(any(MultipartFile.class), anyString())).willReturn(THUMBNAIL_URL);
+    }
+
+    private MockMultipartFile jsonPart(Object request) throws Exception {
+        return new MockMultipartFile("request", "", MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(request));
+    }
+
+    private MockMultipartFile thumbnailPart() {
+        return new MockMultipartFile("thumbnail", "thumb.png", "image/png", "img".getBytes());
+    }
+
+    private ClubBoard saveBoard(String title, String content) {
+        return clubBoardRepository.save(ClubBoard.create(title, content, THUMBNAIL_URL, myClub));
     }
 
     @Test
-    @DisplayName("createBoard(): 게시글 생성에 성공한다.")
+    @DisplayName("createBoard(): 썸네일과 함께 게시글 생성에 성공한다.")
     void createBoard_success() throws Exception {
         CreateBoardRequest request = new CreateBoardRequest("제목입니다", "본문입니다");
 
-        mockMvc.perform(post("/api/admin/clubs/{clubId}/boards", myClub.getId())
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+        mockMvc.perform(multipart("/api/admin/clubs/{clubId}/boards", myClub.getId())
+                        .file(jsonPart(request))
+                        .file(thumbnailPart())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.boardId", notNullValue()));
+
+        verify(s3Service).uploadFile(any(MultipartFile.class), anyString());
+    }
+
+    @Test
+    @DisplayName("createBoard(): 썸네일 파트가 없으면 400이 발생한다.")
+    void createBoard_missingThumbnail() throws Exception {
+        CreateBoardRequest request = new CreateBoardRequest("제목입니다", "본문입니다");
+
+        mockMvc.perform(multipart("/api/admin/clubs/{clubId}/boards", myClub.getId())
+                        .file(jsonPart(request))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -96,41 +139,56 @@ class ClubBoardAdminControllerTest {
     void createBoard_forbidden() throws Exception {
         CreateBoardRequest request = new CreateBoardRequest("제목입니다", "본문입니다");
 
-        mockMvc.perform(post("/api/admin/clubs/{clubId}/boards", myClub.getId())
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + otherAccessToken)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+        mockMvc.perform(multipart("/api/admin/clubs/{clubId}/boards", myClub.getId())
+                        .file(jsonPart(request))
+                        .file(thumbnailPart())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + otherAccessToken))
                 .andExpect(status().isForbidden());
     }
 
     @Test
     @DisplayName("updateBoard(): 게시글 수정에 성공한다.")
     void updateBoard_success() throws Exception {
-        ClubBoard board = clubBoardRepository.save(ClubBoard.create("원래 제목", "원래 내용", myClub));
+        ClubBoard board = saveBoard("원래 제목", "원래 내용");
 
         ClubBoardUpdateRequest request = new ClubBoardUpdateRequest("수정된 제목", null);
 
-        mockMvc.perform(patch("/api/admin/clubs/{clubId}/boards/{boardId}", myClub.getId(), board.getId())
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk());
-    }
-
-    @Test
-    @DisplayName("deleteBoard(): 게시글 삭제에 성공한다.")
-    void deleteBoard_success() throws Exception {
-        ClubBoard board = clubBoardRepository.save(ClubBoard.create("삭제될 제목", "삭제될 내용", myClub));
-
-        mockMvc.perform(delete("/api/admin/clubs/{clubId}/boards/{boardId}", myClub.getId(), board.getId())
+        mockMvc.perform(multipart(HttpMethod.PATCH, "/api/admin/clubs/{clubId}/boards/{boardId}", myClub.getId(), board.getId())
+                        .file(jsonPart(request))
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
                 .andExpect(status().isOk());
     }
 
     @Test
+    @DisplayName("updateBoard(): 썸네일만 보내도 교체에 성공하고 기존 파일이 삭제된다.")
+    void updateBoard_replaceThumbnailOnly() throws Exception {
+        ClubBoard board = saveBoard("원래 제목", "원래 내용");
+
+        mockMvc.perform(multipart(HttpMethod.PATCH, "/api/admin/clubs/{clubId}/boards/{boardId}", myClub.getId(), board.getId())
+                        .file(thumbnailPart())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
+                .andExpect(status().isOk());
+
+        verify(s3Service).uploadFile(any(MultipartFile.class), anyString());
+        verify(s3Service).deleteFile(THUMBNAIL_URL);
+    }
+
+    @Test
+    @DisplayName("deleteBoard(): 게시글 삭제 시 S3 썸네일도 삭제한다.")
+    void deleteBoard_success() throws Exception {
+        ClubBoard board = saveBoard("삭제될 제목", "삭제될 내용");
+
+        mockMvc.perform(delete("/api/admin/clubs/{clubId}/boards/{boardId}", myClub.getId(), board.getId())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
+                .andExpect(status().isOk());
+
+        verify(s3Service).deleteFile(THUMBNAIL_URL);
+    }
+
+    @Test
     @DisplayName("deleteBoard(): 다른 동아리 관리자가 요청하면 403이 발생한다.")
     void deleteBoard_forbidden() throws Exception {
-        ClubBoard board = clubBoardRepository.save(ClubBoard.create("삭제될 제목", "삭제될 내용", myClub));
+        ClubBoard board = saveBoard("삭제될 제목", "삭제될 내용");
 
         mockMvc.perform(delete("/api/admin/clubs/{clubId}/boards/{boardId}", myClub.getId(), board.getId())
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + otherAccessToken))

--- a/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminControllerTest.java
@@ -45,7 +45,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("test")
 class ClubBoardAdminControllerTest {
 
-    private static final String THUMBNAIL_URL = "https://cdn.example.com/board-images/uuid_thumb.png";
+    // 저장된 게시글이 이미 갖고 있는 기존 썸네일 URL과 신규 업로드 결과 URL을 구분해
+    // "기존 파일이 삭제 예약되었는지"를 정확히 검증한다.
+    private static final String EXISTING_THUMBNAIL_URL = "https://cdn.example.com/board-images/uuid_existing.png";
+    private static final String UPLOADED_THUMBNAIL_URL = "https://cdn.example.com/board-images/uuid_uploaded.png";
 
     @Autowired
     private ClubRepository clubRepository;
@@ -92,7 +95,7 @@ class ClubBoardAdminControllerTest {
         myAccessToken = jwtFactory.generateValidToken(myAdmin.getUsername(), Role.ROLE_ADMIN);
         otherAccessToken = jwtFactory.generateValidToken(otherAdmin.getUsername(), Role.ROLE_ADMIN);
 
-        given(s3Service.uploadFile(any(MultipartFile.class), anyString())).willReturn(THUMBNAIL_URL);
+        given(s3Service.uploadFile(any(MultipartFile.class), anyString())).willReturn(UPLOADED_THUMBNAIL_URL);
     }
 
     private MockMultipartFile jsonPart(Object request) throws Exception {
@@ -105,7 +108,7 @@ class ClubBoardAdminControllerTest {
     }
 
     private ClubBoard saveBoard(String title, String content) {
-        return clubBoardRepository.save(ClubBoard.create(title, content, THUMBNAIL_URL, myClub));
+        return clubBoardRepository.save(ClubBoard.create(title, content, EXISTING_THUMBNAIL_URL, myClub));
     }
 
     @Test
@@ -160,7 +163,7 @@ class ClubBoardAdminControllerTest {
     }
 
     @Test
-    @DisplayName("updateBoard(): 썸네일만 보내도 교체에 성공하고 기존 파일이 삭제된다.")
+    @DisplayName("updateBoard(): 썸네일만 보내도 교체에 성공하고 기존 파일이 커밋 후 삭제로 예약된다.")
     void updateBoard_replaceThumbnailOnly() throws Exception {
         ClubBoard board = saveBoard("원래 제목", "원래 내용");
 
@@ -170,11 +173,13 @@ class ClubBoardAdminControllerTest {
                 .andExpect(status().isOk());
 
         verify(s3Service).uploadFile(any(MultipartFile.class), anyString());
-        verify(s3Service).deleteFile(THUMBNAIL_URL);
+        // 신규 업로드본은 롤백 보상 훅, 기존 파일은 커밋 후 삭제로 각각 예약된다.
+        verify(s3Service).deleteFileOnRollback(UPLOADED_THUMBNAIL_URL);
+        verify(s3Service).deleteFileAfterCommit(EXISTING_THUMBNAIL_URL);
     }
 
     @Test
-    @DisplayName("deleteBoard(): 게시글 삭제 시 S3 썸네일도 삭제한다.")
+    @DisplayName("deleteBoard(): 게시글 삭제 시 S3 썸네일이 커밋 후 삭제로 예약된다.")
     void deleteBoard_success() throws Exception {
         ClubBoard board = saveBoard("삭제될 제목", "삭제될 내용");
 
@@ -182,7 +187,7 @@ class ClubBoardAdminControllerTest {
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
                 .andExpect(status().isOk());
 
-        verify(s3Service).deleteFile(THUMBNAIL_URL);
+        verify(s3Service).deleteFileAfterCommit(EXISTING_THUMBNAIL_URL);
     }
 
     @Test

--- a/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardUserControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardUserControllerTest.java
@@ -2,8 +2,10 @@ package org.project.ttokttok.domain.clubboard.controller;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.project.ttokttok.domain.clubboard.controller.dto.response.ClubBoardDetailResponse;
 import org.project.ttokttok.domain.clubboard.controller.dto.response.ClubBoardListResponse;
 import org.project.ttokttok.domain.clubboard.controller.dto.response.ClubBoardListResponse.ClubBoardSummary;
+import org.project.ttokttok.domain.clubboard.exception.ClubBoardNotFoundException;
 import org.project.ttokttok.domain.clubboard.service.ClubBoardUserService;
 import org.project.ttokttok.global.annotationresolver.auth.AuthUserInfoResolver;
 import org.project.ttokttok.global.auth.jwt.service.TokenProvider;
@@ -40,14 +42,14 @@ class ClubBoardUserControllerTest {
     private AuthUserInfoResolver authUserInfoResolver;
 
     private static final String CLUB_ID = "club-1";
+    private static final String THUMBNAIL_URL = "https://cdn.example.com/board-images/uuid_thumb.png";
 
     @Test
     @WithMockUser
     @DisplayName("게시판 목록 조회 API를 기본 파라미터로 호출한다")
     void getBoardListWithDefaultParams() throws Exception {
-        String thumbnailUrl = "https://cdn.example.com/board-images/uuid_thumb.png";
         ClubBoardSummary summary = new ClubBoardSummary(
-                "board-1", "제목", "내용", "동아리", thumbnailUrl, true, LocalDateTime.of(2026, 1, 1, 0, 0)
+                "board-1", THUMBNAIL_URL, LocalDateTime.of(2026, 1, 1, 0, 0)
         );
         given(clubBoardUserService.getBoardList(CLUB_ID, 20, null))
                 .willReturn(ClubBoardListResponse.of(List.of(summary), false, null));
@@ -56,7 +58,8 @@ class ClubBoardUserControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.boards[0].boardId").value("board-1"))
-                .andExpect(jsonPath("$.boards[0].thumbnailUrl").value(thumbnailUrl))
+                .andExpect(jsonPath("$.boards[0].thumbnailUrl").value(THUMBNAIL_URL))
+                .andExpect(jsonPath("$.boards[0].content").doesNotExist())
                 .andExpect(jsonPath("$.hasNext").value(false));
 
         verify(clubBoardUserService).getBoardList(CLUB_ID, 20, null);
@@ -76,5 +79,37 @@ class ClubBoardUserControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.hasNext").value(true))
                 .andExpect(jsonPath("$.nextCursor").value("cursor-2"));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("게시판 상세 조회 API를 호출한다")
+    void getBoardDetail() throws Exception {
+        ClubBoardDetailResponse response = new ClubBoardDetailResponse(
+                "board-1", "제목", "본문 전체 내용", THUMBNAIL_URL, "동아리", LocalDateTime.of(2026, 1, 1, 0, 0)
+        );
+        given(clubBoardUserService.getBoardDetail(CLUB_ID, "board-1"))
+                .willReturn(response);
+
+        mockMvc.perform(get("/api/clubs/{clubId}/boards/{boardId}", CLUB_ID, "board-1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.boardId").value("board-1"))
+                .andExpect(jsonPath("$.title").value("제목"))
+                .andExpect(jsonPath("$.content").value("본문 전체 내용"))
+                .andExpect(jsonPath("$.thumbnailUrl").value(THUMBNAIL_URL))
+                .andExpect(jsonPath("$.clubName").value("동아리"));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("존재하지 않는 게시글의 상세 조회는 404를 반환한다")
+    void getBoardDetailNotFound() throws Exception {
+        given(clubBoardUserService.getBoardDetail(CLUB_ID, "missing"))
+                .willThrow(new ClubBoardNotFoundException());
+
+        mockMvc.perform(get("/api/clubs/{clubId}/boards/{boardId}", CLUB_ID, "missing")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardUserControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardUserControllerTest.java
@@ -45,8 +45,9 @@ class ClubBoardUserControllerTest {
     @WithMockUser
     @DisplayName("게시판 목록 조회 API를 기본 파라미터로 호출한다")
     void getBoardListWithDefaultParams() throws Exception {
+        String thumbnailUrl = "https://cdn.example.com/board-images/uuid_thumb.png";
         ClubBoardSummary summary = new ClubBoardSummary(
-                "board-1", "제목", "내용", "동아리", false, LocalDateTime.of(2026, 1, 1, 0, 0)
+                "board-1", "제목", "내용", "동아리", thumbnailUrl, true, LocalDateTime.of(2026, 1, 1, 0, 0)
         );
         given(clubBoardUserService.getBoardList(CLUB_ID, 20, null))
                 .willReturn(ClubBoardListResponse.of(List.of(summary), false, null));
@@ -55,6 +56,7 @@ class ClubBoardUserControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.boards[0].boardId").value("board-1"))
+                .andExpect(jsonPath("$.boards[0].thumbnailUrl").value(thumbnailUrl))
                 .andExpect(jsonPath("$.hasNext").value(false));
 
         verify(clubBoardUserService).getBoardList(CLUB_ID, 20, null);

--- a/src/test/java/org/project/ttokttok/domain/clubboard/domain/ClubBoardTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/domain/ClubBoardTest.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.mock;
 
 class ClubBoardTest {
 
+    private static final String THUMBNAIL_URL = "https://cdn.example.com/board-images/uuid_thumb.png";
+
     @Nested
     @DisplayName("create()")
     class Create {
@@ -20,10 +22,11 @@ class ClubBoardTest {
         void createSuccess() {
             Club club = mock(Club.class);
 
-            ClubBoard board = ClubBoard.create("제목", "내용", club);
+            ClubBoard board = ClubBoard.create("제목", "내용", THUMBNAIL_URL, club);
 
             assertThat(board.getTitle()).isEqualTo("제목");
             assertThat(board.getContent()).isEqualTo("내용");
+            assertThat(board.getThumbnailUrl()).isEqualTo(THUMBNAIL_URL);
             assertThat(board.getClub()).isEqualTo(club);
             assertThat(board.getId()).isNull(); // JPA 저장 전이므로 null
         }
@@ -33,7 +36,7 @@ class ClubBoardTest {
         void createFailBlankTitle() {
             Club club = mock(Club.class);
 
-            assertThatThrownBy(() -> ClubBoard.create(" ", "내용", club))
+            assertThatThrownBy(() -> ClubBoard.create(" ", "내용", THUMBNAIL_URL, club))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("Title cannot be null or blank.");
         }
@@ -43,7 +46,7 @@ class ClubBoardTest {
         void createFailNullTitle() {
             Club club = mock(Club.class);
 
-            assertThatThrownBy(() -> ClubBoard.create(null, "내용", club))
+            assertThatThrownBy(() -> ClubBoard.create(null, "내용", THUMBNAIL_URL, club))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("Title cannot be null or blank.");
         }
@@ -53,15 +56,35 @@ class ClubBoardTest {
         void createFailBlankContent() {
             Club club = mock(Club.class);
 
-            assertThatThrownBy(() -> ClubBoard.create("제목", " ", club))
+            assertThatThrownBy(() -> ClubBoard.create("제목", " ", THUMBNAIL_URL, club))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("Content cannot be null or blank.");
         }
 
         @Test
+        @DisplayName("썸네일 URL이 null이면 예외가 발생한다.")
+        void createFailNullThumbnailUrl() {
+            Club club = mock(Club.class);
+
+            assertThatThrownBy(() -> ClubBoard.create("제목", "내용", null, club))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Thumbnail URL cannot be null or blank.");
+        }
+
+        @Test
+        @DisplayName("썸네일 URL이 비어있으면 예외가 발생한다.")
+        void createFailBlankThumbnailUrl() {
+            Club club = mock(Club.class);
+
+            assertThatThrownBy(() -> ClubBoard.create("제목", "내용", " ", club))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Thumbnail URL cannot be null or blank.");
+        }
+
+        @Test
         @DisplayName("동아리가 null이면 예외가 발생한다.")
         void createFailNullClub() {
-            assertThatThrownBy(() -> ClubBoard.create("제목", "내용", null))
+            assertThatThrownBy(() -> ClubBoard.create("제목", "내용", THUMBNAIL_URL, null))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("Club cannot be null.");
         }
@@ -71,11 +94,14 @@ class ClubBoardTest {
     @DisplayName("update()")
     class Update {
 
+        private ClubBoard newBoard() {
+            return ClubBoard.create("원제목", "원내용", THUMBNAIL_URL, mock(Club.class));
+        }
+
         @Test
         @DisplayName("제목과 내용을 모두 수정할 수 있다.")
         void updateBothFields() {
-            Club club = mock(Club.class);
-            ClubBoard board = ClubBoard.create("원제목", "원내용", club);
+            ClubBoard board = newBoard();
 
             board.update("새 제목", "새 내용");
 
@@ -86,8 +112,7 @@ class ClubBoardTest {
         @Test
         @DisplayName("title만 전달하면 content는 기존 값을 유지한다.")
         void updateTitleOnly() {
-            Club club = mock(Club.class);
-            ClubBoard board = ClubBoard.create("원제목", "원내용", club);
+            ClubBoard board = newBoard();
 
             board.update("새 제목", null);
 
@@ -98,8 +123,7 @@ class ClubBoardTest {
         @Test
         @DisplayName("content만 전달하면 title은 기존 값을 유지한다.")
         void updateContentOnly() {
-            Club club = mock(Club.class);
-            ClubBoard board = ClubBoard.create("원제목", "원내용", club);
+            ClubBoard board = newBoard();
 
             board.update(null, "새 내용");
 
@@ -110,8 +134,7 @@ class ClubBoardTest {
         @Test
         @DisplayName("둘 다 null이면 아무 것도 바뀌지 않는다.")
         void updateBothNull() {
-            Club club = mock(Club.class);
-            ClubBoard board = ClubBoard.create("원제목", "원내용", club);
+            ClubBoard board = newBoard();
 
             board.update(null, null);
 
@@ -122,12 +145,40 @@ class ClubBoardTest {
         @Test
         @DisplayName("빈 문자열로 수정을 시도하면 예외가 발생한다.")
         void updateBlankTitleThrows() {
-            Club club = mock(Club.class);
-            ClubBoard board = ClubBoard.create("원제목", "원내용", club);
+            ClubBoard board = newBoard();
 
             assertThatThrownBy(() -> board.update(" ", null))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("Title cannot be null or blank.");
+        }
+    }
+
+    @Nested
+    @DisplayName("updateThumbnailUrl()")
+    class UpdateThumbnailUrl {
+
+        @Test
+        @DisplayName("썸네일 URL을 교체할 수 있다.")
+        void updateThumbnailUrlSuccess() {
+            ClubBoard board = ClubBoard.create("제목", "내용", THUMBNAIL_URL, mock(Club.class));
+            String newUrl = "https://cdn.example.com/board-images/uuid_new.png";
+
+            board.updateThumbnailUrl(newUrl);
+
+            assertThat(board.getThumbnailUrl()).isEqualTo(newUrl);
+        }
+
+        @Test
+        @DisplayName("null 또는 빈 문자열로 교체를 시도하면 예외가 발생한다.")
+        void updateThumbnailUrlBlankThrows() {
+            ClubBoard board = ClubBoard.create("제목", "내용", THUMBNAIL_URL, mock(Club.class));
+
+            assertThatThrownBy(() -> board.updateThumbnailUrl(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Thumbnail URL cannot be null or blank.");
+            assertThatThrownBy(() -> board.updateThumbnailUrl(" "))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Thumbnail URL cannot be null or blank.");
         }
     }
 }

--- a/src/test/java/org/project/ttokttok/domain/clubboard/service/ClubBoardAdminServiceTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/service/ClubBoardAdminServiceTest.java
@@ -79,7 +79,8 @@ class ClubBoardAdminServiceTest {
             assertThat(result).isEqualTo("board123");
             verify(s3Service).uploadFile(any(MultipartFile.class), eq(BOARD_IMAGE.getDirectoryName()));
             verify(clubBoardRepository).save(any(ClubBoard.class));
-            verify(s3Service, never()).deleteFile(anyString());
+            // 롤백 시 업로드본이 보상 삭제되도록 훅이 등록되어야 한다.
+            verify(s3Service).deleteFileOnRollback(THUMBNAIL_URL);
         }
 
         @Test
@@ -99,8 +100,8 @@ class ClubBoardAdminServiceTest {
         }
 
         @Test
-        @DisplayName("DB 저장이 실패하면 업로드된 썸네일을 보상 삭제하고 예외를 다시 던진다.")
-        void createBoardCompensatesUploadOnSaveFailure() {
+        @DisplayName("DB 저장이 실패해도 업로드 직후 롤백 보상 훅이 이미 등록되어 있다.")
+        void createBoardRegistersRollbackHookBeforeSave() {
             Club club = mockClub("club123");
             when(clubRepository.findByAdminUsername("admin")).thenReturn(Optional.of(club));
             when(s3Service.uploadFile(any(MultipartFile.class), eq(BOARD_IMAGE.getDirectoryName())))
@@ -115,7 +116,8 @@ class ClubBoardAdminServiceTest {
                     .isInstanceOf(RuntimeException.class)
                     .hasMessage("db down");
 
-            verify(s3Service).deleteFile(THUMBNAIL_URL);
+            // 예외로 트랜잭션이 롤백되면 등록된 훅이 업로드본을 삭제한다 (실제 삭제는 S3ServiceTest가 검증).
+            verify(s3Service).deleteFileOnRollback(THUMBNAIL_URL);
         }
 
         @Test
@@ -199,34 +201,9 @@ class ClubBoardAdminServiceTest {
             clubBoardService.updateBoard(request);
 
             verify(board).updateThumbnailUrl(THUMBNAIL_URL);
-            verify(s3Service).deleteFile(oldUrl);
-        }
-
-        @Test
-        @DisplayName("기존 썸네일 삭제가 실패해도 교체 요청은 성공한다.")
-        void updateBoardOldThumbnailDeleteFailureIsIgnored() {
-            Club club = mockClub("club123");
-            when(clubRepository.findByAdminUsername("admin")).thenReturn(Optional.of(club));
-
-            String oldUrl = "https://cdn.example.com/board-images/uuid_old.png";
-            ClubBoard board = mock(ClubBoard.class);
-            when(board.getClub()).thenReturn(club);
-            when(board.getThumbnailUrl()).thenReturn(oldUrl);
-            when(clubBoardRepository.findById("board123")).thenReturn(Optional.of(board));
-            when(s3Service.uploadFile(any(MultipartFile.class), eq(BOARD_IMAGE.getDirectoryName())))
-                    .thenReturn(THUMBNAIL_URL);
-            doThrow(new RuntimeException("s3 down")).when(s3Service).deleteFile(oldUrl);
-
-            ClubBoardUpdateServiceRequest request = ClubBoardUpdateServiceRequest.builder()
-                    .username("admin")
-                    .clubId("club123")
-                    .boardId("board123")
-                    .thumbnail(imageFile())
-                    .build();
-
-            clubBoardService.updateBoard(request);
-
-            verify(board).updateThumbnailUrl(THUMBNAIL_URL);
+            // 새 업로드본은 롤백 보상 훅 등록, 기존 파일은 커밋 이후 삭제로 예약되어야 한다.
+            verify(s3Service).deleteFileOnRollback(THUMBNAIL_URL);
+            verify(s3Service).deleteFileAfterCommit(oldUrl);
         }
 
         @Test
@@ -303,7 +280,7 @@ class ClubBoardAdminServiceTest {
     class DeleteBoard {
 
         @Test
-        @DisplayName("게시글 삭제 시 S3 썸네일 파일도 삭제한다.")
+        @DisplayName("게시글 삭제 시 S3 썸네일 파일은 커밋 이후 삭제로 예약된다.")
         void deleteBoardSuccess() {
             Club club = mockClub("club123");
             when(clubRepository.findByAdminUsername("admin")).thenReturn(Optional.of(club));
@@ -318,7 +295,7 @@ class ClubBoardAdminServiceTest {
             clubBoardService.deleteBoard(request);
 
             verify(clubBoardRepository).delete(board);
-            verify(s3Service).deleteFile(THUMBNAIL_URL);
+            verify(s3Service).deleteFileAfterCommit(THUMBNAIL_URL);
         }
 
         @Test
@@ -338,25 +315,6 @@ class ClubBoardAdminServiceTest {
 
             verify(clubBoardRepository).delete(board);
             verifyNoInteractions(s3Service);
-        }
-
-        @Test
-        @DisplayName("S3 삭제가 실패해도 게시글 삭제는 성공한다.")
-        void deleteBoardS3FailureIsIgnored() {
-            Club club = mockClub("club123");
-            when(clubRepository.findByAdminUsername("admin")).thenReturn(Optional.of(club));
-
-            ClubBoard board = mock(ClubBoard.class);
-            when(board.getClub()).thenReturn(club);
-            when(board.getThumbnailUrl()).thenReturn(THUMBNAIL_URL);
-            when(clubBoardRepository.findById("board123")).thenReturn(Optional.of(board));
-            doThrow(new RuntimeException("s3 down")).when(s3Service).deleteFile(THUMBNAIL_URL);
-
-            DeleteBoardServiceRequest request = new DeleteBoardServiceRequest("admin", "club123", "board123");
-
-            clubBoardService.deleteBoard(request);
-
-            verify(clubBoardRepository).delete(board);
         }
 
         @Test

--- a/src/test/java/org/project/ttokttok/domain/clubboard/service/ClubBoardAdminServiceTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/service/ClubBoardAdminServiceTest.java
@@ -4,9 +4,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.project.ttokttok.domain.club.domain.Club;
+import org.project.ttokttok.domain.club.exception.FileIsNotImageException;
 import org.project.ttokttok.domain.club.exception.NotClubAdminException;
 import org.project.ttokttok.domain.club.repository.ClubRepository;
 import org.project.ttokttok.domain.clubboard.domain.ClubBoard;
@@ -16,21 +16,30 @@ import org.project.ttokttok.domain.clubboard.repository.ClubBoardRepository;
 import org.project.ttokttok.domain.clubboard.service.dto.request.ClubBoardUpdateServiceRequest;
 import org.project.ttokttok.domain.clubboard.service.dto.request.CreateBoardServiceRequest;
 import org.project.ttokttok.domain.clubboard.service.dto.request.DeleteBoardServiceRequest;
+import org.project.ttokttok.infrastructure.s3.service.S3Service;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
+import static org.project.ttokttok.infrastructure.s3.enums.S3FileDirectory.BOARD_IMAGE;
 
 @ExtendWith(MockitoExtension.class)
 class ClubBoardAdminServiceTest {
 
     private final ClubRepository clubRepository = mock(ClubRepository.class);
     private final ClubBoardRepository clubBoardRepository = mock(ClubBoardRepository.class);
+    private final S3Service s3Service = mock(S3Service.class);
     private final ClubBoardAdminService clubBoardService =
-            new ClubBoardAdminService(clubRepository, clubBoardRepository);
+            new ClubBoardAdminService(clubRepository, clubBoardRepository, s3Service);
+
+    private static final String THUMBNAIL_URL = "https://cdn.example.com/board-images/uuid_thumb.png";
 
     private Club mockClub(String clubId) {
         Club club = mock(Club.class);
@@ -38,26 +47,75 @@ class ClubBoardAdminServiceTest {
         return club;
     }
 
+    private MultipartFile imageFile() {
+        return new MockMultipartFile("thumbnail", "thumb.png", "image/png", "img".getBytes());
+    }
+
+    private MultipartFile pdfFile() {
+        return new MockMultipartFile("thumbnail", "doc.pdf", "application/pdf", "pdf".getBytes());
+    }
+
     @Nested
     @DisplayName("createBoard()")
     class CreateBoard {
 
         @Test
-        @DisplayName("게시글 생성에 성공한다.")
+        @DisplayName("썸네일을 S3에 업로드하고 URL을 저장하며 게시글 생성에 성공한다.")
         void createBoardSuccess() {
             Club club = mockClub("club123");
             when(clubRepository.findByAdminUsername("admin")).thenReturn(Optional.of(club));
+            when(s3Service.uploadFile(any(MultipartFile.class), eq(BOARD_IMAGE.getDirectoryName())))
+                    .thenReturn(THUMBNAIL_URL);
 
             ClubBoard savedBoard = mock(ClubBoard.class);
             when(savedBoard.getId()).thenReturn("board123");
             when(clubBoardRepository.save(any(ClubBoard.class))).thenReturn(savedBoard);
 
-            CreateBoardServiceRequest request = new CreateBoardServiceRequest("admin", "club123", "title", "content");
+            CreateBoardServiceRequest request =
+                    new CreateBoardServiceRequest("admin", "club123", "title", "content", imageFile());
 
             String result = clubBoardService.createBoard(request);
 
             assertThat(result).isEqualTo("board123");
+            verify(s3Service).uploadFile(any(MultipartFile.class), eq(BOARD_IMAGE.getDirectoryName()));
             verify(clubBoardRepository).save(any(ClubBoard.class));
+            verify(s3Service, never()).deleteFile(anyString());
+        }
+
+        @Test
+        @DisplayName("썸네일이 이미지 형식이 아니면 예외가 발생하고 업로드하지 않는다.")
+        void createBoardNotImage() {
+            Club club = mockClub("club123");
+            when(clubRepository.findByAdminUsername("admin")).thenReturn(Optional.of(club));
+
+            CreateBoardServiceRequest request =
+                    new CreateBoardServiceRequest("admin", "club123", "title", "content", pdfFile());
+
+            assertThatThrownBy(() -> clubBoardService.createBoard(request))
+                    .isInstanceOf(FileIsNotImageException.class);
+
+            verify(s3Service, never()).uploadFile(any(), anyString());
+            verify(clubBoardRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("DB 저장이 실패하면 업로드된 썸네일을 보상 삭제하고 예외를 다시 던진다.")
+        void createBoardCompensatesUploadOnSaveFailure() {
+            Club club = mockClub("club123");
+            when(clubRepository.findByAdminUsername("admin")).thenReturn(Optional.of(club));
+            when(s3Service.uploadFile(any(MultipartFile.class), eq(BOARD_IMAGE.getDirectoryName())))
+                    .thenReturn(THUMBNAIL_URL);
+            when(clubBoardRepository.save(any(ClubBoard.class)))
+                    .thenThrow(new RuntimeException("db down"));
+
+            CreateBoardServiceRequest request =
+                    new CreateBoardServiceRequest("admin", "club123", "title", "content", imageFile());
+
+            assertThatThrownBy(() -> clubBoardService.createBoard(request))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("db down");
+
+            verify(s3Service).deleteFile(THUMBNAIL_URL);
         }
 
         @Test
@@ -66,11 +124,13 @@ class ClubBoardAdminServiceTest {
             Club club = mockClub("club123");
             when(clubRepository.findByAdminUsername("admin")).thenReturn(Optional.of(club));
 
-            CreateBoardServiceRequest request = new CreateBoardServiceRequest("admin", "otherClub", "title", "content");
+            CreateBoardServiceRequest request =
+                    new CreateBoardServiceRequest("admin", "otherClub", "title", "content", imageFile());
 
             assertThatThrownBy(() -> clubBoardService.createBoard(request))
                     .isInstanceOf(ClubAdminNameNotMatchException.class);
 
+            verify(s3Service, never()).uploadFile(any(), anyString());
             verify(clubBoardRepository, never()).save(any());
         }
 
@@ -79,7 +139,8 @@ class ClubBoardAdminServiceTest {
         void createBoardNotAdmin() {
             when(clubRepository.findByAdminUsername("stranger")).thenReturn(Optional.empty());
 
-            CreateBoardServiceRequest request = new CreateBoardServiceRequest("stranger", "club123", "title", "content");
+            CreateBoardServiceRequest request =
+                    new CreateBoardServiceRequest("stranger", "club123", "title", "content", imageFile());
 
             assertThatThrownBy(() -> clubBoardService.createBoard(request))
                     .isInstanceOf(NotClubAdminException.class);
@@ -91,7 +152,7 @@ class ClubBoardAdminServiceTest {
     class UpdateBoard {
 
         @Test
-        @DisplayName("일부 필드만 보내도 수정에 성공한다.")
+        @DisplayName("일부 필드만 보내도 수정에 성공하고, 썸네일이 없으면 S3에 접근하지 않는다.")
         void updateBoardPartialSuccess() {
             Club club = mockClub("club123");
             when(clubRepository.findByAdminUsername("admin")).thenReturn(Optional.of(club));
@@ -111,6 +172,85 @@ class ClubBoardAdminServiceTest {
             clubBoardService.updateBoard(request);
 
             verify(board).update("새 제목", null);
+            verifyNoInteractions(s3Service);
+        }
+
+        @Test
+        @DisplayName("썸네일을 교체하면 새 이미지를 업로드하고 기존 파일을 삭제한다.")
+        void updateBoardReplacesThumbnail() {
+            Club club = mockClub("club123");
+            when(clubRepository.findByAdminUsername("admin")).thenReturn(Optional.of(club));
+
+            String oldUrl = "https://cdn.example.com/board-images/uuid_old.png";
+            ClubBoard board = mock(ClubBoard.class);
+            when(board.getClub()).thenReturn(club);
+            when(board.getThumbnailUrl()).thenReturn(oldUrl);
+            when(clubBoardRepository.findById("board123")).thenReturn(Optional.of(board));
+            when(s3Service.uploadFile(any(MultipartFile.class), eq(BOARD_IMAGE.getDirectoryName())))
+                    .thenReturn(THUMBNAIL_URL);
+
+            ClubBoardUpdateServiceRequest request = ClubBoardUpdateServiceRequest.builder()
+                    .username("admin")
+                    .clubId("club123")
+                    .boardId("board123")
+                    .thumbnail(imageFile())
+                    .build();
+
+            clubBoardService.updateBoard(request);
+
+            verify(board).updateThumbnailUrl(THUMBNAIL_URL);
+            verify(s3Service).deleteFile(oldUrl);
+        }
+
+        @Test
+        @DisplayName("기존 썸네일 삭제가 실패해도 교체 요청은 성공한다.")
+        void updateBoardOldThumbnailDeleteFailureIsIgnored() {
+            Club club = mockClub("club123");
+            when(clubRepository.findByAdminUsername("admin")).thenReturn(Optional.of(club));
+
+            String oldUrl = "https://cdn.example.com/board-images/uuid_old.png";
+            ClubBoard board = mock(ClubBoard.class);
+            when(board.getClub()).thenReturn(club);
+            when(board.getThumbnailUrl()).thenReturn(oldUrl);
+            when(clubBoardRepository.findById("board123")).thenReturn(Optional.of(board));
+            when(s3Service.uploadFile(any(MultipartFile.class), eq(BOARD_IMAGE.getDirectoryName())))
+                    .thenReturn(THUMBNAIL_URL);
+            doThrow(new RuntimeException("s3 down")).when(s3Service).deleteFile(oldUrl);
+
+            ClubBoardUpdateServiceRequest request = ClubBoardUpdateServiceRequest.builder()
+                    .username("admin")
+                    .clubId("club123")
+                    .boardId("board123")
+                    .thumbnail(imageFile())
+                    .build();
+
+            clubBoardService.updateBoard(request);
+
+            verify(board).updateThumbnailUrl(THUMBNAIL_URL);
+        }
+
+        @Test
+        @DisplayName("교체할 썸네일이 이미지 형식이 아니면 예외가 발생한다.")
+        void updateBoardNotImage() {
+            Club club = mockClub("club123");
+            when(clubRepository.findByAdminUsername("admin")).thenReturn(Optional.of(club));
+
+            ClubBoard board = mock(ClubBoard.class);
+            when(board.getClub()).thenReturn(club);
+            when(clubBoardRepository.findById("board123")).thenReturn(Optional.of(board));
+
+            ClubBoardUpdateServiceRequest request = ClubBoardUpdateServiceRequest.builder()
+                    .username("admin")
+                    .clubId("club123")
+                    .boardId("board123")
+                    .thumbnail(pdfFile())
+                    .build();
+
+            assertThatThrownBy(() -> clubBoardService.updateBoard(request))
+                    .isInstanceOf(FileIsNotImageException.class);
+
+            verify(s3Service, never()).uploadFile(any(), anyString());
+            verify(board, never()).updateThumbnailUrl(anyString());
         }
 
         @Test
@@ -163,14 +303,54 @@ class ClubBoardAdminServiceTest {
     class DeleteBoard {
 
         @Test
-        @DisplayName("게시글 삭제에 성공한다.")
+        @DisplayName("게시글 삭제 시 S3 썸네일 파일도 삭제한다.")
         void deleteBoardSuccess() {
             Club club = mockClub("club123");
             when(clubRepository.findByAdminUsername("admin")).thenReturn(Optional.of(club));
 
             ClubBoard board = mock(ClubBoard.class);
             when(board.getClub()).thenReturn(club);
+            when(board.getThumbnailUrl()).thenReturn(THUMBNAIL_URL);
             when(clubBoardRepository.findById("board123")).thenReturn(Optional.of(board));
+
+            DeleteBoardServiceRequest request = new DeleteBoardServiceRequest("admin", "club123", "board123");
+
+            clubBoardService.deleteBoard(request);
+
+            verify(clubBoardRepository).delete(board);
+            verify(s3Service).deleteFile(THUMBNAIL_URL);
+        }
+
+        @Test
+        @DisplayName("썸네일이 없는 레거시 게시글은 S3에 접근하지 않고 삭제한다.")
+        void deleteBoardWithoutThumbnail() {
+            Club club = mockClub("club123");
+            when(clubRepository.findByAdminUsername("admin")).thenReturn(Optional.of(club));
+
+            ClubBoard board = mock(ClubBoard.class);
+            when(board.getClub()).thenReturn(club);
+            when(board.getThumbnailUrl()).thenReturn(null);
+            when(clubBoardRepository.findById("board123")).thenReturn(Optional.of(board));
+
+            DeleteBoardServiceRequest request = new DeleteBoardServiceRequest("admin", "club123", "board123");
+
+            clubBoardService.deleteBoard(request);
+
+            verify(clubBoardRepository).delete(board);
+            verifyNoInteractions(s3Service);
+        }
+
+        @Test
+        @DisplayName("S3 삭제가 실패해도 게시글 삭제는 성공한다.")
+        void deleteBoardS3FailureIsIgnored() {
+            Club club = mockClub("club123");
+            when(clubRepository.findByAdminUsername("admin")).thenReturn(Optional.of(club));
+
+            ClubBoard board = mock(ClubBoard.class);
+            when(board.getClub()).thenReturn(club);
+            when(board.getThumbnailUrl()).thenReturn(THUMBNAIL_URL);
+            when(clubBoardRepository.findById("board123")).thenReturn(Optional.of(board));
+            doThrow(new RuntimeException("s3 down")).when(s3Service).deleteFile(THUMBNAIL_URL);
 
             DeleteBoardServiceRequest request = new DeleteBoardServiceRequest("admin", "club123", "board123");
 
@@ -196,6 +376,7 @@ class ClubBoardAdminServiceTest {
                     .isInstanceOf(ClubAdminNameNotMatchException.class);
 
             verify(clubBoardRepository, never()).delete(any());
+            verifyNoInteractions(s3Service);
         }
     }
 }

--- a/src/test/java/org/project/ttokttok/domain/clubboard/service/ClubBoardUserServiceTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/service/ClubBoardUserServiceTest.java
@@ -128,6 +128,49 @@ class ClubBoardUserServiceTest {
 
             assertThat(response.boards().get(0).thumbnailUrl()).isNull();
         }
+
+        @Test
+        @DisplayName("size가 최대치(50)를 초과하면 50으로 보정하여 조회한다.")
+        void getBoardListClampsOversizedRequest() {
+            when(clubRepository.existsById("club123")).thenReturn(true);
+            when(clubBoardRepository.findBoardsByClubIdWithCursor("club123", 50, null))
+                    .thenReturn(List.of());
+
+            clubBoardUserService.getBoardList("club123", 1_000_000, null);
+
+            verify(clubBoardRepository).findBoardsByClubIdWithCursor("club123", 50, null);
+        }
+
+        @Test
+        @DisplayName("size가 1 미만이면 1로 보정하여 조회한다.")
+        void getBoardListClampsUndersizedRequest() {
+            when(clubRepository.existsById("club123")).thenReturn(true);
+            when(clubBoardRepository.findBoardsByClubIdWithCursor("club123", 1, null))
+                    .thenReturn(List.of());
+
+            clubBoardUserService.getBoardList("club123", -5, null);
+            clubBoardUserService.getBoardList("club123", 0, null);
+
+            verify(clubBoardRepository, times(2)).findBoardsByClubIdWithCursor("club123", 1, null);
+        }
+
+        @Test
+        @DisplayName("보정된 size 기준으로 hasNext를 판단한다.")
+        void getBoardListHasNextUsesClampedSize() {
+            when(clubRepository.existsById("club123")).thenReturn(true);
+
+            ClubBoard board1 = mockBoard("board1", "제목1", "내용1");
+            ClubBoard board2 = mockBoard("board2", "제목2", "내용2");
+            // size=0 → 1로 보정, 2건(size+1) 반환 시 hasNext=true + 1건만 반환
+            when(clubBoardRepository.findBoardsByClubIdWithCursor("club123", 1, null))
+                    .thenReturn(List.of(board1, board2));
+
+            ClubBoardListResponse response = clubBoardUserService.getBoardList("club123", 0, null);
+
+            assertThat(response.hasNext()).isTrue();
+            assertThat(response.boards()).hasSize(1);
+            assertThat(response.nextCursor()).isEqualTo("board1");
+        }
     }
 
     @Nested

--- a/src/test/java/org/project/ttokttok/domain/clubboard/service/ClubBoardUserServiceTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/service/ClubBoardUserServiceTest.java
@@ -8,13 +8,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.project.ttokttok.domain.club.domain.Club;
 import org.project.ttokttok.domain.club.exception.ClubNotFoundException;
 import org.project.ttokttok.domain.club.repository.ClubRepository;
+import org.project.ttokttok.domain.clubboard.controller.dto.response.ClubBoardDetailResponse;
 import org.project.ttokttok.domain.clubboard.controller.dto.response.ClubBoardListResponse;
 import org.project.ttokttok.domain.clubboard.controller.dto.response.ClubBoardListResponse.ClubBoardSummary;
 import org.project.ttokttok.domain.clubboard.domain.ClubBoard;
+import org.project.ttokttok.domain.clubboard.exception.ClubBoardNotFoundException;
 import org.project.ttokttok.domain.clubboard.repository.ClubBoardRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -27,6 +30,8 @@ class ClubBoardUserServiceTest {
     private final ClubRepository clubRepository = mock(ClubRepository.class);
     private final ClubBoardUserService clubBoardUserService =
             new ClubBoardUserService(clubBoardRepository, clubRepository);
+
+    private static final String THUMBNAIL_URL = "https://cdn.example.com/board-images/uuid_thumb.webp";
 
     private ClubBoard mockBoard(String id, String title, String content) {
         Club club = mock(Club.class);
@@ -73,8 +78,7 @@ class ClubBoardUserServiceTest {
 
             ClubBoardSummary summary = response.boards().get(0);
             assertThat(summary.boardId()).isEqualTo("board1");
-            assertThat(summary.title()).isEqualTo("제목1");
-            assertThat(summary.clubName()).isEqualTo("동아리");
+            assertThat(summary.createdAt()).isEqualTo(LocalDateTime.of(2026, 1, 1, 0, 0));
         }
 
         @Test
@@ -97,65 +101,76 @@ class ClubBoardUserServiceTest {
         }
 
         @Test
-        @DisplayName("게시글 내용에 img 태그가 있으면 hasImages가 true이다.")
-        void getBoardListHasImagesFromImgTag() {
-            when(clubRepository.existsById("club123")).thenReturn(true);
-
-            ClubBoard board = mockBoard("board1", "제목", "<p>본문 <img src='a.png'/></p>");
-            when(clubBoardRepository.findBoardsByClubIdWithCursor("club123", 20, null))
-                    .thenReturn(List.of(board));
-
-            ClubBoardListResponse response = clubBoardUserService.getBoardList("club123", 20, null);
-
-            assertThat(response.boards().get(0).hasImages()).isTrue();
-        }
-
-        @Test
-        @DisplayName("게시글 내용에 이미지가 없으면 hasImages가 false이다.")
-        void getBoardListNoImages() {
-            when(clubRepository.existsById("club123")).thenReturn(true);
-
-            ClubBoard board = mockBoard("board1", "제목", "그냥 텍스트 내용입니다.");
-            when(clubBoardRepository.findBoardsByClubIdWithCursor("club123", 20, null))
-                    .thenReturn(List.of(board));
-
-            ClubBoardListResponse response = clubBoardUserService.getBoardList("club123", 20, null);
-
-            assertThat(response.boards().get(0).hasImages()).isFalse();
-        }
-
-        @Test
-        @DisplayName("썸네일이 있는 게시글은 thumbnailUrl이 내려가고 내용이 텍스트뿐이어도 hasImages가 true이다.")
+        @DisplayName("썸네일이 있는 게시글은 thumbnailUrl이 내려간다.")
         void getBoardListWithThumbnail() {
             when(clubRepository.existsById("club123")).thenReturn(true);
 
-            String thumbnailUrl = "https://cdn.example.com/board-images/uuid_thumb.webp";
-            ClubBoard board = mockBoard("board1", "제목", "그냥 텍스트 내용입니다.");
-            lenient().when(board.getThumbnailUrl()).thenReturn(thumbnailUrl);
+            ClubBoard board = mockBoard("board1", "제목", "내용");
+            lenient().when(board.getThumbnailUrl()).thenReturn(THUMBNAIL_URL);
             when(clubBoardRepository.findBoardsByClubIdWithCursor("club123", 20, null))
                     .thenReturn(List.of(board));
 
             ClubBoardListResponse response = clubBoardUserService.getBoardList("club123", 20, null);
 
-            ClubBoardSummary summary = response.boards().get(0);
-            assertThat(summary.thumbnailUrl()).isEqualTo(thumbnailUrl);
-            assertThat(summary.hasImages()).isTrue();
+            assertThat(response.boards().get(0).thumbnailUrl()).isEqualTo(THUMBNAIL_URL);
         }
 
         @Test
-        @DisplayName("썸네일이 없는 레거시 게시글은 thumbnailUrl이 null이고 기존 휴리스틱 동작을 유지한다.")
+        @DisplayName("썸네일이 없는 레거시 게시글은 thumbnailUrl이 null이다.")
         void getBoardListLegacyBoardWithoutThumbnail() {
             when(clubRepository.existsById("club123")).thenReturn(true);
 
-            ClubBoard board = mockBoard("board1", "제목", "그냥 텍스트 내용입니다.");
+            ClubBoard board = mockBoard("board1", "제목", "내용");
             when(clubBoardRepository.findBoardsByClubIdWithCursor("club123", 20, null))
                     .thenReturn(List.of(board));
 
             ClubBoardListResponse response = clubBoardUserService.getBoardList("club123", 20, null);
 
-            ClubBoardSummary summary = response.boards().get(0);
-            assertThat(summary.thumbnailUrl()).isNull();
-            assertThat(summary.hasImages()).isFalse();
+            assertThat(response.boards().get(0).thumbnailUrl()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("getBoardDetail()")
+    class GetBoardDetail {
+
+        @Test
+        @DisplayName("게시글 상세 정보를 조회한다.")
+        void getBoardDetailSuccess() {
+            ClubBoard board = mockBoard("board1", "제목", "본문 전체 내용");
+            lenient().when(board.getThumbnailUrl()).thenReturn(THUMBNAIL_URL);
+            when(clubBoardRepository.findByIdAndClubIdWithClub("board1", "club123"))
+                    .thenReturn(Optional.of(board));
+
+            ClubBoardDetailResponse response = clubBoardUserService.getBoardDetail("club123", "board1");
+
+            assertThat(response.boardId()).isEqualTo("board1");
+            assertThat(response.title()).isEqualTo("제목");
+            assertThat(response.content()).isEqualTo("본문 전체 내용");
+            assertThat(response.thumbnailUrl()).isEqualTo(THUMBNAIL_URL);
+            assertThat(response.clubName()).isEqualTo("동아리");
+            assertThat(response.createdAt()).isEqualTo(LocalDateTime.of(2026, 1, 1, 0, 0));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 게시글을 조회하면 예외가 발생한다.")
+        void getBoardDetailNotFound() {
+            when(clubBoardRepository.findByIdAndClubIdWithClub("missing", "club123"))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> clubBoardUserService.getBoardDetail("club123", "missing"))
+                    .isInstanceOf(ClubBoardNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("다른 동아리 소속 게시글을 조회하면 예외가 발생한다.")
+        void getBoardDetailWrongClub() {
+            // 리포지토리 쿼리가 clubId 조건을 포함하므로 다른 동아리의 boardId로는 조회되지 않는다.
+            when(clubBoardRepository.findByIdAndClubIdWithClub("board1", "otherClub"))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> clubBoardUserService.getBoardDetail("otherClub", "board1"))
+                    .isInstanceOf(ClubBoardNotFoundException.class);
         }
     }
 }

--- a/src/test/java/org/project/ttokttok/domain/clubboard/service/ClubBoardUserServiceTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/service/ClubBoardUserServiceTest.java
@@ -123,5 +123,39 @@ class ClubBoardUserServiceTest {
 
             assertThat(response.boards().get(0).hasImages()).isFalse();
         }
+
+        @Test
+        @DisplayName("썸네일이 있는 게시글은 thumbnailUrl이 내려가고 내용이 텍스트뿐이어도 hasImages가 true이다.")
+        void getBoardListWithThumbnail() {
+            when(clubRepository.existsById("club123")).thenReturn(true);
+
+            String thumbnailUrl = "https://cdn.example.com/board-images/uuid_thumb.webp";
+            ClubBoard board = mockBoard("board1", "제목", "그냥 텍스트 내용입니다.");
+            lenient().when(board.getThumbnailUrl()).thenReturn(thumbnailUrl);
+            when(clubBoardRepository.findBoardsByClubIdWithCursor("club123", 20, null))
+                    .thenReturn(List.of(board));
+
+            ClubBoardListResponse response = clubBoardUserService.getBoardList("club123", 20, null);
+
+            ClubBoardSummary summary = response.boards().get(0);
+            assertThat(summary.thumbnailUrl()).isEqualTo(thumbnailUrl);
+            assertThat(summary.hasImages()).isTrue();
+        }
+
+        @Test
+        @DisplayName("썸네일이 없는 레거시 게시글은 thumbnailUrl이 null이고 기존 휴리스틱 동작을 유지한다.")
+        void getBoardListLegacyBoardWithoutThumbnail() {
+            when(clubRepository.existsById("club123")).thenReturn(true);
+
+            ClubBoard board = mockBoard("board1", "제목", "그냥 텍스트 내용입니다.");
+            when(clubBoardRepository.findBoardsByClubIdWithCursor("club123", 20, null))
+                    .thenReturn(List.of(board));
+
+            ClubBoardListResponse response = clubBoardUserService.getBoardList("club123", 20, null);
+
+            ClubBoardSummary summary = response.boards().get(0);
+            assertThat(summary.thumbnailUrl()).isNull();
+            assertThat(summary.hasImages()).isFalse();
+        }
     }
 }

--- a/src/test/java/org/project/ttokttok/infrastructure/s3/service/S3ServiceTest.java
+++ b/src/test/java/org/project/ttokttok/infrastructure/s3/service/S3ServiceTest.java
@@ -1,7 +1,9 @@
 package org.project.ttokttok.infrastructure.s3.service;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -10,6 +12,8 @@ import org.project.ttokttok.infrastructure.s3.enums.S3FileDirectory;
 import org.project.ttokttok.infrastructure.s3.exception.S3FileUploadException;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -19,6 +23,7 @@ import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,6 +46,14 @@ class S3ServiceTest {
     void setUp() {
         s3Service = new S3Service(s3Client, validator, keyUrlGenerator);
         ReflectionTestUtils.setField(s3Service, "bucketName", TEST_BUCKET);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // 테스트에서 수동으로 연 트랜잭션 동기화 컨텍스트를 반드시 정리한다 (스레드 로컬 누수 방지).
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
     }
 
     @Test
@@ -198,5 +211,146 @@ class S3ServiceTest {
         verify(validator).validateType(contentType);
         verify(keyUrlGenerator).generateKey(dirName, fileName);
         verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    }
+
+    // ------- 트랜잭션 연동 삭제 (tx-aware) -------
+
+    private static final String FILE_URL = "https://cdn.test.com/board-images/uuid_thumb.png";
+
+    private void stubExtractKey() {
+        lenient().when(keyUrlGenerator.extractKeyFromUrl(FILE_URL))
+                .thenReturn("board-images/uuid_thumb.png");
+    }
+
+    private void triggerAfterCommit() {
+        TransactionSynchronizationManager.getSynchronizations()
+                .forEach(TransactionSynchronization::afterCommit);
+    }
+
+    private void triggerAfterCompletion(int status) {
+        TransactionSynchronizationManager.getSynchronizations()
+                .forEach(sync -> sync.afterCompletion(status));
+    }
+
+    @Nested
+    @DisplayName("deleteFileAfterCommit()")
+    class DeleteFileAfterCommit {
+
+        @Test
+        @DisplayName("활성 트랜잭션이 있으면 커밋 전에는 삭제하지 않고, 커밋 이후에 삭제한다.")
+        void deletesOnlyAfterCommit() {
+            stubExtractKey();
+            TransactionSynchronizationManager.initSynchronization();
+
+            s3Service.deleteFileAfterCommit(FILE_URL);
+
+            verify(s3Client, never()).deleteObject(any(DeleteObjectRequest.class));
+
+            triggerAfterCommit();
+
+            verify(s3Client).deleteObject(any(DeleteObjectRequest.class));
+        }
+
+        @Test
+        @DisplayName("트랜잭션이 롤백되면(afterCommit 미호출) 파일을 삭제하지 않는다.")
+        void doesNotDeleteOnRollback() {
+            TransactionSynchronizationManager.initSynchronization();
+
+            s3Service.deleteFileAfterCommit(FILE_URL);
+
+            triggerAfterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK);
+
+            verify(s3Client, never()).deleteObject(any(DeleteObjectRequest.class));
+        }
+
+        @Test
+        @DisplayName("활성 트랜잭션이 없으면 즉시 삭제한다.")
+        void deletesImmediatelyWithoutTransaction() {
+            stubExtractKey();
+
+            s3Service.deleteFileAfterCommit(FILE_URL);
+
+            verify(s3Client).deleteObject(any(DeleteObjectRequest.class));
+        }
+
+        @Test
+        @DisplayName("커밋 이후 삭제가 실패해도 예외를 전파하지 않는다.")
+        void swallowsDeleteFailureAfterCommit() {
+            stubExtractKey();
+            TransactionSynchronizationManager.initSynchronization();
+            when(s3Client.deleteObject(any(DeleteObjectRequest.class)))
+                    .thenThrow(new RuntimeException("s3 down"));
+
+            s3Service.deleteFileAfterCommit(FILE_URL);
+
+            assertThatCode(S3ServiceTest.this::triggerAfterCommit)
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteFileOnRollback()")
+    class DeleteFileOnRollback {
+
+        @Test
+        @DisplayName("트랜잭션이 롤백되면 파일을 삭제한다.")
+        void deletesOnRollback() {
+            stubExtractKey();
+            TransactionSynchronizationManager.initSynchronization();
+
+            s3Service.deleteFileOnRollback(FILE_URL);
+
+            verify(s3Client, never()).deleteObject(any(DeleteObjectRequest.class));
+
+            triggerAfterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK);
+
+            verify(s3Client).deleteObject(any(DeleteObjectRequest.class));
+        }
+
+        @Test
+        @DisplayName("트랜잭션이 커밋되면 파일을 삭제하지 않는다.")
+        void doesNotDeleteOnCommit() {
+            TransactionSynchronizationManager.initSynchronization();
+
+            s3Service.deleteFileOnRollback(FILE_URL);
+
+            triggerAfterCompletion(TransactionSynchronization.STATUS_COMMITTED);
+
+            verify(s3Client, never()).deleteObject(any(DeleteObjectRequest.class));
+        }
+
+        @Test
+        @DisplayName("커밋 여부가 불명확하면(STATUS_UNKNOWN) 파일을 삭제하지 않는다.")
+        void doesNotDeleteOnUnknownStatus() {
+            TransactionSynchronizationManager.initSynchronization();
+
+            s3Service.deleteFileOnRollback(FILE_URL);
+
+            triggerAfterCompletion(TransactionSynchronization.STATUS_UNKNOWN);
+
+            verify(s3Client, never()).deleteObject(any(DeleteObjectRequest.class));
+        }
+
+        @Test
+        @DisplayName("활성 트랜잭션이 없으면 아무 동작도 하지 않는다.")
+        void noOpWithoutTransaction() {
+            s3Service.deleteFileOnRollback(FILE_URL);
+
+            verifyNoInteractions(s3Client);
+        }
+
+        @Test
+        @DisplayName("롤백 시 삭제가 실패해도 예외를 전파하지 않는다.")
+        void swallowsDeleteFailureOnRollback() {
+            stubExtractKey();
+            TransactionSynchronizationManager.initSynchronization();
+            when(s3Client.deleteObject(any(DeleteObjectRequest.class)))
+                    .thenThrow(new RuntimeException("s3 down"));
+
+            s3Service.deleteFileOnRollback(FILE_URL);
+
+            assertThatCode(() -> triggerAfterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK))
+                    .doesNotThrowAnyException();
+        }
     }
 }


### PR DESCRIPTION
## ✨ 작업 내용
- 동아리 게시판을 인스타그램식 사진 피드 형태로 확장 — 게시글 대표(썸네일) 이미지 도입
- 게시글 생성 API(`POST /api/admin/clubs/{clubId}/boards`)를 multipart/form-data로 전환: `request`(JSON) + `thumbnail`(이미지, **필수**) 파트, S3 `board-images/` 업로드 후 URL 저장
- 게시글 수정 API(`PATCH`)도 multipart 전환, 썸네일 교체 지원 (썸네일만 교체도 가능)
- **게시글 상세 조회 API 신설**: `GET /api/clubs/{clubId}/boards/{boardId}` — 본문 전문 포함, fetch join, 타 동아리 boardId 접근 시 404
- **목록 API 응답 경량화**: 항목당 `boardId` + `thumbnailUrl` + `createdAt`만 내려가는 썸네일 피드로 변경 (content 전문/`hasImages` 제거 — 상세는 상세 API로)
- 트랜잭션-S3 정합성: S3 삭제는 커밋 이후로 예약(`deleteFileAfterCommit`), 업로드본은 롤백 시 보상 삭제(`deleteFileOnRollback`) — S3 실패가 DB 작업을 막지 않음
- `MissingServletRequestPartException` → 400 매핑 추가 (기존엔 캐치올로 500)
- Swagger 어노테이션을 `docs` 인터페이스(`ClubBoardAdminDocs`/`ClubBoardUserDocs`)로 분리
- 팀 공용 `.claude/settings.json` 신설 (verify.sh 실행 allow 권한)
- **DB 변경 있음**: Flyway 2건 — `V24` `club_boards.thumbnail_url VARCHAR(512)` 컬럼 추가 (V23은 PR #336이 선점), `V25` 피드 커서 쿼리용 복합 인덱스 `(club_id, created_at DESC, id DESC)`

---

## 🔍 관련 이슈
- 해결한 이슈 번호: #337

---

## ✅ 체크리스트
- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요?
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항
> - **프론트 API 계약 변경 (협의 필요)**:
>   1. 생성/수정 요청: JSON → multipart/form-data
>   2. 목록 응답: 항목당 `{boardId, thumbnailUrl, createdAt}`만 (기존 title/content/clubName/hasImages 제거)
>   3. 상세 화면은 신설된 `GET .../boards/{boardId}` 사용
> - 신규 게시글부터 썸네일 필수 정책, 기존 텍스트-온리 글은 `thumbnailUrl: null`로 유지 (운영 데이터 없음 확인, 마이그레이션 불필요)
> - S3 업로드는 기존 `S3Service` 스트리밍 재사용, 이미지 타입 검증은 `AllowedFileTypes.IMAGES` 단일 소스. multipart 사이즈 제한은 yml 단일 소스 유지(#326)
> - `bash maintenance/verify.sh` 그린 (전체 테스트 + JaCoCo 게이트 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

