### PR TITLE
파일 도메인의 404/403 캐시 헤더 제거 (fix/#359 -> develop)

### DIFF
--- a/deploy/config/nginx/templates/minio-public.inc
+++ b/deploy/config/nginx/templates/minio-public.inc
@@ -37,4 +37,7 @@ proxy_hide_header x-amz-meta-server-side-encryption;
 proxy_hide_header Server;
 
 # 정적 파일이므로 캐시를 길게 (키에 UUID 가 들어가 내용이 바뀌지 않는다).
-add_header Cache-Control "public, max-age=31536000, immutable" always;
+# always 를 쓰지 않는다. 붙이면 404/403 응답까지 1년 immutable 로 캐시되어,
+# 업로드 전파 지연으로 404 를 한 번 받은 클라이언트가 파일이 올라온 뒤에도
+# 계속 깨진 이미지를 보게 된다. 기본 동작(2xx/3xx 에만 적용)이 정확히 원하는 것이다.
+add_header Cache-Control "public, max-age=31536000, immutable";


### PR DESCRIPTION
## ✨ 작업 내용

`minio-public.inc` 의 `add_header ... always` 에서 `always` 를 뗐다.

`always` 는 이 헤더를 **모든 응답에** 붙인다. 그래서 오브젝트가 없어 MinIO 가 404 를,
목록 조회 차단으로 403 을 돌려줄 때도 `max-age=31536000, immutable` 이 함께 나갔다.

업로드 전파 지연 등으로 404 를 한 번 받은 클라이언트는 **그 URL 을 1년간 404 로 기억한다.**
`immutable` 이라 새로고침으로도 재검증하지 않으므로, 파일이 정상적으로 올라온 뒤에도
그 사용자에게는 계속 깨진 이미지로 보인다.

nginx 의 `add_header` 는 `always` 없이 200/201/204/206/301/302/303/304/307/308 에만
적용되는데, 그게 정확히 원하는 동작이다.

## 🔍 관련 이슈

- 해결한 이슈 번호: #359
- 관련된 이슈 번호 (선택): #354

## ✅ 체크리스트

- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요?
- [ ] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

### 검증 결과

실제 MinIO·nginx 를 띄우고 실제 오브젝트로 확인했다.

| 응답 | 수정 전 | 수정 후 |
|---|---|---|
| 200 (정상 오브젝트) | 캐시 헤더 있음 | 캐시 헤더 **있음** ✅ |
| 404 (없는 키) | 캐시 헤더 있음 ✗ | 캐시 헤더 **없음** ✅ |
| 403 (버킷 목록 조회) | 캐시 헤더 있음 ✗ | 캐시 헤더 **없음** ✅ |

`nginx -t` 통과, reload 후 정상 오브젝트 GET 은 그대로 200.

## 💬 기타 참고 사항

#354 이관을 실제 덤프·`.env`·compose 로 리허설하다 발견했다. 같은 리허설에서 나온
Postfix 빌드 실패는 #357 / PR #358 로 따로 올렸다.