### PR TITLE
자체 우분투 서버 이관을 위한 docker-compose 스택 및 앱 컨테이너화 (chore/#354 -> develop)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,49 @@
+# 빌드 컨텍스트에서 제외할 것들.
+#
+# 두 가지 목적이 있다.
+#  1) 컨텍스트 전송량을 줄여 빌드를 빠르게 한다.
+#  2) 시크릿이 이미지 레이어에 굽히는 것을 막는다. 이미지에 한 번 들어간 파일은
+#     이후 레이어에서 지워도 히스토리에 남으므로, 애초에 컨텍스트에 넣지 않는다.
+
+### 빌드 산출물 / 로컬 환경 ###
+.git
+.gitignore
+.gradle
+build
+bin
+out
+.idea
+.vscode
+
+### 에이전트 / 하네스 ###
+.claude
+.omc
+.agents
+.gemini
+maintenance
+rules
+load-test
+*.md
+
+### 시크릿 — 이미지에 굽지 않고 런타임에 /app/config 로 마운트한다 ###
+src/main/resources/application.yml
+src/main/resources/application-*.yml
+src/test/resources/application.yml
+src/test/resources/application-*.yml
+src/main/resources/ttokttok-push*.json
+
+### 로컬 전용 픽스처 (운영 이미지에 불필요) ###
+src/main/resources/db/seed
+src/test/resources/db/seed
+**/*.csv
+
+### 인프라 정의 자체는 이미지 안에서 쓰이지 않는다 ###
+Dockerfile
+.dockerignore
+docker-compose*.yml
+docker
+.env
+.env.*
+!.env.example
+data
+config

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,36 @@
+# docker-compose.yml 이 읽는 환경변수 템플릿.
+#
+#   cp .env.example .env   후 값을 채운다. .env 는 gitignore 대상이다.
+#
+# 여기 있는 값은 전부 플레이스홀더다. 실제 시크릿을 이 파일에 적지 말 것.
+# AWS 에서 이관하면서 DB/Redis/스토리지가 모두 새로 생성되므로, 기존 운영
+# 자격증명을 재사용하지 말고 이 기회에 전부 새로 발급하는 것을 권장한다.
+
+### PostgreSQL ###
+# 백업 SQL 을 복원할 대상이다. 덤프의 소유자/DB명과 맞추면 복원이 단순해진다.
+POSTGRES_DB=ttokttok
+POSTGRES_USER=ttokttok
+POSTGRES_PASSWORD=change-me
+
+### Redis ###
+REDIS_PASSWORD=change-me
+
+### MinIO (S3 호환 오브젝트 스토리지) ###
+# 앱이 S3 자격증명으로 사용하는 값과 동일하다.
+MINIO_ROOT_USER=change-me
+MINIO_ROOT_PASSWORD=change-me-at-least-8-chars
+
+# 기존 S3 버킷명을 그대로 쓴다. 저장된 파일 URL 이 "<도메인>/<키>" 형태라 URL 자체에
+# 버킷명은 없지만, nginx 가 path-style 요청으로 바꿀 때 이 이름을 경로에 끼워 넣는다.
+# 값을 바꾸면 docker/nginx/conf.d/ttokttok.conf 의 proxy_pass 도 같이 바꿔야 한다.
+MINIO_BUCKET=ttokttokbucket
+
+### 파일 공개 도메인 ###
+# 이관 전 CloudFront 도메인을 그대로 유지한다. 이 값이 바뀌면 DB 에 절대 URL 로
+# 저장된 기존 파일 링크가 전부 깨지고, 마크다운 본문과 JSON 내부까지 치환해야 한다.
+FILE_CLOUD_URL=https://www.ddockddock-file.co.kr
+
+### Firebase ###
+# config/ 디렉터리에 놓아둔 서비스 계정 키의 파일명.
+# 앱 컨테이너에는 /app/config/<이 이름> 으로 마운트된다.
+FIREBASE_JSON_NAME=ttokttok-push-firebase-adminsdk-example.json

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,16 @@ IMPLEMENTATION.md
 
 # Firebase 서비스 계정 키 파일
 ttokttok-push*.json
+
+### Docker 운영 스택 (docker-compose.yml) ###
+# 실제 시크릿이 담기는 환경변수 파일. 템플릿인 .env.example 만 커밋한다.
+.env
+.env.*
+!.env.example
+
+# 컨테이너가 쓰는 운영 설정 디렉터리 — application-prod.yml 과 Firebase 키가 들어간다.
+# 둘 다 위에서 이미 제외 대상이지만, 이 경로로도 새지 않도록 디렉터리째 막는다.
+/config/
+
+# 컨테이너 데이터 볼륨 (PostgreSQL, Redis, MinIO). 백업 대상이지 커밋 대상이 아니다.
+/data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,37 @@
-# 나중에 수정
-FROM ubuntu:latest
-LABEL authors="tnals"
+# 빌드 스테이지 — 의존성 해석을 소스 복사보다 먼저 두어, 소스만 바뀐 재빌드에서
+# 의존성 레이어가 캐시에 남도록 한다.
+FROM eclipse-temurin:17-jdk-alpine AS builder
+WORKDIR /build
 
-ENTRYPOINT ["top", "-b"]
+COPY gradlew ./
+COPY gradle gradle
+COPY build.gradle settings.gradle ./
+RUN chmod +x ./gradlew && ./gradlew dependencies --no-daemon
+
+COPY src src
+RUN ./gradlew bootJar -x test --no-daemon
+
+# 실행 스테이지
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR /app
+
+RUN addgroup -S ttokttok && adduser -S -G ttokttok ttokttok
+
+# bootJar 는 실행 가능한 부트 jar 하나만 만든다(`build` 와 달리 *-plain.jar 를 만들지 않는다).
+COPY --from=builder /build/build/libs/*-SNAPSHOT.jar app.jar
+
+# 운영 설정(application-prod.yml)과 Firebase 서비스 계정 키는 이미지에 굽지 않는다.
+# 런타임에 이 디렉터리로 마운트하며, Spring Boot 가 ./config/ 를 기본 설정 탐색 경로에
+# 포함하므로 application-prod.yml 은 별도 옵션 없이 읽힌다.
+# Firebase 키는 classpath 가 아니므로 firebase.credentials-location 에 file: 경로를 준다.
+RUN mkdir -p /app/config && chown -R ttokttok:ttokttok /app
+
+USER ttokttok
+EXPOSE 8080
+
+# 힙을 고정값(-Xmx)이 아니라 비율로 잡아, compose 의 메모리 제한만 조정해도 힙이 따라오게 한다.
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=75.0 -XX:+UseG1GC"
+
+# exec 로 넘겨 java 가 PID 1 이 되게 한다. SIGTERM 이 셸에 먹히지 않고 그대로 전달되어야
+# Spring 의 graceful shutdown 이 동작한다.
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar /app/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,218 @@
+# ttokttok 운영 스택 — 개인 우분투 서버 단일 호스트 구성.
+#
+# 사용법:
+#   1) .env.example 을 .env 로 복사하고 값을 채운다 (.env 는 커밋되지 않는다).
+#   2) config/application-prod.yml 과 Firebase 키를 서버에 배치한다 (둘 다 gitignore 대상).
+#   3) docker compose up -d --build
+#
+# ── 포트 정책 ────────────────────────────────────────────────────────────────
+# 외부에 노출하는 것은 nginx 의 80/443 뿐이고, 나머지는 전부 127.0.0.1 에만 바인딩한다.
+# "15432:5432" 처럼 주소를 생략하면 0.0.0.0 에 열려 외부에서 스캔되며, UFW 는 Docker 가
+# 삽입한 iptables 규칙보다 뒤에 평가되기 때문에 이 포트를 막아주지 못한다.
+# 그래서 포트 번호를 바꾸는 것이 아니라 바인드 주소를 제한하는 것이 실제 방어선이다.
+#
+# 관리 접속은 SSH 터널을 쓴다:
+#   ssh -L 15432:127.0.0.1:15432 <user>@<host>   # 이후 로컬 15432 로 psql 접속
+#
+# 컨테이너끼리는 아래 ttokttok 네트워크 안에서 "서비스명 + 기본 포트"로 통신하므로
+# (예: postgres:5432), 호스트 포트를 바꿔도 앱 설정에는 영향이 없다.
+
+name: ttokttok
+
+services:
+  # ── 리버스 프록시 — 유일한 공개 지점 ──────────────────────────────────────
+  nginx:
+    image: nginx:1.27-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./docker/nginx/conf.d:/etc/nginx/conf.d:ro
+    depends_on:
+      app:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    networks: [ttokttok]
+
+  # ── 애플리케이션 ──────────────────────────────────────────────────────────
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:18080:8080"
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+
+      # 아래 값들은 마운트된 application-prod.yml 보다 우선순위가 높다.
+      # (Spring 의 설정 우선순위: 환경변수 > 설정 파일)
+      # 덕분에 인프라 주소/자격증명만 여기서 덮어쓰고, 나머지 운영 설정은
+      # application-prod.yml 을 그대로 재사용할 수 있다.
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB}
+      SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
+      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
+
+      SPRING_DATA_REDIS_HOST: redis
+      SPRING_DATA_REDIS_PORT: 6379
+      SPRING_DATA_REDIS_PASSWORD: ${REDIS_PASSWORD}
+
+      # MinIO 를 S3 API 로 사용한다. endpoint 가 주어지면 S3Config 가 path-style 로
+      # 전환한다 — MinIO 는 버킷을 호스트명이 아니라 경로에 두기 때문이다.
+      CLOUD_AWS_S3_ENDPOINT: http://minio:9000
+      CLOUD_AWS_S3_BUCKET: ${MINIO_BUCKET}
+      CLOUD_AWS_CREDENTIALS_ACCESS_KEY: ${MINIO_ROOT_USER}
+      CLOUD_AWS_CREDENTIALS_SECRET_KEY: ${MINIO_ROOT_PASSWORD}
+
+      # 저장된 파일 URL 의 도메인. 이관 전 CloudFront 도메인을 그대로 유지한다 —
+      # DB(clubs.content 마크다운 본문, 지원서 답변 JSON, temp_applicant.temp_data)에
+      # 절대 URL 로 박혀 있어, 도메인이 바뀌면 전수 치환이 필요해진다.
+      FILE_CLOUD_URL: ${FILE_CLOUD_URL}
+
+      # Firebase 키는 이미지에 없고 /app/config 에 마운트되므로 file: 로 지정한다.
+      FIREBASE_CREDENTIALS_LOCATION: file:/app/config/${FIREBASE_JSON_NAME}
+    volumes:
+      # application-prod.yml 과 Firebase 키가 들어있는 디렉터리.
+      # Spring Boot 가 ./config/ 를 기본 설정 탐색 경로에 포함한다.
+      - ./config:/app/config:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    healthcheck:
+      # /health 는 SecurityWhiteList 에 등록된 공개 엔드포인트다.
+      # actuator 쪽은 화이트리스트에 없어 401 을 돌려주므로 쓰지 않는다.
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 20
+      start_period: 90s
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+    networks: [ttokttok]
+
+  # ── PostgreSQL ────────────────────────────────────────────────────────────
+  postgres:
+    image: postgres:17.4-alpine
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:15432:5432"
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      # named volume 대신 호스트 경로 바인드를 쓴다 — 백업 스크립트가 경로를
+      # 그대로 다룰 수 있고, 볼륨 실수 삭제로 데이터가 날아가는 경로를 줄인다.
+      - ./data/postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+    networks: [ttokttok]
+
+  # ── Redis ─────────────────────────────────────────────────────────────────
+  redis:
+    image: redis:7.2-alpine
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:16379:6379"
+    command: >
+      redis-server --appendonly yes --requirepass ${REDIS_PASSWORD}
+    environment:
+      # redis-cli 가 이 값을 자동으로 사용한다. 헬스체크 명령줄에 비밀번호를 직접
+      # 쓰면 `ps` 에 노출되므로 환경변수로 넘긴다.
+      REDISCLI_AUTH: ${REDIS_PASSWORD}
+    volumes:
+      - ./data/redis:/data
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping | grep -q PONG"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+    networks: [ttokttok]
+
+  # ── MinIO (S3 호환 오브젝트 스토리지) ─────────────────────────────────────
+  minio:
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    ports:
+      - "127.0.0.1:19000:9000"
+      - "127.0.0.1:19001:9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+    volumes:
+      - ./data/minio:/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:9000/minio/health/live || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+    networks: [ttokttok]
+
+  # ── MinIO 초기화 (일회성) ─────────────────────────────────────────────────
+  # 버킷을 만들고 익명 읽기를 연다. 파일 도메인으로 들어오는 요청은 인증 없이
+  # 오기 때문에, CloudFront 가 하던 공개 읽기를 여기서 재현해야 한다.
+  # 쓰기는 익명에 열지 않으므로 업로드는 앱의 자격증명으로만 가능하다.
+  minio-init:
+    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+    restart: "no"
+    depends_on:
+      minio:
+        condition: service_healthy
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+      MINIO_BUCKET: ${MINIO_BUCKET}
+    # $$ 는 compose 의 보간을 피해 컨테이너 셸이 확장하도록 남기는 이스케이프다.
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 $$MINIO_ROOT_USER $$MINIO_ROOT_PASSWORD &&
+      mc mb --ignore-existing local/$$MINIO_BUCKET &&
+      mc anonymous set download local/$$MINIO_BUCKET
+      "
+    networks: [ttokttok]
+
+  # ── Mailpit — 개발/테스트용 SMTP 싱크 ─────────────────────────────────────
+  # 운영 메일 발송은 외부 릴레이(smtp.naver.com)를 그대로 쓴다. 개인 서버에서
+  # 직접 발송하면 SPF/DKIM/PTR 을 맞춰도 IP 평판 때문에 전달률을 보장할 수 없고,
+  # 인증 메일 미도달은 곧 서비스 장애가 된다.
+  # 이 컨테이너는 보내지 않고 받아서 UI 에 쌓아두기만 한다.
+  mailpit:
+    image: axllent/mailpit:v1.24
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:11025:1025"
+      - "127.0.0.1:18025:8025"
+    environment:
+      MP_MAX_MESSAGES: 500
+    networks: [ttokttok]
+
+networks:
+  ttokttok:
+    driver: bridge

--- a/docker/nginx/conf.d/ttokttok.conf
+++ b/docker/nginx/conf.d/ttokttok.conf
@@ -1,0 +1,66 @@
+# ttokttok 리버스 프록시.
+#
+# 현재는 HTTP(80)만 처리한다. TLS 는 DNS 를 새 서버로 옮긴 뒤 인증서를 발급해야
+# 설정할 수 있어 후속 작업으로 분리했다. 존재하지 않는 인증서 경로를 미리 적어두면
+# nginx 가 기동 자체에 실패해 스택 전체가 뜨지 않으므로, 여기서는 넣지 않는다.
+#
+# 통신사가 80 인바운드를 막는 회선이라면 Let's Encrypt 의 HTTP-01 챌린지가 실패한다.
+# 그 경우 DNS-01 방식으로 발급해야 한다.
+
+# ── 앱 도메인 ──────────────────────────────────────────────────────────────
+server {
+    listen 80;
+    server_name www.hearmeout.kr hearmeout.kr;
+
+    # application-prod.yml 의 spring.servlet.multipart.max-request-size(50MB)와 맞춘다.
+    # 톰캣의 max-swallow-size 가 60MB 로 더 크게 잡혀 있어, 초과 요청이 잘려도
+    # 톰캣이 본문을 끝까지 읽고 정상적인 오류 응답을 돌려줄 수 있다.
+    client_max_body_size 50M;
+
+    location / {
+        proxy_pass http://app:8080;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # 지원서 제출처럼 첨부가 큰 요청이 있어 기본 60s 보다 넉넉히 잡는다.
+        proxy_read_timeout 120s;
+        proxy_send_timeout 120s;
+    }
+}
+
+# ── 파일 도메인 ────────────────────────────────────────────────────────────
+# 이관 전 CloudFront 가 쓰던 도메인을 그대로 유지한다. S3KeyUrlGenerator 가 만든
+# 절대 URL 이 DB 여러 곳(clubs.profile_img, club_boards.thumbnail_url, clubs.content
+# 마크다운 본문, 지원서 답변 JSON, temp_applicant.temp_data jsonb)에 저장돼 있어서,
+# 도메인이 바뀌면 텍스트/JSON 내부까지 전수 치환해야 한다. 도메인을 유지해 그 작업을 없앤다.
+server {
+    listen 80;
+    server_name www.ddockddock-file.co.kr ddockddock-file.co.kr;
+
+    client_max_body_size 50M;
+
+    location / {
+        # 저장된 URL 은 "<도메인>/<키>" 형태라 버킷명이 들어있지 않다.
+        # proxy_pass 끝의 "/ttokttokbucket/" 가 경로 앞에 버킷을 끼워 넣어
+        # MinIO 가 이해하는 path-style 요청으로 바꾼다.
+        # 이 버킷명은 .env 의 MINIO_BUCKET 과 반드시 일치해야 한다.
+        proxy_pass http://minio:9000/ttokttokbucket/;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # 이 도메인은 읽기 전용으로만 쓴다. 업로드는 앱이 내부 네트워크에서
+        # 자격증명을 갖고 수행하므로, 외부에서 들어오는 쓰기 메서드는 차단한다.
+        # (버킷 익명 정책도 download 로만 열려 있어 이중 방어가 된다.)
+        limit_except GET HEAD {
+            deny all;
+        }
+    }
+}

--- a/src/main/java/org/project/ttokttok/infrastructure/firebase/config/FirebaseConfig.java
+++ b/src/main/java/org/project/ttokttok/infrastructure/firebase/config/FirebaseConfig.java
@@ -6,20 +6,33 @@ import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
 import java.io.IOException;
 import java.io.InputStream;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
 
 @Configuration
+@RequiredArgsConstructor
 public class FirebaseConfig {
 
-    @Value("${firebase.json}")
-    private String firebaseResourceName;
+    private final ResourceLoader resourceLoader;
+
+    /**
+     * Firebase 서비스 계정 키의 위치. Spring 리소스 표기(classpath:, file:)를 따른다.
+     *
+     * <p>기본값은 기존 동작 그대로 {@code firebase.json} 이 가리키는 classpath 리소스다.
+     * 컨테이너 운영 환경에서는 이 키를 이미지에 굽지 않고 런타임에 마운트하므로
+     * {@code file:/app/config/...} 형태로 덮어쓴다. 서비스 계정 키가 이미지 레이어에
+     * 남으면 이미지를 얻은 쪽이 그대로 인증에 쓸 수 있어, 마운트로 분리한다.
+     */
+    @Value("${firebase.credentials-location:classpath:${firebase.json}}")
+    private String credentialsLocation;
 
     @Bean
     public FirebaseApp firebaseApp() throws IOException {
-        ClassPathResource resource = new ClassPathResource(firebaseResourceName);
+        Resource resource = resourceLoader.getResource(credentialsLocation);
 
         try (InputStream serviceAccount = resource.getInputStream()) {
             FirebaseOptions options = new FirebaseOptions.Builder()

--- a/src/main/java/org/project/ttokttok/infrastructure/s3/config/S3Config.java
+++ b/src/main/java/org/project/ttokttok/infrastructure/s3/config/S3Config.java
@@ -3,11 +3,17 @@ package org.project.ttokttok.infrastructure.s3.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+import java.net.URI;
 
 @Configuration
 public class S3Config {
@@ -21,21 +27,57 @@ public class S3Config {
     @Value("${cloud.aws.region.static}")
     private String region;
 
+    /**
+     * S3 호환 스토리지(MinIO 등)의 엔드포인트.
+     *
+     * <p>비어 있으면 실제 AWS S3 에 붙는다 — 기존 운영/로컬/테스트 동작을 그대로
+     * 유지하기 위한 기본값이다. 값이 주어지면 해당 엔드포인트로 붙으면서 path-style
+     * 접근으로 전환한다. MinIO 는 버킷을 호스트명(virtual-hosted style)이 아니라 경로에
+     * 두기 때문에, 엔드포인트만 바꾸고 path-style 을 켜지 않으면 버킷명이 DNS 로
+     * 해석되지 않아 요청이 실패한다.
+     */
+    @Value("${cloud.aws.s3.endpoint:}")
+    private String endpoint;
+
     @Bean
     public S3Client s3Client() {
-        return S3Client.builder()
+        S3ClientBuilder builder = S3Client.builder()
                 .region(Region.of(region))
-                .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(accessKey, secretKey)))
-                .build();
+                .credentialsProvider(credentialsProvider());
+
+        if (hasCustomEndpoint()) {
+            builder.endpointOverride(URI.create(endpoint))
+                    .serviceConfiguration(pathStyleConfiguration());
+        }
+
+        return builder.build();
     }
 
     @Bean
     public S3Presigner s3Presigner() {
-        return S3Presigner.builder()
+        S3Presigner.Builder builder = S3Presigner.builder()
                 .region(Region.of(region))
-                .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(accessKey, secretKey)))
+                .credentialsProvider(credentialsProvider());
+
+        if (hasCustomEndpoint()) {
+            builder.endpointOverride(URI.create(endpoint))
+                    .serviceConfiguration(pathStyleConfiguration());
+        }
+
+        return builder.build();
+    }
+
+    private boolean hasCustomEndpoint() {
+        return StringUtils.hasText(endpoint);
+    }
+
+    private AwsCredentialsProvider credentialsProvider() {
+        return StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey));
+    }
+
+    private S3Configuration pathStyleConfiguration() {
+        return S3Configuration.builder()
+                .pathStyleAccessEnabled(true)
                 .build();
     }
 }


