### PR TITLE
ship 스킬 커밋 단위 분할 규칙 도입 및 커밋 메시지 AI 서명 금지 (chore/#348 -> develop)

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -5,6 +5,8 @@ argument-hint: <task description> [--type feature|fix|refactor|chore|test|arch|h
 
 Follow the `ship` project skill end-to-end for this task: $ARGUMENTS
 
-Read `.omc/skills/ship/SKILL.md` at the project root and execute its full protocol in order: issue creation, branch + worktree creation, implementation, the verify gate (cap at 3 retries), `IMPLEMENTATION.md` recording, commit, push, and PR creation against `develop`. Follow the type-mapping table in that file for issue template/label/branch-prefix selection.
+Read `.omc/skills/ship/SKILL.md` at the project root and execute its full protocol in order: issue creation, branch + worktree creation, implementation, the verify gate (cap at 3 retries), the commit-split plan, one commit per slice, the per-commit compile gate, `IMPLEMENTATION.md` recording, push, and PR creation against `develop`. Follow the type-mapping table in that file for issue template/label/branch-prefix selection.
+
+Commits must follow `rules/agent/commit-granularity.md` (one concern per commit) and carry no AI signatures — no `Co-Authored-By: <model>`, no `🤖 Generated with…` — in either commit messages or the PR body.
 
 Run fully autonomously — do not pause for confirmation between steps, per the skill's protocol. If `release` is requested, refuse and point at the release-PR section of `.github/PULL_REQUEST_TEMPLATE.md` instead.

--- a/.omc/skills/ship/SKILL.md
+++ b/.omc/skills/ship/SKILL.md
@@ -79,6 +79,8 @@ Every issue body must also cover the fields from [`maintenance/task.md`](../../.
    ```
    Never edit `.gitignore` to make these trackable — they stay untracked by design (secrets/local fixtures). This step only mirrors the working-tree copy across so the new worktree can actually build and test; it changes nothing about what git tracks.
 
+   Note the `-- src` scope: this deliberately does **not** copy the root-level gitignored docs `GEMINI.md` and `IMPLEMENTATION.md`. Those stay single-copy in the original checkout so the work log never forks. Read and append to them there (path from `git worktree list`), not inside the worktree.
+
 4. **Implement (Change)** — follow `AGENTS.md` conventions. Use the per-type mini checklist in `maintenance/task.md` as the working checklist.
 
 5. **Verify**:
@@ -116,6 +118,10 @@ Every issue body must also cover the fields from [`maintenance/task.md`](../../.
    Then confirm the rebase changed nothing: `git diff <pre-rebase HEAD> HEAD --stat` must be empty. If it is not, re-run `bash maintenance/verify.sh`. The full test suite runs **once** on the final tree, not per commit.
 
 9. **Record** — append a dated section to `IMPLEMENTATION.md`, following its existing format (see prior entries: dated header, 주요 작업 내용, 기술적 세부 사항, 업데이트된 파일, 최종 확인 사항). Written after the code commits so it can describe the actual commit breakdown. Do not sign the entry with a model name.
+
+   **`IMPLEMENTATION.md` is gitignored** (`.gitignore:68`, alongside `GEMINI.md`) — it is a local-only work log and is **never committed**. Do not stage it, do not expect a commit from this step, and do not "fix" it by editing `.gitignore`. Two consequences:
+   - A fresh worktree does not contain it (step 3's restore only sweeps gitignored files under `src`). Append to the log in the **original checkout** found via `git worktree list`, not to a new copy inside the worktree.
+   - Treat it like the other protected local-only files: append only, never overwrite or recreate (`rules/agent/protected-local-files.md`).
 
 10. **Push**:
    ```bash

--- a/.omc/skills/ship/SKILL.md
+++ b/.omc/skills/ship/SKILL.md
@@ -111,7 +111,7 @@ Every issue body must also cover the fields from [`maintenance/task.md`](../../.
    ```bash
    git rebase origin/develop --exec './gradlew.bat compileJava compileTestJava'
    ```
-   (Verified working in Git Bash on Windows; `gradlew.bat` needs no `cmd //c` wrapper.) On failure the rebase halts at the offending commit — fix it, `git commit --amend`, then `git rebase --continue`.
+   (Verified working in Git Bash on Windows; `gradlew.bat` needs no `cmd //c` wrapper. Each run prints `'DOSKEY' is not recognized…` — a harmless Git-Bash artifact of `gradlew.bat`, not a failure. Judge by `BUILD SUCCESSFUL` and the exit code.) On failure the rebase halts at the offending commit — fix it, `git commit --amend`, then `git rebase --continue`.
 
    **Never use `git stash` for this.** Rebase leaves untracked and gitignored files alone, so the local-only config restored in step 3 survives; `git stash -a` / `--all` would sweep those up (see `rules/agent/protected-local-files.md`).
 

--- a/.omc/skills/ship/SKILL.md
+++ b/.omc/skills/ship/SKILL.md
@@ -24,8 +24,11 @@ Callable directly as a typed slash command via [`/ship`](../../../.claude/comman
 Automates the full `ttokttok` task pipeline described in [`maintenance/HARNESS.md`](../../../maintenance/HARNESS.md):
 
 ```
-issue → branch/worktree → implement (Change) → verify → record → commit → push → PR
+issue → branch/worktree → implement (Change) → verify
+      → split-plan → commit ×N → per-commit gate → record → push → PR
 ```
+
+Commits are sliced per concern, not dumped as one big commit — see [`rules/agent/commit-granularity.md`](../../../rules/agent/commit-granularity.md).
 
 Runs fully autonomously once invoked — no confirmation checkpoints between steps. It stops and reports (never fakes success) if the verification gate keeps failing.
 
@@ -84,35 +87,55 @@ Every issue body must also cover the fields from [`maintenance/task.md`](../../.
    ```
    On failure, go back to step 4 and retry. **Cap at 3 verify attempts.** If still failing after 3, stop — do not commit/push/open a PR. Report the failure with the test report path (`build/reports/tests/test/index.html`) and leave the worktree in place for manual inspection. If a failure looks unrelated to the actual change (widespread Spring-context/Flyway errors across unrelated domains), first double-check the local-resource copy above before spending a retry attempt.
 
-6. **Record** — append a dated section to `IMPLEMENTATION.md`, following its existing format (see prior entries: dated header, 주요 작업 내용, 기술적 세부 사항, 업데이트된 파일, 최종 확인 사항).
+6. **Plan the commit split** — before committing anything, enumerate every changed file with `git status --porcelain` and `git diff --stat`, then assign each one to a slice according to [`rules/agent/commit-granularity.md`](../../../rules/agent/commit-granularity.md) (one concern per commit; never mix the four axes; soft caps ~6 code files / ~300 hand-written lines). Output the plan as a table before proceeding:
 
-7. **Commit** — re-run `git status` to confirm no secret files (`application*.yml`, Firebase `*.json`) are staged, then commit with:
+   | # | Commit title | Files | Axis | Rationale |
+   |---|---|---|---|---|
+
+   Order the slices so each compiles on top of the previous one. **Do not move on to committing without this table.**
+
+7. **Commit in slices** — work through the table in order. Stage with `git add <paths>`, or `git add -p` when one file has to be split across slices. After staging each slice, re-run `git status` to confirm no secret files (`application*.yml`, Firebase `*.json`) are staged, then commit with:
    ```
    [#<issue-number>] - <message>
 
    - <item>
    - <item>
    ```
-   (Korean header, per `rules/agent/commit-message.md`. The `commit-msg` hook enforces the format.)
+   (Korean header, per `rules/agent/commit-message.md`. The `commit-msg` hook enforces both the format and the **no-AI-signature** rule — never add `Co-Authored-By: <model>` or `🤖 Generated with…` trailers.)
 
-8. **Push**:
+   After the last slice, assert that **`git status --porcelain` is empty**. That is what proves the committed HEAD tree is identical to the tree `verify.sh` already passed in step 5 — so the full gate does not need re-running. If anything is left over, a slice was missed: go back to the table.
+
+8. **Per-commit gate** — sweep the finished branch so every intermediate commit is known to compile:
+   ```bash
+   git rebase origin/develop --exec './gradlew.bat compileJava compileTestJava'
+   ```
+   (Verified working in Git Bash on Windows; `gradlew.bat` needs no `cmd //c` wrapper.) On failure the rebase halts at the offending commit — fix it, `git commit --amend`, then `git rebase --continue`.
+
+   **Never use `git stash` for this.** Rebase leaves untracked and gitignored files alone, so the local-only config restored in step 3 survives; `git stash -a` / `--all` would sweep those up (see `rules/agent/protected-local-files.md`).
+
+   Then confirm the rebase changed nothing: `git diff <pre-rebase HEAD> HEAD --stat` must be empty. If it is not, re-run `bash maintenance/verify.sh`. The full test suite runs **once** on the final tree, not per commit.
+
+9. **Record** — append a dated section to `IMPLEMENTATION.md`, following its existing format (see prior entries: dated header, 주요 작업 내용, 기술적 세부 사항, 업데이트된 파일, 최종 확인 사항). Written after the code commits so it can describe the actual commit breakdown. Do not sign the entry with a model name.
+
+10. **Push**:
    ```bash
    git push -u origin "<prefix>/#<issue-number>"
    ```
-   The `pre-push` hook enforces branch naming, blocks force-push, and blocks direct pushes to `main`/`develop` — do not bypass it.
+   The `pre-push` hook enforces branch naming, blocks force-push, and blocks direct pushes to `main`/`develop` — do not bypass it. (Step 8's rebase rewrites commit hashes, but this is the branch's first push, so no force is needed.)
 
-9. **Create the PR** against `develop`, using only the upper half of `.github/PULL_REQUEST_TEMPLATE.md` (everything above the "아래 부터 `develop -> main` PR 템플릿입니다" divider — the release-PR section below it does not apply here). The title must follow [`rules/agent/pr-title.md`](../../../rules/agent/pr-title.md): `<작업 내용> (<branch> -> develop)` — Korean 작업 내용, no issue number in the title (the branch already carries `#<issue>`):
+11. **Create the PR** against `develop`, using only the upper half of `.github/PULL_REQUEST_TEMPLATE.md` (everything above the "아래 부터 `develop -> main` PR 템플릿입니다" divider — the release-PR section below it does not apply here). The title must follow [`rules/agent/pr-title.md`](../../../rules/agent/pr-title.md): `<작업 내용> (<branch> -> develop)` — Korean 작업 내용, no issue number in the title (the branch already carries `#<issue>`):
    ```bash
    gh pr create --base develop --head "<branch>" --title "<작업 내용> (<branch> -> develop)" --body-file <generated PR body> --label "<mapped label>"
    ```
-   e.g. `--title "파일 업로드 로직 개선 (refactor/#326 -> develop)"`. Auto-check the checklist items you can actually verify (로컬 테스트 완료 — since verify.sh passed; 라벨을 붙혔나요 — yes; 팀 코드 컨벤션 준수 — yes), fill in 관련 이슈 with `#<issue-number>`, and summarize the change in 기타 참고 사항.
+   e.g. `--title "파일 업로드 로직 개선 (refactor/#326 -> develop)"`. Auto-check the checklist items you can actually verify (로컬 테스트 완료 — since verify.sh passed; 라벨을 붙혔나요 — yes; 팀 코드 컨벤션 준수 — yes), fill in 관련 이슈 with `#<issue-number>`, and summarize the change in 기타 참고 사항. **No AI signatures in the PR body either** — no model names, no `🤖 Generated with…` footer.
 
-10. **Cleanup** — leave the worktree and branch on disk (for review follow-up commits); do not remove them automatically. If you used `EnterWorktree`, you may call `ExitWorktree({action: "keep"})` to return the parent session to its original directory without deleting anything.
+12. **Cleanup** — leave the worktree and branch on disk (for review follow-up commits); do not remove them automatically. If you used `EnterWorktree`, you may call `ExitWorktree({action: "keep"})` to return the parent session to its original directory without deleting anything.
 
-11. **Report** — output the issue URL, PR URL, branch name, worktree path, and a one-line verify-status summary.
+13. **Report** — output the issue URL, PR URL, branch name, worktree path, the commit breakdown (`git log --oneline origin/develop..HEAD`), and a one-line verify-status summary.
 
 ## Safety
 
-- Never bypass the git hooks in `maintenance/hooks/` (secret guard, protected-branch guard, branch-naming/commit-message checks, no-force-push). They already enforce the conventions this skill relies on.
+- Never bypass the git hooks in `maintenance/hooks/` (secret guard, protected-branch guard, branch-naming/commit-message checks, AI-signature check, no-force-push). They already enforce the conventions this skill relies on.
 - Never claim the task is done if `verify.sh` hasn't gone green in this run.
+- Never squash the slices back into one commit to "keep it simple" — the split is the deliverable, not an optimization.
 - If asked for a `release`, refuse this pipeline and point at the release-PR section of `.github/PULL_REQUEST_TEMPLATE.md` instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,7 @@ public class ClubService {
 Detailed, situational rules live under [`rules/`](rules/) — common agent rules in [`rules/agent/`](rules/agent/), runtime-specific rules in `rules/<runtime>/` (e.g. `rules/claude/`, pointed to from that runtime's entry doc). Git rules are enforced by the hooks in `maintenance/hooks/` (install once via `bash maintenance/hooks/install.sh`).
 
 - **Commit messages** → [`rules/agent/commit-message.md`](rules/agent/commit-message.md)
+- **Commit granularity** → [`rules/agent/commit-granularity.md`](rules/agent/commit-granularity.md)
 - **Branches** → [`rules/agent/branch-naming.md`](rules/agent/branch-naming.md)
 - **PR titles** → [`rules/agent/pr-title.md`](rules/agent/pr-title.md)
 - **Protected local-only files** → [`rules/agent/protected-local-files.md`](rules/agent/protected-local-files.md)

--- a/maintenance/HARNESS.md
+++ b/maintenance/HARNESS.md
@@ -81,7 +81,7 @@ bash maintenance/verify.sh
 ## 5. Record — Log the work
 
 - Append the work to [`../IMPLEMENTATION.md`](../IMPLEMENTATION.md) as a **dated section** (keep the existing format: key work / changed files / verification notes).
-- Commit message: `[#issue] - message` (Korean header), with each item as a `- item` line in the body. (See the commit convention in [`GEMINI.md`](../GEMINI.md).)
+- Commit message: `[#issue] - message` (Korean header), with each item as a `- item` line in the body. (See the commit convention in [`GEMINI.md`](../GEMINI.md).) No AI signatures — see [`rules/agent/commit-message.md`](../rules/agent/commit-message.md).
 - **Split the work into one commit per concern** rather than a single large commit — see [`rules/agent/commit-granularity.md`](../rules/agent/commit-granularity.md).
 - PR: fill in the [`.github/PULL_REQUEST_TEMPLATE.md`](../.github/PULL_REQUEST_TEMPLATE.md) checklist.
 

--- a/maintenance/HARNESS.md
+++ b/maintenance/HARNESS.md
@@ -82,6 +82,7 @@ bash maintenance/verify.sh
 
 - Append the work to [`../IMPLEMENTATION.md`](../IMPLEMENTATION.md) as a **dated section** (keep the existing format: key work / changed files / verification notes).
 - Commit message: `[#issue] - message` (Korean header), with each item as a `- item` line in the body. (See the commit convention in [`GEMINI.md`](../GEMINI.md).)
+- **Split the work into one commit per concern** rather than a single large commit — see [`rules/agent/commit-granularity.md`](../rules/agent/commit-granularity.md).
 - PR: fill in the [`.github/PULL_REQUEST_TEMPLATE.md`](../.github/PULL_REQUEST_TEMPLATE.md) checklist.
 
 > ⚠️ Before committing, re-run `git status` to confirm no secrets are staged.

--- a/maintenance/hooks/commit-msg
+++ b/maintenance/hooks/commit-msg
@@ -20,4 +20,14 @@ if ! printf '%s' "$first_line" | grep -Eq '^\[#[0-9]+\] - .+'; then
         "형식: [#이슈번호] - 메시지   (예: [#312] - 즐겨찾기 도메인 로직 추가)"
 fi
 
+# ④ Block AI attribution (model names / bot emails). Human Co-Authored-By stays allowed.
+if grep -Eiq '^[[:space:]]*co-authored-by:.*(claude|anthropic|noreply@|gemini|gpt|copilot|cursor|codex)' "$msg_file" \
+   || grep -Eiq 'generated with \[?claude' "$msg_file" \
+   || grep -q '🤖' "$msg_file"; then
+  block "커밋 메시지에 AI 서명(모델명/봇 이메일)을 넣지 않습니다." \
+        "제거 대상: 'Co-Authored-By: <모델> <noreply@...>', 'Generated with Claude Code', '🤖'" \
+        "사람 공동 작업자의 Co-Authored-By는 허용됩니다." \
+        "규칙: rules/agent/commit-message.md"
+fi
+
 exit 0

--- a/rules/agent/commit-granularity.md
+++ b/rules/agent/commit-granularity.md
@@ -1,0 +1,67 @@
+# Rule: Commit Granularity
+
+> Indexed from [`AGENTS.md`](../../AGENTS.md) → Git Conventions. Applied by the `/ship` pipeline ([`.omc/skills/ship/SKILL.md`](../../.omc/skills/ship/SKILL.md)) and by [`maintenance/HARNESS.md`](../../maintenance/HARNESS.md) step 5.
+>
+> Unlike the other git rules here, this one is **not** hook-enforced — see [Why no hook](#why-no-hook).
+
+## The rule
+
+> **One commit = one concern a reviewer can understand in a single pass, together with that concern's tests.**
+
+Production code and the tests that directly cover it belong in the **same** commit. Do not split them apart.
+
+## Soft caps
+
+Split the commit — or state in the commit body why it cannot be split — once it exceeds:
+
+- **~6 code files** (`src/**`)
+- **~300 lines** of hand-written diff
+
+Exempt from the caps:
+
+- **Purely mechanical changes** (rename, import cleanup, reformatting) may span any number of files in one commit — provided that commit contains *nothing but* the mechanical change.
+- **Generated files and measurement artifacts** do not count toward the line cap. They still count toward the file cap.
+
+## Never mix these four axes
+
+A single commit must stay within one axis:
+
+| Axis | Typical paths |
+|---|---|
+| 1. Production code + its tests | `src/main/**`, `src/test/**` |
+| 2. Test harness, infrastructure, scripts | `load-test/` (`docker-compose*.yml`, `k6/**`, `scripts/*.ps1`, `sql/**`), `maintenance/**`, `.github/**`, `.claude/**`, `.omc/**` |
+| 3. Measurement artifacts and reports | `load-test/results/**` (`*.log`, `summary.json`, report `*.md`) |
+| 4. Standalone docs and reports | top-level `*.md` such as `migration_plan.md`, report `*.md` |
+
+The 40-file commit in `#346` mixed axes 1, 2, and 3 — a production concurrency fix, the k6 harness that measured it, and 31 result artifacts. That is exactly what this rule prevents.
+
+> **`IMPLEMENTATION.md` is not one of these axes — it is gitignored** (`.gitignore:68`, next to `GEMINI.md`) and is never committed at all. Append to it as the local work log, but do not stage it and do not expect a commit from it.
+
+## Ordering
+
+Order commits so that **each one compiles on top of the one before it**. Preferred sequence:
+
+```
+characterization tests first → behavior-preserving refactor → new behavior → cleanup (comments, dead code)
+```
+
+`#344` is the worked example in this repo's history: `e437740 ApplicantCustomRepositoryImpl characterization 테스트 선작성` lands before `f6b06ff 서류/면접 분기를 ApplicantPhaseQuery 전략으로 제거`.
+
+## Verifying a split branch
+
+Commits are sliced **after** the work is finished, so while staging a slice the working tree still holds every later change — you cannot compile "just this commit's state" in place. Sweep the finished branch instead:
+
+```bash
+git rebase origin/develop --exec './gradlew.bat compileJava compileTestJava'
+```
+
+- Guarantees every intermediate commit compiles, so `git revert` and `git bisect` actually work.
+- On failure the rebase stops at the offending commit. Fix it, `git commit --amend`, then `git rebase --continue`.
+- **Do not use `git stash` for this.** Rebase never touches untracked or gitignored files, so `application*.yml`, the Firebase key, and `db/seed/` stay safe. In particular `git stash -a` / `--all` **would** stash those gitignored local-only files — never use it here (see [`protected-local-files.md`](protected-local-files.md)).
+- Afterwards confirm the final tree is unchanged: `git diff <pre-rebase HEAD> HEAD --stat` must be empty. If it is, the full `verify.sh` run from HARNESS step 4 still holds and does not need repeating. If it is not, re-run `verify.sh`.
+
+The full test suite runs **once**, on the final tree — not per commit. `gradlew clean build` with tests takes minutes; running it N times is not worth the bisect precision it buys.
+
+## Why no hook
+
+The caps above are deliberately *soft* and are not enforced by `maintenance/hooks/`. They require judgment, and legitimate exceptions exist (mechanical bulk renames, artifact-only commits). Contrast [`commit-message.md`](commit-message.md), whose format and AI-signature rules **are** hook-enforced because they are mechanical.

--- a/rules/agent/commit-message.md
+++ b/rules/agent/commit-message.md
@@ -14,3 +14,20 @@
   - 관련 단위 테스트 작성
   ```
 - Auto-generated messages (`Merge`, `Revert`, `fixup!`, `squash!`) are exempt from the format check.
+
+## No AI signatures
+
+Commit messages must not carry AI attribution — no model names, no bot email addresses. Blocked by the same `commit-msg` hook:
+
+- `Co-Authored-By: <model name> <noreply@...>`
+- `🤖 Generated with [Claude Code]` and similar trailers
+- Any model name or bot address in the header or body
+
+**Co-Authored-By for human collaborators stays allowed** — only AI/bot signatures are blocked.
+
+The same applies to **PR bodies**, which the `/ship` pipeline generates from
+[`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md).
+
+> Scope note: the hook only runs on local commits that go through `core.hooksPath`. Squash-merging from
+> the GitHub web UI bypasses it. That gap is accepted; no CI check is added for it.
+


### PR DESCRIPTION
## ✨ 작업 내용

`/ship` 파이프라인이 이슈 하나당 거대한 커밋 하나를 만들어내던 문제를 구조적으로 고치고, 커밋 메시지에 남던 AI 서명을 금지했습니다.

- **커밋 단위 규칙 신설** (`rules/agent/commit-granularity.md`) — 1 커밋 = 리뷰어가 한 번에 이해하는 하나의 관심사 + 그 테스트. 소프트 상한(코드 파일 약 6개 / 손수 작성 diff 약 300줄), 섞지 않는 4개 축, 커밋 순서 규칙을 규정. `AGENTS.md`·`maintenance/HARNESS.md`에 인덱스 등록
- **AI 서명 금지** — `rules/agent/commit-message.md`에 규칙 추가, `maintenance/hooks/commit-msg`에 차단 검사 추가. 사람 공동 작업자의 `Co-Authored-By:`는 계속 허용
- **ship 스킬 프로토콜 재구성** — 분할 계획 스텝(6)과 커밋별 컴파일 게이트 스텝(8) 신설, record를 코드 커밋 이후(9)로 이동
- **gitignore된 작업 로그 처리 버그 수정** — 아래 "기타 참고 사항" 참조

Swagger 문서 변경: 없음
DB 변경 사항: 없음 (프로덕션 코드 `src/` 변경 자체가 없습니다)

---

## 🔍 관련 이슈
- 해결한 이슈 번호: #348

---

## ✅ 체크리스트
- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요?
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항

### 왜 이 변경이 필요했나
원인은 에이전트의 판단이 아니라 스킬의 구조였습니다. 기존 프로토콜은 `구현 → verify → record → commit` 순서에 **단수형 "Commit" 스텝 하나**로 끝나고 분할에 대한 언급이 전혀 없어, 기본 결과가 "이슈 = 커밋 1개"가 됐습니다. 히스토리도 이분적이었습니다 — `#346`은 40-file 커밋 하나(프로덕션 수정 5 + k6 하네스 4 + 실측 산출물 31)로 뭉친 반면 `#344`는 커밋당 1~6 files로 잘 갈렸는데, 후자는 규칙이 아니라 그때그때의 판단이었습니다.

### 작업 중 발견한 별개 버그
`IMPLEMENTATION.md`와 `GEMINI.md`는 `.gitignore:67-68` 대상이라 **커밋될 수 없습니다.** 그런데 기존 프로토콜은 "기록 후 커밋"을 지시하고 있어 빈 커밋을 유도하는 상태였습니다. 또한 워크트리 생성 시 로컬 자원 복원이 `-- src` 범위만 훑기 때문에 새 워크트리에는 작업 로그가 아예 없습니다. 두 사실을 스킬에 명시하고, 로그는 원본 체크아웃에 단일 사본으로 유지하도록 했습니다. (이번 PR의 작업 로그도 그렇게 기록했고, 따라서 diff에는 나타나지 않습니다.)

### 검증 전략: 왜 커밋마다 풀 게이트를 돌리지 않나
`verify.sh`(= `gradlew clean build` + 테스트 전체)는 이번 실측에서 **2분 26초**가 걸립니다. 커밋마다 돌리면 N배가 되는데 그렇게 사서 얻는 건 bisect 정밀도뿐이라, 2단으로 나눴습니다.
- **커밋별(가벼움)**: `compileJava compileTestJava` — 모든 중간 커밋이 컴파일됨을 보장하여 `revert`/`bisect`가 실제로 동작
- **최종 1회(풀)**: `verify.sh`

사후 분할이라 슬라이스 스테이징 시점에는 "그 커밋만의 트리"를 제자리에서 컴파일할 수 없어서, 커밋을 다 만든 뒤 `git rebase origin/develop --exec './gradlew.bat compileJava compileTestJava'`로 브랜치 전체를 훑습니다. `git stash --keep-index`를 쓰지 않은 이유는 rebase가 untracked/gitignore된 파일을 건드리지 않아 `application*.yml`·Firebase 키·`db/seed/`가 안전한 반면 `git stash -a`/`--all`은 그것들까지 쓸어담기 때문입니다.

### 강제 수준의 비대칭 (의도된 설계)
- **커밋 단위**: 훅으로 강제하지 **않습니다.** 판단이 개입하는 소프트 상한이고 정당한 예외(기계적 대량 rename, 산출물 커밋)가 실재합니다.
- **AI 서명 금지**: 훅으로 강제합니다. 판단이 개입하지 않는 기계적 규칙입니다.

`commit-msg` 훅은 `core.hooksPath`를 거치는 로컬 커밋에만 걸리고 GitHub 웹 UI의 스쿼시 머지는 우회한다는 한계가 있습니다. 수용 가능한 범위로 보고 CI 검사는 추가하지 않았습니다.

### 리뷰 시 참고
- 이 PR 자체가 새 규칙의 도그푸딩입니다. 커밋 5개, 각 1~3 파일로 분할했습니다.
- `HARNESS.md`와 `SKILL.md`는 각각 두 관심사에 걸쳐 있어, 인접 줄이라 `git add -p`로 깔끔히 갈리지 않았습니다. 중간 버전 파일을 써서 스테이징 → 커밋 → 최종 버전 복원하는 결정적 방식으로 분할했습니다.
- 기존 히스토리는 재작성하지 않았습니다 (`#346`의 40-file 커밋, 기존 12개 커밋의 `Co-Authored-By` 서명 모두 그대로 둠).
- `.claude/worktrees/*` 안의 스킬 사본은 수정하지 않았습니다. 새 워크트리는 `origin/develop`에서 생성되므로 이 PR 머지 후 자동 반영됩니다.
