### PR TITLE
Postfix 이미지 빌드 실패 수정 (fix/#357 -> develop)

### DIFF
--- a/deploy/docker/postfix/Dockerfile
+++ b/deploy/docker/postfix/Dockerfile
@@ -4,11 +4,15 @@
 # "사내 SMTP 수신 → 외부 릴레이로 전달" 만 한다.
 FROM alpine:3.20
 
+# PLAIN 메커니즘(libplain.so)은 별도 패키지가 아니라 cyrus-sasl 본체에 들어 있다.
+# Alpine 에 cyrus-sasl-plain 이라는 패키지는 존재하지 않아, 넣으면 빌드가
+# "unable to select packages" 로 실패한다. LOGIN 만 별도 패키지다.
 RUN apk add --no-cache \
       postfix \
-      cyrus-sasl cyrus-sasl-plain cyrus-sasl-login \
+      cyrus-sasl cyrus-sasl-login \
       ca-certificates tzdata \
- && rm -rf /var/cache/apk/*
+ && rm -rf /var/cache/apk/* \
+ && test -f /usr/lib/sasl2/libplain.so   # PLAIN 가용 여부를 빌드 시점에 못박는다
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
## ✨ 작업 내용

`deploy/docker/postfix/Dockerfile` 이 빌드되지 않아 메일 릴레이 컨테이너가 기동하지 못하던 문제를 고쳤다.

```
ERROR: unable to select packages:
  cyrus-sasl-plain (no such package):
    required by: world[cyrus-sasl-plain]
```

Alpine 3.20 에 `cyrus-sasl-plain` 패키지는 존재하지 않는다. 실제 제공되는 것은
`cyrus-sasl`, `cyrus-sasl-crammd5`, `cyrus-sasl-digestmd5`, `cyrus-sasl-gs2`,
`cyrus-sasl-gssapiv2`, `cyrus-sasl-login`, `cyrus-sasl-ntlm`, `cyrus-sasl-scram` 이고
**PLAIN 메커니즘(`/usr/lib/sasl2/libplain.so`)은 `cyrus-sasl` 본체에 들어 있다.**
별도 패키지가 필요한 건 LOGIN 쪽뿐이다.

그래서 `cyrus-sasl-plain` 을 지우고, 대신 빌드 마지막에 `libplain.so` 존재를 검사하는
한 줄을 넣었다. 패키지 구성이 또 바뀌면 이미지가 만들어진 뒤 런타임에 인증이 깨지는 대신
빌드가 그 자리에서 실패한다. 네이버 릴레이가 PLAIN/LOGIN 을 쓰므로 이 파일이 없으면
`smtp_sasl_mechanism_filter = plain, login` 이 무의미해진다.

## 🔍 관련 이슈

- 해결한 이슈 번호: #357
- 관련된 이슈 번호 (선택): #354

## ✅ 체크리스트

- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요?
- [ ] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

### 검증 결과

| 항목 | 결과 |
|---|---|
| `docker build` | 통과 (수정 전에는 실패) |
| 컨테이너 기동 | `Up (healthy)` |
| `/usr/lib/sasl2/` | `libplain.so`, `liblogin.so` 존재 |
| `mynetworks` | `127.0.0.0/8 172.31.0.0/16` — 실제 compose 대역과 일치 |
| `smtpd_relay_restrictions` | `permit_mynetworks, reject` (오픈릴레이 아님) |
| `mydestination` | 비어 있음 (MX 수신 안 함) |
| `smtp_tls_security_level` | `encrypt` |
| 25번 포트 | 호스트에 publish 안 됨 |

## 💬 기타 참고 사항

#354 의 자체 서버 이관을 실제 덤프·`.env`·compose 로 리허설하다 발견했다.
`docker compose up smtp` 를 실행해야만 드러나는 결함이라 #356 검증에서 놓쳤다.