### PR DESCRIPTION
## ✨ 작업 내용

AWS Elastic Beanstalk 운영 환경을 자체 우분투 서버로 이관하기 위한 **compose 스택과 앱 컨테이너화**를 작성했습니다. #352가 "이번 범위에서 제외한 것"으로 남긴 인프라 파일(Dockerfile / compose / nginx)을 실제로 채우는 2단계 작업입니다.

- **운영용 `docker-compose.yml` 신규 작성** — postgres, redis, minio, mailpit, app, nginx를 단일 스택으로 구성
- **루트 `Dockerfile` 교체** — 기존 `FROM ubuntu:latest` + `top -b` 스텁을 temurin 17 멀티스테이지 빌드로 대체, 비-root 실행
- **`.dockerignore` 신규** — 설정 파일과 Firebase 키가 이미지 레이어에 굽히지 않도록 차단
- **nginx 리버스 프록시 설정 신규** — 앱 도메인과 파일 도메인 분리 라우팅
- **`S3Config` 수정** — `cloud.aws.s3.endpoint`가 설정된 경우에만 `endpointOverride` + path-style 적용 (MinIO 대응)
- **`FirebaseConfig` 수정** — `ClassPathResource` 고정을 `ResourceLoader` 기반으로 변경해 마운트된 키를 읽을 수 있게 함
- **`.env.example` 신규 + `.gitignore`에 `.env`, `/config/`, `/data/` 등록**

