### PR TITLE
deploy.sh 의 컨테이너 판별을 compose 조회로 교체 (fix/#361 -> develop)

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -88,6 +88,15 @@ docker compose up -d $INFRA_SERVICES
 log "app-$target 기동"
 docker compose --profile "$target" up -d --no-deps "app-$target"
 
+# 대상 색 컨테이너가 running 인지 compose 에게 직접 묻는다.
+# compose ps -q 는 자기 프로젝트의 컨테이너 ID 를 정확히 돌려주므로 이름 규약과 무관하다.
+target_running() {
+  local cid
+  cid="$(docker compose --profile "$1" ps -q "app-$1" 2>/dev/null | head -1)"
+  [[ -n "$cid" ]] || return 1
+  [[ "$(docker inspect -f '{{.State.Running}}' "$cid" 2>/dev/null)" == "true" ]]
+}
+
 cleanup_target() {
   warn "app-$target 정리 중"
   docker compose --profile "$target" logs --tail 100 "app-$target" || true
@@ -100,10 +109,15 @@ cleanup_target() {
 log "헬스체크 대기 (최대 ${HEALTH_TIMEOUT}s)"
 healthy=0
 for ((i = 0; i < HEALTH_TIMEOUT; i++)); do
-  # 컨테이너가 죽었으면 기다릴 이유가 없다
-  if ! docker ps --filter "name=ttokttok-app-$target" --filter status=running -q | grep -q .; then
+  # 컨테이너가 죽었으면 기다릴 이유가 없다.
+  #
+  # 컨테이너를 이름으로 찾지 않고 compose 에게 묻는다. `docker ps --filter name=` 은
+  # (1) container_name 이나 프로젝트명이 바뀌면 멀쩡히 도는 컨테이너를 못 찾아
+  # 배포를 영구히 실패시키고, (2) 부분 일치라서 ttokttok-app-blue-old 같은
+  # 잔여 컨테이너에도 매칭돼 죽은 배포를 살아있다고 오판한다.
+  if ! target_running "$target"; then
     sleep 1
-    if ! docker ps --filter "name=ttokttok-app-$target" --filter status=running -q | grep -q .; then
+    if ! target_running "$target"; then
       cleanup_target
       die "app-$target 컨테이너가 기동 중 종료됐다"
     fi


### PR DESCRIPTION
## ✨ 작업 내용

헬스 대기 루프가 컨테이너 존재를 이름 규약으로 판단하던 것을 `docker compose ps -q` 로 바꿨다.

```diff
-if ! docker ps --filter "name=ttokttok-app-$target" --filter status=running -q | grep -q .; then
+if ! target_running "$target"; then
```

기존 방식의 문제 두 가지:

1. **compose 에게 묻지 않는다.** `container_name` 이나 프로젝트명이 바뀌면 멀쩡히 도는
   컨테이너를 못 찾아 `기동 중 종료됐다` 로 즉시 중단한다. 앱은 정상인데 배포만 영구히
   실패하고, 원인이 로그에 드러나지 않는다.
2. **`--filter name=` 은 부분 일치다.** `ttokttok-app-blue` 가 `ttokttok-app-blue-old`
   에도 매칭된다. 정리되다 만 잔여 컨테이너가 있으면 죽은 배포를 살아있다고 오판한다.

추가한 `target_running()` 은 compose 에게 컨테이너 ID 를 받아 `.State.Running` 을 확인하므로
이름과 무관하고 부분 일치도 없다.

## 🔍 관련 이슈

- 해결한 이슈 번호: #361
- 관련된 이슈 번호 (선택): #354

## ✅ 체크리스트

- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요?
- [ ] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

### 검증 결과

**실제 앱 이미지**(더미가 아님)로 전체 스택을 띄워 검증했다. 복원한 운영 덤프, 정리한
`application-prod.yml`, 실제 compose 를 그대로 썼다.

| 항목 | 결과 |
|---|---|
| 수정 전 (컨테이너명 변경 시) | 앱이 14초 만에 정상 기동해 `{"status":"Healthy"}` 를 주는데도 `기동 중 종료됐다` 로 중단 ✗ |
| 수정 후 | 헬스체크 15s 통과 → 전환 완료 ✅ |
| 무중단 전환 (blue → green, 실제 앱) | **400 요청 / 비200 0건** ✅ |
| `ddl-auto: validate` | 복원된 스키마에 대해 통과 (스키마 검증 오류 없음) |
| Flyway | 17개 검증, 현재 버전 25, 추가 마이그레이션 없음 |
| nginx 경유 API | `/health` 200 |

## 💬 기타 참고 사항

이번 리허설에서 확인된 것 하나 더 — 정리한 `application-prod.yml` 에는 DB/Redis/S3 자격증명이
아예 없는데 앱이 정상 기동했다. `cloud.aws.credentials.access-key` 나 `file-cloud.url` 처럼
하이픈이 든 키도 `CLOUD_AWS_CREDENTIALS_ACCESS_KEY` / `FILE_CLOUD_URL` 환경변수로 정확히
바인딩된다는 뜻이다.