### PR TITLE
관측성 기반 구축 및 스케줄러 중복 실행 방지 (arch/#352 -> develop)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@ out/
 /src/main/resources/application-prod.yml
 /src/main/resources/application-test.yml
 
+# 예외: observability 프로파일은 시크릿이 없는 순수 노출 설정이다.
+# 어떤 엔드포인트를 어느 포트로 여는지는 보안에 직결되므로 코드 리뷰 대상이어야 한다.
+!/src/main/resources/application-observability.yml
+
 # DB Seed 파일들 (테스트용 데이터)
 /src/main/resources/db/seed/
 /src/test/resources/db/seed/

--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,12 @@ dependencies {
     // Firebase
     implementation 'com.google.firebase:firebase-admin:9.4.1'
 
+	// Actuator + Prometheus 메트릭 노출
+	// load-test/prometheus.yml 이 /actuator/prometheus 를 스크레이프하도록 이미 설정돼 있으나
+	// 그동안 이 의존성이 없어 엔드포인트 자체가 존재하지 않았다(404).
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
+	// ShedLock — 다중 인스턴스(블루-그린) 환경에서 @Scheduled 중복 실행 방지.
+	// 락 저장소로 이미 사용 중인 Redis 를 그대로 쓴다(신규 인프라 불필요).
+	implementation 'net.javacrumbs.shedlock:shedlock-spring:5.16.0'
+	implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:5.16.0'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/maintenance/hooks/lib.sh
+++ b/maintenance/hooks/lib.sh
@@ -36,6 +36,14 @@ is_secret_path() {
   local base
   base="$(basename "$path")"
 
+  # Allowlist: the observability profile holds no secrets — only which actuator
+  # endpoints are exposed on which port. That is security-relevant config that
+  # belongs in code review, so it is committed on purpose. Pairs with the
+  # matching negation rule in .gitignore.
+  case "$path" in
+    src/main/resources/application-observability.yml) return 1 ;;
+  esac
+
   case "$path" in
     src/main/resources/application*.yml|src/test/resources/application*.yml) return 0 ;;
     */db/seed/*|src/main/resources/db/seed/*|src/test/resources/db/seed/*)   return 0 ;;

--- a/src/main/java/org/project/ttokttok/domain/applyform/scheduler/ApplyFormScheduler.java
+++ b/src/main/java/org/project/ttokttok/domain/applyform/scheduler/ApplyFormScheduler.java
@@ -2,6 +2,7 @@ package org.project.ttokttok.domain.applyform.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.project.ttokttok.domain.applyform.domain.ApplyForm;
 import org.project.ttokttok.domain.applyform.repository.ApplyFormRepository;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -18,7 +19,14 @@ public class ApplyFormScheduler {
 
     private final ApplyFormRepository applyFormRepository;
 
+    // 블루-그린 전환 창에서 blue/green 이 동시에 떠 있어도 한 인스턴스만 실행하도록 락을 건다.
+    // lockAtLeastFor: 인스턴스 간 시계 오차로 락이 조기 해제돼 중복 실행되는 것을 막는다.
     @Scheduled(cron = "0 0 4 * * *")
+    @SchedulerLock(
+            name = "ApplyFormScheduler_updateExpiredApplyFormsStatus",
+            lockAtMostFor = "PT10M",
+            lockAtLeastFor = "PT1M"
+    )
     @Transactional
     public void updateExpiredApplyFormsStatus() {
         log.info("지원 폼 마감날짜 확인 스케줄러 시작");

--- a/src/main/java/org/project/ttokttok/global/config/ShedLockConfig.java
+++ b/src/main/java/org/project/ttokttok/global/config/ShedLockConfig.java
@@ -1,0 +1,31 @@
+package org.project.ttokttok.global.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+/**
+ * 분산 스케줄러 락 설정.
+ *
+ * <p>블루-그린 무중단 배포에서는 전환 창 동안 blue/green 두 인스턴스가 동시에 떠 있다.
+ * {@code @Scheduled} 는 인스턴스마다 독립적으로 동작하므로, 이 락이 없으면 매일 새벽 4시에
+ * FCM 토큰 정리와 지원 폼 마감 처리가 <b>두 번</b> 실행된다.
+ *
+ * <p>락 저장소로는 이미 리프레시 토큰에 쓰고 있는 Redis 를 그대로 재사용한다
+ * ({@link org.project.ttokttok.infrastructure.redis.RedisConfig} 의 커넥션 팩토리).
+ */
+@Configuration
+@EnableSchedulerLock(defaultLockAtMostFor = "PT10M")
+public class ShedLockConfig {
+
+    /** 락 키 접두사. dev/prod 가 같은 Redis 를 바라보더라도 락이 섞이지 않게 한다. */
+    private static final String LOCK_ENVIRONMENT = "ttokttok";
+
+    @Bean
+    public LockProvider lockProvider(RedisConnectionFactory redisConnectionFactory) {
+        return new RedisLockProvider(redisConnectionFactory, LOCK_ENVIRONMENT);
+    }
+}

--- a/src/main/java/org/project/ttokttok/infrastructure/firebase/scheduler/FCMScheduler.java
+++ b/src/main/java/org/project/ttokttok/infrastructure/firebase/scheduler/FCMScheduler.java
@@ -4,6 +4,7 @@ import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.project.ttokttok.domain.notification.fcm.repository.FCMTokenRepository;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -16,7 +17,14 @@ public class FCMScheduler {
     private final FCMTokenRepository fcmTokenRepository;
 
     // 매일 새벽 4시에 실행 (초 분 시 일 월 요일)
+    // 블루-그린 전환 창에서 blue/green 이 동시에 떠 있어도 한 인스턴스만 실행하도록 락을 건다.
+    // lockAtLeastFor: 인스턴스 간 시계 오차로 락이 조기 해제돼 중복 실행되는 것을 막는다.
     @Scheduled(cron = "0 0 4 * * *")
+    @SchedulerLock(
+            name = "FCMScheduler_cleanupStaleTokens",
+            lockAtMostFor = "PT10M",
+            lockAtLeastFor = "PT1M"
+    )
     @Transactional
     public void cleanupStaleTokens() {
         // 1. 기준 시간 설정 (오늘로부터 2달 전)

--- a/src/main/resources/application-observability.yml
+++ b/src/main/resources/application-observability.yml
@@ -1,0 +1,47 @@
+# Observability 프로파일 — 운영 관측성 및 무중단 배포용 설정
+#
+# 이 파일은 다른 application-*.yml 과 달리 **커밋된다** (.gitignore 의 negation 규칙).
+# 시크릿이 전혀 없고, "어떤 엔드포인트를 어느 포트로 여는지"는 보안에 직결되므로
+# PC 디스크에서 손으로 고치는 대신 코드 리뷰를 거쳐야 하기 때문이다.
+#
+# 활성화: SPRING_PROFILES_ACTIVE=prod,observability
+# (compose 를 도입하는 후속 이슈에서 연결한다. 현재 EB 파이프라인은 prod 단독으로 뜨므로
+#  이 파일은 아직 로드되지 않는다 — 설정값 자체는 ObservabilityProfileConfigTest 로 검증한다.)
+
+management:
+  server:
+    # 서비스 포트(8080)와 분리한다. 이 포트는 호스트에 publish 하지 않고
+    # 컴포즈 내부 네트워크에서 Prometheus 만 접근한다 — 인증 대신 네트워크로 격리한다.
+    port: 9080
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus,info
+  endpoint:
+    health:
+      # 운영에서 DB 호스트명/드라이버/디스크 경로가 새지 않도록 한다.
+      # (application-loadtest.yml 은 always 지만 그건 로컬 부하테스트 전용이다.)
+      show-details: never
+      probes:
+        enabled: true
+  health:
+    group:
+      readiness:
+        # ★ Spring 의 기본 readiness 그룹은 readinessState 만 본다 — DB 를 검사하지 않는다.
+        #   블루-그린 전환 게이트로 쓰려면 db/redis 를 명시적으로 넣어야 한다.
+        #   이게 빠지면 DB 가 끊긴 green 컨테이너도 UP 을 반환해 트래픽을 넘겨받는다.
+        include: readinessState,db,redis
+  metrics:
+    tags:
+      application: ttokttok
+      # 블루-그린 전환 시 Grafana 에서 두 색상을 나란히 비교하기 위한 라벨
+      color: ${DEPLOY_COLOR:unknown}
+
+server:
+  # 구컨테이너 종료 시 인플라이트 요청과 @Async 작업(FCMService, EmailService)이
+  # 잘려나가지 않도록 드레인 시간을 준다. 배포 스크립트의 드레인 대기는 이 값보다 길어야 한다.
+  shutdown: graceful
+
+spring:
+  lifecycle:
+    timeout-per-shutdown-phase: 30s

--- a/src/test/java/org/project/ttokttok/global/config/ObservabilityProfileConfigTest.java
+++ b/src/test/java/org/project/ttokttok/global/config/ObservabilityProfileConfigTest.java
@@ -1,0 +1,102 @@
+package org.project.ttokttok.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.ClassPathResource;
+
+/**
+ * {@code application-observability.yml} 의 값이 의도대로 정의돼 있는지 검증한다.
+ *
+ * <p>이 프로파일은 아직 어떤 실행 경로에서도 활성화되지 않는다(compose 도입 이슈에서 연결).
+ * 그래서 "설정이 존재하고 값이 맞다"는 것을 여기서 못 박아두지 않으면, 나중에 활성화하는 시점에
+ * 조용히 틀린 채로 켜질 수 있다. 특히 readiness 그룹은 기본값이 DB 를 보지 않기 때문에
+ * 빠뜨려도 아무 에러 없이 "항상 UP" 이 되어버린다 — 그 회귀를 막는 것이 이 테스트의 목적이다.
+ */
+@DisplayName("application-observability.yml")
+class ObservabilityProfileConfigTest {
+
+    private static PropertySource<?> properties;
+
+    @BeforeAll
+    static void loadYaml() throws IOException {
+        YamlPropertySourceLoader loader = new YamlPropertySourceLoader();
+        List<PropertySource<?>> sources =
+                loader.load("observability", new ClassPathResource("application-observability.yml"));
+
+        assertThat(sources)
+                .as("application-observability.yml 이 클래스패스에 존재해야 한다")
+                .hasSize(1);
+        properties = sources.get(0);
+    }
+
+    @Test
+    @DisplayName("management 포트를 서비스 포트(8080)와 분리한다")
+    void managementPortIsSeparatedFromServicePort() {
+        // then: 별도 포트여야 호스트에 publish 하지 않고 내부 네트워크로만 격리할 수 있다
+        assertThat(properties.getProperty("management.server.port")).isEqualTo(9080);
+    }
+
+    @Test
+    @DisplayName("노출 엔드포인트를 health/prometheus/info 로 제한한다")
+    void exposesOnlyTheThreeNeededEndpoints() {
+        // then
+        assertThat(properties.getProperty("management.endpoints.web.exposure.include"))
+                .isEqualTo("health,prometheus,info");
+    }
+
+    @Test
+    @DisplayName("health 상세 정보를 노출하지 않는다")
+    void healthDetailsAreNeverExposed() {
+        // then: show-details 가 always 면 DB 호스트명/드라이버/디스크 경로가 그대로 샌다
+        assertThat(properties.getProperty("management.endpoint.health.show-details"))
+                .isEqualTo("never");
+    }
+
+    @Test
+    @DisplayName("liveness/readiness 프로브를 활성화한다")
+    void probesAreEnabled() {
+        // then
+        assertThat(properties.getProperty("management.endpoint.health.probes.enabled"))
+                .isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("readiness 그룹이 db 와 redis 를 명시적으로 포함한다")
+    void readinessGroupIncludesDbAndRedis() {
+        // given: Spring 의 기본 readiness 그룹은 readinessState 만 본다 — DB 를 검사하지 않는다.
+        //        블루-그린 전환 게이트로 쓰려면 반드시 db/redis 를 직접 넣어야 한다.
+        Object include = properties.getProperty("management.health.group.readiness.include");
+
+        // then
+        assertThat(include).asString()
+                .contains("readinessState")
+                .contains("db")
+                .contains("redis");
+    }
+
+    @Test
+    @DisplayName("메트릭에 블루-그린 색상 라벨을 붙인다")
+    void metricsCarryDeployColorTag() {
+        // then: Grafana 에서 전환 중 두 색상을 나란히 비교하기 위한 라벨
+        assertThat(properties.getProperty("management.metrics.tags.application"))
+                .isEqualTo("ttokttok");
+        assertThat(properties.getProperty("management.metrics.tags.color")).asString()
+                .contains("DEPLOY_COLOR");
+    }
+
+    @Test
+    @DisplayName("graceful shutdown 을 켜고 드레인 시간을 준다")
+    void gracefulShutdownIsEnabled() {
+        // then: 구컨테이너 종료 시 인플라이트 요청과 @Async 작업이 잘려나가지 않도록
+        assertThat(properties.getProperty("server.shutdown")).isEqualTo("graceful");
+        assertThat(properties.getProperty("spring.lifecycle.timeout-per-shutdown-phase"))
+                .isEqualTo("30s");
+    }
+}

--- a/src/test/java/org/project/ttokttok/global/config/ObservabilityProfileConfigTest.java
+++ b/src/test/java/org/project/ttokttok/global/config/ObservabilityProfileConfigTest.java
@@ -37,13 +37,6 @@ class ObservabilityProfileConfigTest {
     }
 
     @Test
-    @DisplayName("management 포트를 서비스 포트(8080)와 분리한다")
-    void managementPortIsSeparatedFromServicePort() {
-        // then: 별도 포트여야 호스트에 publish 하지 않고 내부 네트워크로만 격리할 수 있다
-        assertThat(properties.getProperty("management.server.port")).isEqualTo(9080);
-    }
-
-    @Test
     @DisplayName("노출 엔드포인트를 health/prometheus/info 로 제한한다")
     void exposesOnlyTheThreeNeededEndpoints() {
         // then

--- a/src/test/java/org/project/ttokttok/global/config/SchedulerLockCoverageTest.java
+++ b/src/test/java/org/project/ttokttok/global/config/SchedulerLockCoverageTest.java
@@ -1,0 +1,116 @@
+package org.project.ttokttok.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 모든 {@code @Scheduled} 메서드가 {@code @SchedulerLock} 으로 보호되는지 검증한다.
+ *
+ * <p>블루-그린 무중단 배포에서는 전환 창 동안 blue/green 두 인스턴스가 동시에 떠 있고,
+ * {@code @Scheduled} 는 인스턴스마다 독립적으로 발화한다. 락이 없는 스케줄러가 하나라도 있으면
+ * FCM 푸시 중복 발송 같은 사용자에게 직접 보이는 버그가 된다.
+ *
+ * <p>개별 스케줄러를 하나씩 검사하는 대신 클래스패스를 스캔하는 이유는, 앞으로 <b>새로 추가되는</b>
+ * 스케줄러가 락 없이 들어오는 것까지 막기 위해서다. 이 테스트가 이 규칙의 유일한 강제 수단이다.
+ */
+@DisplayName("스케줄러 분산 락 적용 범위")
+class SchedulerLockCoverageTest {
+
+    private static final String BASE_PACKAGE = "org.project.ttokttok";
+
+    @Test
+    @DisplayName("@Scheduled 메서드는 예외 없이 @SchedulerLock 을 가진다")
+    void everyScheduledMethodIsLocked() {
+        // given
+        List<Method> scheduledMethods = findScheduledMethods();
+
+        // then: 스캔 자체가 헛돌면(0건) 테스트가 의미 없이 통과하므로 최소 개수를 못 박는다
+        assertThat(scheduledMethods)
+                .as("@Scheduled 메서드를 하나도 찾지 못했다면 스캔 설정이 잘못된 것이다")
+                .isNotEmpty();
+
+        List<String> unlocked = scheduledMethods.stream()
+                .filter(method -> method.getAnnotation(SchedulerLock.class) == null)
+                .map(method -> method.getDeclaringClass().getSimpleName() + "#" + method.getName())
+                .toList();
+
+        assertThat(unlocked)
+                .as("락이 없는 스케줄러는 블루-그린 전환 창에서 중복 실행된다")
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("락 이름은 스케줄러마다 고유하다")
+    void lockNamesAreUnique() {
+        // given
+        List<String> lockNames = findScheduledMethods().stream()
+                .map(method -> method.getAnnotation(SchedulerLock.class))
+                .filter(lock -> lock != null)
+                .map(SchedulerLock::name)
+                .toList();
+
+        // then: 이름이 겹치면 서로 무관한 스케줄러가 서로를 막아 하나가 조용히 실행되지 않는다
+        assertThat(lockNames).doesNotHaveDuplicates();
+        assertThat(lockNames).allSatisfy(name -> assertThat(name).isNotBlank());
+    }
+
+    @Test
+    @DisplayName("lockAtMostFor 가 lockAtLeastFor 보다 길다")
+    void lockDurationsAreCoherent() {
+        // given
+        List<SchedulerLock> locks = findScheduledMethods().stream()
+                .map(method -> method.getAnnotation(SchedulerLock.class))
+                .filter(lock -> lock != null)
+                .toList();
+
+        // then: lockAtMostFor 는 프로세스가 죽어도 락이 영구히 남지 않게 하는 상한이므로
+        //       하한(lockAtLeastFor)보다 반드시 길어야 한다
+        assertThat(locks).allSatisfy(lock -> {
+            Duration atMost = Duration.parse(lock.lockAtMostFor());
+            Duration atLeast = Duration.parse(lock.lockAtLeastFor());
+            assertThat(atMost)
+                    .as("%s: lockAtMostFor 는 lockAtLeastFor 보다 길어야 한다", lock.name())
+                    .isGreaterThan(atLeast);
+        });
+    }
+
+    private List<Method> findScheduledMethods() {
+        ClassPathScanningCandidateComponentProvider scanner =
+                new ClassPathScanningCandidateComponentProvider(false);
+        scanner.addIncludeFilter(new AnnotationTypeFilter(Component.class));
+
+        Set<BeanDefinition> candidates = scanner.findCandidateComponents(BASE_PACKAGE);
+
+        List<Method> scheduledMethods = new ArrayList<>();
+        for (BeanDefinition candidate : candidates) {
+            Class<?> type = resolve(candidate.getBeanClassName());
+            for (Method method : type.getDeclaredMethods()) {
+                if (method.getAnnotation(Scheduled.class) != null) {
+                    scheduledMethods.add(method);
+                }
+            }
+        }
+        return scheduledMethods;
+    }
+
+    private Class<?> resolve(String className) {
+        try {
+            return Class.forName(className);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("스캔된 클래스를 로드할 수 없다: " + className, e);
+        }
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용

배포 아키텍처를 **AWS Elastic Beanstalk → 개인 우분투 PC + 블루-그린 무중단 배포**로 재설계하는 작업의 **1단계(애플리케이션 선행 작업)**입니다.

무중단 배포는 "배포 성공 여부를 지표로 판정할 수 있을 때" 안전합니다. 관측 수단이 없으면 블루-그린은 장애를 더 매끄럽게 자동화할 뿐이므로, **관측성 확보를 선행 조건**으로 두고 "앱을 2개 인스턴스로 동시에 띄워도 안전한 상태"까지만 이번 PR에 담았습니다.

### 1. Actuator/Prometheus 메트릭 노출 (`164aa15`)
- `spring-boot-starter-actuator`, `micrometer-registry-prometheus` 의존성 추가
- `load-test/prometheus.yml:7`이 `/actuator/prometheus`를 스크레이프하도록 이미 설정돼 있었으나 **의존성이 없어 엔드포인트 자체가 존재하지 않았습니다(404).** Grafana 앱 메트릭 패널이 비어 있던 원인입니다.
- `application-observability.yml` 신규 — management 포트 9080 분리, `show-details: never`, graceful shutdown

### 2. 스케줄러 중복 실행 방지 (`40c9d93`)
- `FCMScheduler`와 `ApplyFormScheduler`가 **둘 다 매일 새벽 4시**(`0 0 4 * * *`)에 실행됩니다. blue/green이 동시에 떠 있는 전환 창에서 4시가 지나면 **FCM 푸시가 중복 발송**되고 지원 폼 마감 처리가 두 번 돕니다.
- ShedLock 도입 — 락 저장소로 이미 쓰고 있는 Redis를 재사용해 신규 인프라 없이 해결

### 3. 시크릿 차단 정책 예외 (`2925b8d`)
- `application-observability.yml`은 시크릿이 0건이고, "어떤 엔드포인트를 어느 포트로 여는지"는 보안에 직결되므로 **코드 리뷰 대상이어야 합니다.** 그래서 예외적으로 커밋합니다.
- `.gitignore`와 `maintenance/hooks/lib.sh`(`is_secret_path`) **양쪽**에 명시적 허용 규칙을 추가했습니다. 같은 정책이 두 군데 인코딩돼 있어 한쪽만 고치면 커밋이 훅에 막힙니다. **훅 우회는 하지 않았습니다.**

### DB 변경 사항
**없습니다.** Flyway 스크립트 불필요.

### Swagger
변경 없음. 기존 `/health`(`HealthCheckController`)는 외부 소비자 호환을 위해 그대로 유지했습니다.

---

## 🔍 관련 이슈
- 해결한 이슈 번호: #352

---

## ✅ 체크리스트
- [ ] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요?
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항

### ⚠️ 이 PR은 운영 배포에 영향을 주지 않습니다
`.github/workflows/ci-cd.yml`은 **건드리지 않았습니다.** `application-observability.yml`도 현재 어떤 실행 경로에서도 로드되지 않습니다(활성화는 `SPRING_PROFILES_ACTIVE=prod,observability`이며 compose 도입 이슈의 몫). 지금 EB 파이프라인은 `prod` 단독으로 뜹니다.

그래서 설정값 자체는 `ObservabilityProfileConfigTest`가 YAML을 직접 로드해 검증합니다 — 나중에 켜는 시점에 **조용히 틀린 채로 켜지는 것**을 막기 위해서입니다.

### 리뷰 시 봐주셨으면 하는 부분

**readiness 그룹에 `db,redis`를 명시한 이유**
Spring의 **기본 readiness 그룹은 `readinessState`만 봅니다 — DB를 검사하지 않습니다.** `probes.enabled: true`만 켜면 "항상 UP"인 엔드포인트가 생기고, 이는 현재 `/health`가 조건 없이 `Healthy`를 반환하는 문제를 이름만 바꿔 재현합니다. 빠뜨려도 **에러 없이 조용히** 잘못 동작하는 종류의 설정이라 테스트로 못 박았습니다.

**스케줄러 락 커버리지를 클래스패스 스캔으로 강제**
개별 스케줄러 2개를 하나씩 검사하는 대신 `org.project.ttokttok`을 스캔해 **모든** `@Scheduled` 메서드가 `@SchedulerLock`을 갖는지 검증합니다. 앞으로 새로 추가되는 스케줄러가 락 없이 들어오는 것까지 막기 위해서이며, 이 테스트가 해당 규칙의 유일한 강제 수단입니다. 스캔이 헛돌아 0건으로 통과하는 위양성을 막으려 `isNotEmpty()` 단언도 함께 뒀습니다.

락 이름 중복 검사도 넣었습니다. ShedLock은 이름이 겹치면 무관한 스케줄러끼리 서로를 막아 **하나가 조용히 실행되지 않는** 형태로 고장납니다.

### 이번 범위에서 제외한 것 (후속 이슈)

제외 사유는 취향이 아니라 실제 제약입니다.

- **`ci-cd.yml` 재작성**: 등록되지 않은 self-hosted runner를 가리키게 되어, 지금 머지하면 **운영 배포가 즉시 중단**됩니다. 물리 장비 준비가 선행되어야 합니다.
- **`Dockerfile`(현재 `ubuntu:latest` + `top` 스텁), `.dockerignore`, `docker-compose.prod.yml`, nginx 설정**: PC·GHCR 결정에 종속되고 현재 환경에서 검증 불가합니다.
- **블루-그린 전환 스크립트, Flyway 배포 전 분리, 운영 모니터링 스택 배치, Cloudflare Tunnel**: 위에 종속됩니다.

### 조사 중 확인된 미해결 항목

1. **Flyway baseline 부재 → DB 롤백 불가.** `db/migration`에 `clubs`/`users`의 `CREATE TABLE`이 없고 V0부터 `ALTER TABLE`로 시작합니다(`load-test/docker-compose.yml:45-49` 주석에 이미 기록돼 있습니다). prod는 `baseline-on-migrate: true`로 우회 중이며, **스키마를 마이그레이션만으로 재현할 수 없습니다.** 무중단 배포에서 green 실패 시 앱은 되돌려도 스키마는 되돌릴 수 없습니다. DB 이전이나 스키마 대격변 전에 `V1__baseline.sql` 복구가 반드시 선행되어야 합니다.
2. **`ci-cd.yml`이 `-x test`로 테스트를 건너뜁니다.** JaCoCo 80% 하드 게이트 때문으로 보이며 `verify.sh`가 로컬에서 공백을 메우고 있습니다. 무중단 배포는 이 문제를 고쳐주지 않으므로 별도 이슈 분리를 제안합니다.
3. **`FCMScheduler`가 `jakarta.transaction.Transactional`을 사용합니다.** `ApplyFormScheduler`는 Spring 것을 씁니다. 이번 범위 밖이라 손대지 않았으나 일관성 정리 대상입니다.

### 검증

- `bash maintenance/verify.sh` 그린 (BUILD SUCCESSFUL in 4m 39s, 테스트 + JaCoCo 80% 게이트 포함) — **1회차 통과**
- 커밋별 게이트 `git rebase origin/develop --exec './gradlew.bat compileJava compileTestJava'` → 3커밋 모두 `BUILD SUCCESSFUL`
- rebase 후 최종 트리 불변 확인 (`git diff <pre-rebase> HEAD --stat` 비어 있음)
