### PR TITLE
mailExecutor 동시성 상한 및 백프레셔 테스트 추가 (test/#350 -> develop)

### DIFF
--- a/src/test/java/org/project/ttokttok/global/config/MailExecutorSaturationTest.java
+++ b/src/test/java/org/project/ttokttok/global/config/MailExecutorSaturationTest.java
@@ -1,0 +1,108 @@
+package org.project.ttokttok.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+/**
+ * {@code mailExecutor}의 동시 실행 상한(max=5)과 포화 시 백프레셔(CallerRunsPolicy)가
+ * 런타임에 실제로 동작하는지 검증한다.
+ *
+ * <p>{@link AsyncConfigTest}는 setter로 넣은 <b>설정값</b>을 되읽을 뿐이고,
+ * {@code MailAsyncDispatchTest}는 태스크 1건이 {@code mail-} 스레드로 넘어가는지만 본다.
+ * 둘 다 상한이 지켜지는지는 증명하지 못한다. 이 테스트가 그 구멍을 막는다.
+ *
+ * <p><b>왜 105건인가.</b> {@link java.util.concurrent.ThreadPoolExecutor}는 큐가 가득 찬
+ * 뒤에야 core를 넘어 스레드를 늘린다. 따라서 "20건 제출 후 스레드 &le; 5" 같은 순진한 테스트는
+ * 항상 2개(core)만 관찰하며, max를 50으로 바꿔도 통과하는 위양성이 된다. 실제 상한을 목격하려면
+ * 큐를 먼저 채워야 한다:
+ *
+ * <pre>
+ *   제출 1~2     → core 스레드 2개 생성
+ *   제출 3~102   → 전부 큐 적재 (스레드 증설 없음)
+ *   제출 103~105 → 큐 포화 → 스레드 3, 4, 5 생성 (max 도달)
+ *   제출 106     → 큐 만석 + max 도달 → 거부 → CallerRunsPolicy → 호출 스레드가 직접 실행
+ * </pre>
+ *
+ * <p>{@code AsyncConfig}의 상한 값을 바꾸면 이 테스트는 깨진다. 상한은 외부 SMTP의 동시 연결
+ * 제한에 맞춘 계약이므로, 계약을 바꾸는 변경에는 위 표와 아래 상수도 함께 갱신해야 한다는 신호다.
+ *
+ * <p>Spring 컨텍스트 없이 빈 생성 메서드를 직접 호출한다({@link AsyncConfigTest}와 동일).
+ * DB/Redis/SMTP가 필요 없고 밀리초 단위로 끝난다.
+ */
+@DisplayName("mailExecutor 포화 동작")
+class MailExecutorSaturationTest {
+
+    private static final int MAX_POOL_SIZE = 5;
+    private static final int QUEUE_CAPACITY = 100;
+
+    /** 풀이 거부 없이 받아낼 수 있는 최대 태스크 수 = 실행 중 5건 + 큐 대기 100건. */
+    private static final int SATURATING_TASKS = MAX_POOL_SIZE + QUEUE_CAPACITY;
+
+    private static final int TIMEOUT_SECONDS = 5;
+
+    @Test
+    @Timeout(30) // 래치 설계가 틀어졌을 때 무한 대기 대신 실패시키는 안전장치
+    @DisplayName("풀이 포화되면 스레드는 5개에서 멈추고, 초과분은 호출 스레드가 실행한다")
+    void saturatedPoolCapsAtMaxThenRunsOverflowOnCaller() throws Exception {
+        // given
+        ThreadPoolTaskExecutor pool = (ThreadPoolTaskExecutor) new AsyncConfig().mailExecutor();
+        CountDownLatch gate = new CountDownLatch(1);                 // 워커를 동시에 붙잡아 두는 관문
+        CountDownLatch allWorkersStarted = new CountDownLatch(MAX_POOL_SIZE);
+        Set<String> workerThreads = ConcurrentHashMap.newKeySet();
+
+        try {
+            // when: 거부 직전까지 가득 채운다 (2 core + 100 큐 + 3 증설 = 105건)
+            for (int i = 0; i < SATURATING_TASKS; i++) {
+                pool.execute(() -> {
+                    workerThreads.add(Thread.currentThread().getName());
+                    allWorkersStarted.countDown();
+                    awaitQuietly(gate); // 5개가 동시에 살아있도록 붙잡아 둔다
+                });
+            }
+
+            // then: 정확히 5개 스레드만 동시에 살아있고, 전부 mail- 풀 소속이다
+            assertThat(allWorkersStarted.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue();
+            assertThat(workerThreads)
+                    .hasSize(MAX_POOL_SIZE)
+                    .allMatch(name -> name.startsWith("mail-"));
+            assertThat(pool.getPoolSize()).isEqualTo(MAX_POOL_SIZE);
+
+            // and: 나머지는 스레드를 늘리는 대신 큐에 쌓여 있다 (큐 선적재 동작)
+            assertThat(pool.getThreadPoolExecutor().getQueue()).hasSize(QUEUE_CAPACITY);
+
+            // and: 한 건 더 밀어 넣으면 거부되어 CallerRunsPolicy가 호출 스레드에서 동기 실행한다
+            AtomicReference<String> overflowRunner = new AtomicReference<>();
+            pool.execute(() -> overflowRunner.set(Thread.currentThread().getName()));
+            // ^ 이 태스크는 gate를 기다리면 안 된다. 호출 스레드에서 동기 실행되므로
+            //   테스트 스레드가 자기 자신을 데드락시킨다.
+
+            assertThat(overflowRunner.get())
+                    .isEqualTo(Thread.currentThread().getName())
+                    .doesNotStartWith("mail-");
+        } finally {
+            gate.countDown(); // 단언이 실패해도 워커를 반드시 풀어준다
+            pool.shutdown();  // mail- 스레드 5개 누수 방지
+        }
+    }
+
+    /**
+     * 람다 안에서는 checked exception을 던질 수 없어 감싼다.
+     * 무기한 대기하면 {@code finally}가 실패했을 때 워커가 영영 남으므로 상한을 둔다.
+     */
+    private static void awaitQuietly(CountDownLatch latch) {
+        try {
+            latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/test/java/org/project/ttokttok/global/config/MailExecutorSaturationTest.java
+++ b/src/test/java/org/project/ttokttok/global/config/MailExecutorSaturationTest.java
@@ -32,8 +32,14 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
  *   제출 106     → 큐 만석 + max 도달 → 거부 → CallerRunsPolicy → 호출 스레드가 직접 실행
  * </pre>
  *
- * <p>{@code AsyncConfig}의 상한 값을 바꾸면 이 테스트는 깨진다. 상한은 외부 SMTP의 동시 연결
- * 제한에 맞춘 계약이므로, 계약을 바꾸는 변경에는 위 표와 아래 상수도 함께 갱신해야 한다는 신호다.
+ * <p><b>이 상한이 제한하는 대상.</b> 태스크 1개 = {@code EmailService#sendResultMail} 호출 1회다.
+ * 이 메서드는 {@code List<String>}을 받아 내부에서 순회하므로, 200통을 발송해도 태스크는 1개이고
+ * SMTP 전송은 그 태스크 안에서 순차로 일어난다({@code ApplicantAdminService}는 합격/불합격
+ * 두 번만 호출한다). 따라서 max=5가 제한하는 것은 <b>동시에 진행 중인 벌크 발송 요청 수</b>이지
+ * 메일 통수가 아니다. 메일 통수는 이 풀의 동시성과 무관하다.
+ *
+ * <p>{@code AsyncConfig}의 상한 값을 바꾸면 이 테스트는 깨진다. 계약을 바꾸는 변경에는
+ * 위 표와 아래 상수도 함께 갱신해야 한다는 신호다.
  *
  * <p>Spring 컨텍스트 없이 빈 생성 메서드를 직접 호출한다({@link AsyncConfigTest}와 동일).
  * DB/Redis/SMTP가 필요 없고 밀리초 단위로 끝난다.


### PR DESCRIPTION
## ✨ 작업 내용
- `mailExecutor`의 동시 실행 상한(max=5)과 포화 시 백프레셔(`CallerRunsPolicy`)가 런타임에 실제로 동작하는지 검증하는 `MailExecutorSaturationTest`를 추가했습니다.
- 래치로 105건을 붙잡아 **동시 실행 스레드가 정확히 5개**(`mail-` 접두사)임을 검증합니다.
- 그 시점의 **큐 크기가 100**임을 확인해 "큐를 먼저 채운 뒤 스레드를 늘리는" `ThreadPoolExecutor` 동작을 문서화합니다.
- **106번째 태스크가 호출 스레드에서 동기 실행**됨(= `CallerRunsPolicy` 백프레셔)을 검증합니다.
- 테스트만 추가했고 프로덕션 코드(`src/main/`) 변경은 없습니다.
- Swagger 문서 변경: 없음
- DB 변경 사항: 없음

---

## 🔍 관련 이슈
- 해결한 이슈 번호: #350

---

## ✅ 체크리스트
- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요?
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항

### 왜 하필 105건인가 (리뷰 포인트)
`java.util.concurrent.ThreadPoolExecutor`는 **큐가 가득 찬 뒤에야** core를 넘어 스레드를 늘립니다. 그래서 "20건 던지고 스레드 ≤ 5" 같은 순진한 테스트는 **항상 2개(core)만 관찰**하며, max를 50으로 바꿔도 통과하는 위양성이 됩니다.

```
제출 1~2     → core 스레드 2개 생성
제출 3~102   → 전부 큐 적재 (스레드 증설 없음)
제출 103~105 → 큐 포화 → 스레드 3, 4, 5 생성 (max 도달)
제출 106     → 큐 만석 + max 도달 → 거부 → CallerRunsPolicy → 호출 스레드가 직접 실행
```

이 표는 테스트 클래스 주석에도 그대로 남겨두었습니다.

### 이 테스트가 실제로 무언가를 잡는지 실측했습니다
통과 확인만으로는 위양성을 못 거릅니다. `AsyncConfig`를 양방향으로 변조해 확인했고, **두 단언이 서로 다른 방향을 담당**합니다.

| 변조 | 실패 지점 | 실측 증거 |
|---|---|---|
| `max=50` | `CallerRunsPolicy` 단언 | 106번째가 `mail-6`에서 실행 — 5가 천장이 아님 |
| `max=3` | `hasSize(5)` 단언 | `["mail-1", "mail-2", "mail-3", "Test worker"]` |

`hasSize(5)`는 상한을 **낮추는** 변경을, `CallerRunsPolicy` 단언은 상한을 **올리는** 변경을 잡습니다. 105건만 제출해서는 max=50이어도 스레드가 5개까지만 생기므로 후자 없이는 상향을 놓칩니다. 그래서 두 단언을 한 테스트에 함께 두었습니다.

### 데드락 회피
106번째 태스크는 호출 스레드에서 **동기 실행**되므로, 이 태스크가 게이트 래치를 기다리면 테스트가 자기 자신을 데드락시킵니다. 해당 태스크만 대기 없이 스레드 이름만 기록하도록 했고 코드에 주석을 남겼습니다. 추가로 `finally`의 `gate.countDown()` + `pool.shutdown()`, 그리고 `@Timeout(30)`으로 3중 방어합니다.

### 알아두실 점
`AsyncConfig`의 `queueCapacity`나 `maxPoolSize`를 바꾸면 이 테스트는 깨집니다. 계약을 바꿀 때 테스트도 함께 갱신하라는 의도된 신호입니다. 갱신 방법은 클래스 주석의 표에 있습니다.

### 이 상한이 제한하는 대상 (리뷰 중 정정된 부분)

처음 이 PR을 올릴 때 "max=5가 SMTP 동시 연결 수를 제한한다"고 적었는데 **틀린 설명이라 정정했습니다**(커밋 `dad5534`).

`@Async`는 **메서드 호출 1회 = 태스크 1개**입니다. `sendResultMail`은 `List<String>`을 통째로 받아 내부에서 순회하고, `ApplicantAdminService`는 합격/불합격 두 번만 호출합니다. 따라서:

| | |
|---|---|
| 지원자 200명에게 결과 발송 | 태스크 **2개** |
| 그 200통의 SMTP 전송 | 스레드 **1개**에서 **순차** |

즉 `max=5`가 제한하는 것은 **동시에 진행 중인 벌크 발송 요청 수**이지 메일 통수가 아닙니다. 메일 통수는 이 풀의 동시성과 무관합니다.

이 테스트의 검증 내용 자체는 영향받지 않습니다(풀에 태스크를 직접 제출해 상한 계약만 확인하므로). 정정한 것은 **왜 그 상한이 중요한가에 대한 설명**입니다.

참고로 `AsyncConfig.java`의 클래스 주석에도 같은 오해("SMTP가 감당 가능한 동시 연결 수를 기준으로")가 남아 있습니다. 프로덕션 파일이라 이 PR 범위 밖으로 두고 별도 이슈로 다룰 예정입니다.

### 검증
- `bash maintenance/verify.sh` 그린 (BUILD SUCCESSFUL in 3m 29s, 테스트 포함)
- `git rebase origin/develop --exec './gradlew.bat compileJava compileTestJava'` → `BUILD SUCCESSFUL`

