### PR TITLE
[#365] - setup.sh 에서 ttokttokuser 도 docker 그룹에 추가

### DIFF
--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -85,7 +85,23 @@ find "$ROOT" -type d -not -path "$ROOT/data/*" -exec chmod 2775 {} +
 chmod 0660 "$ROOT/app/.env"
 chmod 0770 "$ROOT/config/app"     # 시크릿(application-prod.yml, firebase.json)
 
-# ── 7. CI 사용자에게 docker 권한 ─────────────────────────────────────────
+# ── 7. docker 권한 ───────────────────────────────────────────────────────
+# 두 사용자 다 필요하다.
+#   - $CICD_USER: 러너가 이미지 빌드와 deploy.sh 를 돌린다.
+#   - $RUN_USER : 운영 주체다. bin/ 아래 스크립트가 전부 docker 를 호출한다 —
+#     import-files.sh(docker run), issue-cert.sh(compose run), nginx-apply.sh
+#     (compose exec ... -s reload), backup-db.sh(compose exec pg_dump).
+#     뒤의 둘은 cron 으로 도는 무인 경로라, 빠뜨리면 백업과 인증서 갱신이
+#     아무 신호 없이 계속 실패한다.
+if ! id -nG "$RUN_USER" | tr ' ' '\n' | grep -qx docker; then
+    log "$RUN_USER 를 docker 그룹에 추가 (bin/ 스크립트·백업 cron 에 필수)"
+    usermod -aG docker "$RUN_USER"
+    # 러너처럼 재시작할 대상이 없다. $RUN_USER 는 상주 세션이 없고
+    # sudo -u 와 cron 이 실행 시점에 그룹을 새로 계산하므로 바로 반영된다.
+else
+    log "$RUN_USER 는 이미 docker 그룹 소속"
+fi
+
 if ! id -nG "$CICD_USER" | tr ' ' '\n' | grep -qx docker; then
     log "$CICD_USER 를 docker 그룹에 추가 (배포에 필수)"
     usermod -aG docker "$CICD_USER"


### PR DESCRIPTION
Closes #365

## 무엇을

`setup.sh` 7단계가 `ttokttok-cicd` 만 docker 그룹에 넣고 있었다. 운영 주체인
`ttokttokuser` 도 함께 넣는다.

## 왜

`bin/` 아래 스크립트가 전부 docker 를 호출하는데, 전부 `ttokttokuser` 로 실행하도록
설계돼 있다.

| 스크립트 | 호출 |
|---|---|
| `import-files.sh` | `docker run --network ttokttok` |
| `issue-cert.sh` | `docker compose run certbot` |
| `nginx-apply.sh` | `docker compose exec nginx nginx -s reload` |
| `backup-db.sh` | `docker compose exec postgres pg_dump` |

뒤의 둘은 cron 으로 도는 무인 경로다. 실패해도 아무 신호가 없어서, 백업이 없는 채로
몇 주가 지나거나 인증서가 만료된 뒤에야 드러난다. README 의 설치 절차
(`sudo -u ttokttokuser bin/...`)도 그대로는 막힌다.

## 러너 재시작이 필요 없는 이유

`ttokttok-cicd` 는 러너가 상주 프로세스라 그룹 변경을 반영하려면 재시작이 필요하다.
`ttokttokuser` 는 상주 세션이 없고 `sudo -u` 와 cron 이 실행 시점마다 그룹을 새로
계산하므로 후속 조치 없이 즉시 반영된다.

## 권한 경계

docker 그룹은 사실상 root 다. 다만 `ttokttokuser` 는 이미 `/opt/ttokttok` 전체와
DB·업로드 데이터의 소유자이고 스택 컨테이너를 소유해야 하는 주체라, 이 변경으로
권한 경계가 새로 넓어지지는 않는다.

## 검증

- `bash -n deploy/setup.sh`
- 멱등성: 이미 소속이면 `이미 docker 그룹 소속` 로그만 남기고 넘어간다.