**Swagger 문서: 변경 없음** (API 변경 없음)
**DB 변경: 없음** (Flyway 스크립트 추가 없음)

---

## 🔍 관련 이슈

- 해결한 이슈 번호: #354
- 관련된 이슈 번호: #352 (1단계 — 관측성 기반 구축)

---

## ✅ 체크리스트
- [ ] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요?
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항

### 이번 PR은 운영 배포에 영향이 없습니다

`ci-cd.yml`을 건드리지 않았습니다. 머지되어도 기존 EB 파이프라인이 그대로 돌고, 추가된 인프라 파일은 서버에서 수동으로 기동하기 전까지 아무것도 하지 않습니다.

### 리뷰 포인트 1 — 파일 도메인을 유지하는 것이 설계의 핵심입니다

`S3KeyUrlGenerator`가 버킷 주소가 아니라 `file-cloud.url` 프로퍼티 기준으로 URL을 만들어 DB에 저장합니다. 즉 공개 URL이 스토리지 백엔드와 이미 분리돼 있어서, **도메인만 유지하면 스토리지를 MinIO로 바꿔도 DB에 저장된 URL을 하나도 손대지 않아도 됩니다.**

이게 중요한 이유는 URL이 단순 컬럼에만 있지 않기 때문입니다:

| 위치 | 저장 형태 |
|---|---|
| `clubs.profile_img` | URL 단독 컬럼 |
| `club_boards.thumbnail_url` | URL 단독 컬럼 |
| `clubs.content` (TEXT) | 마크다운 본문에 임베드 |
| 지원서 답변 (`Answer` JSON) | JSON 값 내부 |
| `temp_applicant.temp_data` (jsonb) | jsonb 내부 |

