### PR TITLE
bind mount 미적용 시 낡은 DB 로 기동하는 것 차단 (fix/#363 -> develop)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -137,6 +137,21 @@ Postfix 는 `mynetworks` 안에서 오는 요청을 인증 없이 받으므로 �
   root 소유 파일을 만들고, 그러면 백업 cron 이 `ttokttokuser` 로 읽지 못한다.
 - **ufw 는 Docker 가 publish 한 포트를 막지 못한다.** iptables 평가 순서 때문이다.
   그래서 인프라 포트를 전부 `127.0.0.1:` 에 묶는다.
+- **`/opt/ttokttok/data` 의 bind mount 가 없으면 낡은 DB 로 조용히 뜬다.** compose 가
+  `/opt/ttokttok/data/postgres` 를 직접 참조하는데, 마운트가 없으면 그건 루트 파티션의 빈
+  디렉터리다. postgres 는 PGDATA 가 비었으니 `initdb` 를 돌리고 이어서 `00-restore.sql` 로
+  **최초 덤프**를 복원한다. 서비스는 멀쩡해 보이지만 덤프 시점 데이터로 운영되고, 진짜
+  데이터는 `/home` 에 방치된 채 양쪽이 갈라진다. `setup.sh` 가 마운트를 단언하지만,
+  재부팅 후에는 직접 확인하는 습관이 필요하다.
+
+  ```bash
+  mountpoint /opt/ttokttok/data    # "is a mountpoint" 여야 한다
+  df -h /opt/ttokttok/data         # /dev/nvme0n1p3(/home) 이어야 한다
+  ```
+
+  fstab 항목에 `nofail` 은 일부러 넣지 않았다. 넣으면 마운트 실패해도 부팅이 되어 위 상황이
+  조용히 발생한다. 지금은 마운트 실패 시 부팅이 멈추므로 즉시 알아챌 수 있다 — 대신
+  헤드리스 서버에서는 콘솔 접근이 필요하다. 트레이드오프를 알고 선택한 것이다.
 
 ## 남은 리스크
 

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -37,6 +37,13 @@ if ! grep -qF " $ROOT/data " /etc/fstab; then
     printf '%s %s none bind 0 0\n' "$DATA_SRC" "$ROOT/data" >> /etc/fstab
 fi
 
+# 마운트를 단언한다. 이게 없으면 스택이 루트 파티션의 빈 디렉터리 위에서 뜨고,
+# postgres 는 PGDATA 가 비었으니 initdb → 00-restore.sql 순으로 "최초 덤프"를 복원한다.
+# 서비스는 정상으로 보이지만 낡은 데이터로 운영되고, 진짜 데이터는 /home 에 방치된 채
+# 양쪽이 갈라진다. 조용히 일어나므로 여기서 막는다.
+mountpoint -q "$ROOT/data" \
+    || { echo "[setup] $ROOT/data 가 마운트되지 않았다. $DATA_SRC 확인 필요." >&2; exit 1; }
+
 # ── 4. 파일 배치 ─────────────────────────────────────────────────────────
 log "설정/스크립트 배치"
 install -m 0664 "$SRC/docker-compose.yml"                        "$ROOT/app/docker-compose.yml"


### PR DESCRIPTION
## ✨ 작업 내용

`setup.sh` 가 bind mount 성공을 단언하도록 했고, 이 실패 양상을 README 에 적었다.

compose 는 `/opt/ttokttok/data/postgres` 를 직접 참조한다. 마운트가 없으면 그건 루트 파티션의
빈 디렉터리이고, postgres 엔트리포인트는 PGDATA 가 비었으니 `initdb` 를 돌린 뒤
`docker-entrypoint-initdb.d/00-restore.sql` 로 **최초 덤프를 복원한다.**

결과적으로 헬스체크도 통과하고 서비스도 정상으로 보이지만 **덤프 시점의 낡은 데이터로 운영된다.**
진짜 데이터는 `/home` 에 그대로 있는데 아무도 안 보고 있고, 그 사이 들어온 쓰기는 루트 파티션의
새 DB 에 쌓여 양쪽이 갈라진다. 이관 직후에는 두 DB 의 내용이 거의 같아서 더 알아채기 어렵다.

기존 `setup.sh` 에는 `mount --bind` 뒤 검사가 없어 실패해도 그대로 다음 단계로 넘어갔다.

## 🔍 관련 이슈

- 해결한 이슈 번호: #363
- 관련된 이슈 번호 (선택): #354

## ✅ 체크리스트

- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요?
- [ ] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

### 검증 결과

`bash -n` 통과. 동작 자체는 sudo 가 필요해 실제 실행은 서버에서 확인해야 한다.

## 💬 기타 참고 사항

fstab 에 `nofail` 은 **일부러 넣지 않았다.** 붙이면 마운트 실패해도 부팅이 되어 위 상황이
조용히 발생한다. 지금은 마운트 실패 시 부팅이 멈춰 즉시 알아챌 수 있다 — 대신 헤드리스
서버라면 콘솔 접근이 필요하다. README 에 이 트레이드오프를 명시했으니, 운영하면서
반대 선택이 낫다고 판단되면 그때 바꾸면 된다.