### PR TITLE
[#367] - setup.sh 재귀 chown 이 실행 중인 컨테이너 데이터를 건드리지 않게

### DIFF
--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -21,7 +21,10 @@ log() { printf '\033[36m[setup]\033[0m %s\n' "$*"; }
 # /opt 은 루트 파티션(46G 중 34G 여유)이라 DB+업로드가 쌓이면 위험하다.
 log "데이터 디렉터리: $DATA_SRC"
 mkdir -p "$DATA_SRC"/{postgres,redis,minio,certbot/conf,certbot/www}
-chown -R "$RUN_USER:$RUN_GROUP" "$DATA_SRC"
+# 디렉터리 자체만 chown 한다. -R 을 쓰면 실행 중인 컨테이너의 데이터 파일까지
+# 소유권이 바뀐다 — 6단계 주석 참고.
+chown "$RUN_USER:$RUN_GROUP" \
+      "$DATA_SRC" "$DATA_SRC"/{postgres,redis,minio,certbot,certbot/conf,certbot/www}
 
 # ── 2. /opt/ttokttok 구조 ────────────────────────────────────────────────
 log "디렉터리 구조 생성"
@@ -79,9 +82,24 @@ fi
 # ── 6. 소유권/권한 ───────────────────────────────────────────────────────
 # setgid(2775): ttokttok-cicd 가 만든 파일도 ttokttok 그룹을 상속 →
 # ttokttokuser 와 파일을 주고받을 수 있다.
+#
+# data/ 안쪽은 건드리지 않는다. 거기는 각 컨테이너가 자기 uid 로 소유하는 영역이고,
+# 호스트에서 소유권을 강제할 이유가 없다. 반대로 강제하면 실행 중인 서비스가 깨진다 —
+# postgres 는 user: 지정 없이 내부 uid 70 으로 도는데, PGDATA 를 1001:1003 으로
+# 바꾸는 순간 자기 파일을 못 읽고 PANIC 한다.
+#
+#   FATAL: could not open file "global/pg_filenode.map": Permission denied
+#   PANIC: could not open file "global/pg_control": Permission denied
+#
+# 이 스크립트는 멱등이라 스택이 뜬 상태에서도 재실행될 수 있으므로 실제로 일어난다.
+# postgres 는 엔트리포인트가 root 로 시작하면서 PGDATA 를 다시 chown 해 복구하지만,
+# 그건 이 이미지의 우연한 성질이다. redis/minio 에는 그런 복구 경로가 없다.
+#
+# 마운트 포인트($ROOT/data) 자체는 제외하지 않는다. 그건 /home 쪽 디렉터리 하나이고
+# 1단계에서 이미 같은 소유권으로 맞춰둔다.
 log "소유권/권한 설정"
-chown -R "$RUN_USER:$RUN_GROUP" "$ROOT"
-find "$ROOT" -type d -not -path "$ROOT/data/*" -exec chmod 2775 {} +
+find "$ROOT" -path "$ROOT/data/*" -prune -o -exec chown "$RUN_USER:$RUN_GROUP" {} +
+find "$ROOT" -path "$ROOT/data/*" -prune -o -type d -exec chmod 2775 {} +
 chmod 0660 "$ROOT/app/.env"
 chmod 0770 "$ROOT/config/app"     # 시크릿(application-prod.yml, firebase.json)
 


### PR DESCRIPTION
Closes #367

> base 가 `fix/#365` 입니다. #366 이 develop 에 머지되면 base 를 develop 으로 바꿔 주세요.

## 무엇을

`setup.sh` 6단계의 `chown -R "$ROOT"` 를 `$ROOT/data/*` 를 제외한 `find` 로 바꾼다.
1단계의 `chown -R "$DATA_SRC"` 도 생성한 디렉터리만 대상으로 좁힌다.

## 왜

`chmod` 에는 `-not -path "$ROOT/data/*"` 가 있었는데 바로 윗줄 `chown` 에는 없었다.
`$ROOT/data` 아래가 PGDATA 다. postgres 컨테이너는 `user:` 지정이 없어 내부 uid 70 으로
도는데, 소유권이 1001:1003 으로 바뀌는 순간 자기 파일을 못 읽는다. 실제로 부트스트랩 중
기동 13초 만에 죽었다.

```
17:18:22 LOG:  database system is ready to accept connections
17:18:35 FATAL: could not open file "global/pg_filenode.map": Permission denied
17:18:37 PANIC: could not open file "pg_wal/000000010000000000000001": Permission denied
17:18:38 LOG:  all server processes terminated; reinitializing
17:18:38 PANIC: could not open file "global/pg_control": Permission denied
```

이번에는 엔트리포인트가 root 로 시작하면서 PGDATA 를 다시 chown 해 자동 복구됐고
데이터 손실도 없었다. 하지만 그건 postgres 이미지의 우연한 성질이지 설계가 아니다.
redis/minio 에는 그런 복구 경로가 없다. 스크립트 헤더의 "멱등이라 재실행해도 안전"이
사실이 되려면 이 줄이 고쳐져야 한다.

1단계도 같은 파일을 가리킨다. `$DATA_SRC` 는 `$ROOT/data` 의 bind mount 원본이다.

## 동작 확인

가짜 트리에서 선택 대상을 확인했다.

```
$ find $T -path "$T/data/*" -prune -o -print
.
./app
./app/.env
./bin
./config
./config/nginx
./data          ← 마운트 포인트 자체는 포함 (기존 chmod 동작과 동일)

data 하위 선택된 개수: 0
```

`$ROOT/data` 자체는 계속 포함된다. 그건 `/home` 쪽 디렉터리 하나일 뿐이고 1단계에서
이미 같은 소유권으로 맞춰둔다. 제외 대상은 그 **안쪽**뿐이다.

- `bash -n deploy/setup.sh`