`ClubAdminService.updateMarkdownImage`가 URL만 반환하고 클라이언트가 마크다운에 끼워 넣는 구조라, 뒤 3개는 텍스트 부분 치환이 필요합니다. 치환이 실패하면 `S3KeyUrlGenerator.extractKeyFromUrl`이 예외를 던져 **기존 파일 삭제가 불가능해집니다.** 도메인 유지로 이 위험을 회피했습니다.

### 리뷰 포인트 2 — 포트는 번호가 아니라 바인드 주소로 막았습니다

`- "15432:5432"`는 포트 번호만 바뀔 뿐 여전히 `0.0.0.0`에 열립니다. 게다가 **UFW는 Docker가 삽입한 iptables 규칙보다 뒤에 평가되어 published 포트를 막아주지 못합니다.** 그래서 인프라 서비스를 전부 `127.0.0.1:`에 바인딩하고, 외부 공개는 nginx의 80/443만 남겼습니다. 관리 접속은 SSH 터널을 씁니다.

`docker compose config` 렌더 결과로 nginx 외 전 서비스에 `host_ip: 127.0.0.1`이 붙는 것을 확인했습니다.

### 리뷰 포인트 3 — `S3Config` 변경은 기존 동작을 바꾸지 않습니다

`cloud.aws.s3.endpoint`가 비어 있으면 `endpointOverride`와 path-style을 **둘 다 적용하지 않습니다.** 로컬/테스트/현재 운영(실제 AWS S3)의 동작이 그대로 유지되도록 한 조건부 처리입니다. path-style을 함께 켜는 이유는, 엔드포인트만 바꾸면 SDK가 `버킷명.호스트` 형태로 요청을 만들어 DNS 해석에 실패하기 때문입니다.

### ⚠️ 알려진 한계 (후속 이슈 대상)

1. **컨테이너 헬스체크로 `/health`를 쓰고 있으나 임시방편입니다.** #352가 기록했듯 `HealthCheckController`는 조건 없이 `Healthy`를 반환하며 DB/Redis를 보지 않습니다. **DB가 끊긴 앱도 healthy로 보고됩니다.** #352의 readiness 그룹이 develop에 머지되면 그쪽으로 교체해야 합니다.
2. **`SPRING_PROFILES_ACTIVE=prod` 단독입니다.** #352가 관측성 프로파일 활성화를 이 이슈의 몫으로 남겼으나, `application-observability.yml`이 아직 `origin/develop`에 없어 참조할 수 없었습니다. #352 머지 후 `prod,observability`로 바꿔야 합니다.
3. **nginx 설정을 실제로 검증하지 못했습니다.** 작업 환경에서 Docker Desktop 엔진이 실행 중이 아니라 `docker compose config`(클라이언트 측 파싱)까지만 확인했습니다. `nginx -t`와 컨테이너 기동 테스트는 **서버에서 첫 기동 시 반드시 수행해야 합니다.**
4. **버킷명이 두 곳에 나뉘어 있습니다.** nginx는 환경변수를 읽지 않으므로 `ttokttok.conf`의 `proxy_pass` 경로와 `.env`의 `MINIO_BUCKET`이 각각 존재합니다. 한쪽만 바꾸면 파일 서빙이 조용히 404가 됩니다. 양쪽에 주석 경고를 넣어뒀습니다.
5. **TLS는 이번 범위 밖이라 nginx를 HTTP(80) 전용으로 뒀습니다.** 존재하지 않는 인증서 경로를 미리 적으면 nginx가 기동에 실패해 스택 전체가 뜨지 않기 때문입니다.

### 참고 — DB 이관 시 반드시 확인할 것

`db/migration`의 `V0`가 이미 `ALTER TABLE`로 시작하고 `users`/`clubs`의 `CREATE TABLE`이 없어, **Flyway만으로는 새 DB 스키마를 만들 수 없습니다.** 새 서버 DB는 기존 덤프 복원으로만 만들 수 있으며, 복원 시 `flyway_schema_history` 테이블이 함께 넘어가는지 확인해야 합니다. 빠지면 앱 기동 시 Flyway가 V0부터 재실행을 시도해 실패합니다.

### SMTP만 compose에서 제외한 이유

운영 발송은 기존 외부 릴레이를 유지합니다. 개인 서버에서 직접 발송하면 SPF/DKIM/PTR을 모두 맞춰도 IP 대역 평판 문제로 전달률을 보장할 수 없고 대부분의 ISP가 25번 아웃바운드를 막습니다. 인증 메일 미도달은 곧 서비스 장애라 자체 운영을 배제했습니다. compose의 Mailpit은 발송하지 않고 받아서 쌓아두는 테스트 싱크입니다.

### 검증

- `bash maintenance/verify.sh` 그린 (BUILD SUCCESSFUL in 2m 1s) — 1회차 통과
- 커밋별 게이트 `git rebase origin/develop --exec './gradlew.bat compileJava compileTestJava'` → 5커밋 모두 `BUILD SUCCESSFUL`
- 커밋 5개로 분할 (관심사 1개당 1커밋, 축 혼합 없음)
