### PR TITLE
[#369] - 인증서 발급 사전점검 경로 수정 + 갱신 감시 추가

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -16,6 +16,7 @@ EB → 자체 우분투 서버(`/opt/ttokttok`) 이관용 인프라 코드. 이�
 | `bin/nginx-apply.sh` | 도메인 치환 후 nginx 설정 적용 (`--https` 로 HTTPS 전환) |
 | `bin/issue-cert.sh` | Let's Encrypt 최초 발급 (API/파일 도메인 각각, 사전 도달성 점검 포함) |
 | `bin/import-files.sh` | 기존 S3 백업(`resources.tar`)을 MinIO 버킷에 적재 |
+| `bin/check-certs.sh` | 서빙 중인 인증서 만료 감시 → 임박 시 경고 메일 |
 | `bin/backup-db.sh` | 일일 pg_dump + 주간 파일 백업 |
 | `test/bluegreen-test.sh` | 앱 없이 배포·프록시 로직 검증 |
 
@@ -60,6 +61,34 @@ cd /opt/ttokttok/app && docker compose logs -f app-$(cat ./state)
 
 # MinIO 콘솔 / psql (외부 노출 없음. SSH 터널로만)
 ssh -L 19001:127.0.0.1:19001 -L 15432:127.0.0.1:15432 <서버>
+```
+
+## 인증서 갱신
+
+세 고리가 물려 돌아간다. 하나라도 빠지면 만료가 조용히 진행된다.
+
+| 주체 | 주기 | 하는 일 |
+|---|---|---|
+| `ttokttok-certbot` 컨테이너 | 12시간 | `certbot renew` — 만료 30일 전부터 실제 갱신 |
+| cron `04:30` | 매일 | `nginx -s reload` — 갱신된 인증서를 실제로 내보내게 |
+| cron `05:00` | 매일 | `check-certs.sh` — 남은 일수 확인, 21일 미만이면 경고 메일 |
+
+`reload` 는 조건 없이 매일 돈다. graceful 이라 비용이 없고, "갱신은 됐는데 reload 를
+놓쳤다"를 원천 차단하는 쪽이 조건 판정보다 싸다.
+
+**감시가 핵심이다.** `certbot renew --quiet` 의 오류는 컨테이너 로그로만 간다. 갱신은
+만료 30일 전부터 시도하므로, 실패가 누적되면 30일 뒤 HTTPS 가 죽고 나서야 알게 된다.
+`check-certs.sh` 는 파일이 아니라 **실제로 서빙 중인 인증서**(`openssl s_client` 로
+`127.0.0.1:443`)를 보므로, 갱신은 됐지만 reload 가 안 된 상태까지 잡는다. 경고는
+이미 검증된 Postfix 릴레이로 `CERT_EMAIL` 에 보낸다.
+
+발급 전에는 조용히 넘어간다. 아직 HTTPS 로 전환하지 않은 단계에서 매일 경고가 오면
+진짜 경고를 무시하게 되기 때문이다.
+
+```bash
+/opt/ttokttok/bin/check-certs.sh          # 수동 확인
+tail -20 /opt/ttokttok/logs/certs.log
+docker logs --tail 50 ttokttok-certbot
 ```
 
 ## 앱 설정

--- a/deploy/bin/check-certs.sh
+++ b/deploy/bin/check-certs.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# 인증서 만료 감시. cron 이 매일 돌린다.
+#
+# 갱신은 ttokttok-certbot 컨테이너가 12시간마다 시도하지만, 실패해도 오류가
+# 컨테이너 로그로만 간다. 갱신은 만료 30일 전부터 시작하므로 실패가 누적되면
+# 30일 뒤 조용히 만료되고, HTTPS 가 죽고 나서야 알게 된다. 이 스크립트가
+# 그 사이에 사람에게 알리는 유일한 경로다.
+#
+#   check-certs.sh
+#
+set -Eeuo pipefail
+
+ROOT="${ROOT:-/opt/ttokttok}"
+ENV_FILE="$ROOT/app/.env"
+WARN_DAYS="${WARN_DAYS:-21}"   # 갱신 시작(30일)이 두 번 이상 실패해야 도달하는 값
+
+# shellcheck disable=SC1090
+set -a; . "$ENV_FILE"; set +a
+: "${DOMAIN:?.env 에 DOMAIN 이 필요하다}"
+: "${FILE_DOMAIN:?.env 에 FILE_DOMAIN 이 필요하다}"
+
+log() { printf '[check-certs] %s\n' "$*"; }
+
+# 발급 전이면 조용히 끝낸다. 아직 HTTPS 로 전환하지 않은 단계에서 매일 경고가
+# 오면 진짜 경고를 무시하게 된다.
+if ! compgen -G "$ROOT/data/certbot/conf/live/*/" >/dev/null; then
+    log "발급된 인증서 없음 — 건너뜀"
+    exit 0
+fi
+
+# 파일이 아니라 **실제로 서빙 중인 인증서**를 본다. 파일만 보면
+# "갱신은 됐지만 nginx 가 reload 되지 않아 옛 인증서를 계속 내보내는" 상태를
+# 놓친다. 클라이언트가 보는 것이 곧 진실이다.
+days_left() {
+    local host="$1" end
+    end="$(echo | openssl s_client -connect 127.0.0.1:443 -servername "$host" 2>/dev/null \
+           | openssl x509 -noout -enddate 2>/dev/null | cut -d= -f2)" || return 1
+    [[ -n "$end" ]] || return 1
+    echo $(( ( $(date -d "$end" +%s) - $(date +%s) ) / 86400 ))
+}
+
+problems=()
+for h in "$DOMAIN" "$FILE_DOMAIN"; do
+    if d="$(days_left "$h")"; then
+        log "$h: ${d}일 남음"
+        (( d < WARN_DAYS )) && problems+=("$h — 만료까지 ${d}일")
+    else
+        log "$h: 인증서를 읽지 못했다"
+        problems+=("$h — HTTPS 응답 없음 (nginx 중단 또는 설정 오류)")
+    fi
+done
+
+[[ ${#problems[@]} -eq 0 ]] && exit 0
+
+# ── 경고 메일 ───────────────────────────────────────────────────────────────
+TO="${CERT_EMAIL:-}"
+if [[ -z "$TO" ]]; then
+    log "CERT_EMAIL 이 비어 있어 메일을 보내지 못한다. 문제: ${problems[*]}"
+    exit 1
+fi
+
+# 컨테이너 안에서의 이름은 RELAY_USER 다 (compose 가 SMTP_RELAY_USER 를 바꿔 넘긴다).
+# 네이버는 인증 계정과 다른 From 을 거절하므로 반드시 이 값을 써야 한다.
+FROM="$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' ttokttok-smtp 2>/dev/null \
+        | grep '^RELAY_USER=' | cut -d= -f2- || true)"
+if [[ -z "$FROM" ]]; then
+    log "smtp 컨테이너에서 RELAY_USER 를 찾지 못했다. 문제: ${problems[*]}"
+    exit 1
+fi
+
+log "경고 메일 발송 → $TO"
+{
+    printf 'From: TtokTtok <%s>\n' "$FROM"
+    printf 'To: %s\n' "$TO"
+    printf 'Subject: [TtokTtok] HTTPS 인증서 경고\n'
+    printf 'Content-Type: text/plain; charset=UTF-8\n\n'
+    printf '자체 서버의 인증서 상태에 문제가 있다.\n\n'
+    printf '  - %s\n' "${problems[@]}"
+    printf '\n확인:\n'
+    printf '  docker logs --tail 50 ttokttok-certbot\n'
+    printf '  cd %s/app && docker compose exec -T nginx nginx -s reload\n' "$ROOT"
+    printf '  %s/bin/issue-cert.sh    # 재발급이 필요한 경우\n' "$ROOT"
+    printf '\n검사 시각: %s\n' "$(date '+%F %T %Z')"
+} | docker exec -i ttokttok-smtp sh -c "sendmail -f '$FROM' '$TO'"
+
+exit 1

--- a/deploy/bin/issue-cert.sh
+++ b/deploy/bin/issue-cert.sh
@@ -21,9 +21,15 @@ EMAIL="${CERT_EMAIL:-${1:-}}"
 
 cd "$ROOT/app"
 
+# 프로브는 certbot 이 실제로 쓰는 경로에 둬야 한다. nginx 는
+#   location /.well-known/acme-challenge/ { root /var/www/certbot; }
+# 이므로 /var/www/certbot/.well-known/acme-challenge/<파일> 을 찾는다. root 는 alias 와
+# 달리 요청 경로를 잘라내지 않는다. 웹루트 최상단에 두면 전부 정상이어도 404 다.
 probe="acme-probe-$$"
-echo ok > "$ROOT/data/certbot/www/$probe"
-trap 'rm -f "$ROOT/data/certbot/www/$probe"' EXIT
+probe_dir="$ROOT/data/certbot/www/.well-known/acme-challenge"
+mkdir -p "$probe_dir"
+echo ok > "$probe_dir/$probe"
+trap 'rm -f "$probe_dir/$probe"' EXIT
 
 for d in $SERVER_NAMES $FILE_SERVER_NAMES; do
     echo "[cert] 사전 점검: $d 의 ACME 경로가 외부에서 열려 있는지 확인"
@@ -56,3 +62,15 @@ issue "$FILE_DOMAIN" $FILE_SERVER_NAMES
 
 echo "[cert] 발급 완료. HTTPS 로 전환한다."
 "$ROOT/bin/nginx-apply.sh" --https
+
+# 갱신 데몬을 여기서 띄운다. compose 에 정의는 있지만 기동 목록에서 빠지기 쉽고,
+# 배포가 한 번도 없으면 deploy.sh 의 INFRA_SERVICES 도 실행되지 않는다.
+# 발급 직후가 갱신 경로를 세우기에 가장 자연스러운 지점이다.
+echo "[cert] 갱신 데몬 기동 (12시간 주기)"
+docker compose up -d certbot
+
+echo
+echo "갱신 체계:"
+echo "  - ttokttok-certbot   12시간마다 certbot renew (만료 30일 전부터 실제 갱신)"
+echo "  - cron 04:30         nginx reload (갱신된 인증서 반영)"
+echo "  - cron 05:00         check-certs.sh — 만료 임박 시 경고 메일"

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -61,6 +61,7 @@ install -m 0664 "$SRC/config/nginx/templates/https.conf"         "$ROOT/config/n
 install -m 0664 "$SRC/config/nginx/templates/minio-public.inc"   "$ROOT/config/nginx/templates/minio-public.inc"
 install -m 0775 "$SRC/bin/nginx-apply.sh"                        "$ROOT/bin/nginx-apply.sh"
 install -m 0775 "$SRC/bin/issue-cert.sh"                         "$ROOT/bin/issue-cert.sh"
+install -m 0775 "$SRC/bin/check-certs.sh"                        "$ROOT/bin/check-certs.sh"
 install -m 0775 "$SRC/bin/backup-db.sh"                          "$ROOT/bin/backup-db.sh"
 install -m 0775 "$SRC/bin/import-files.sh"                       "$ROOT/bin/import-files.sh"
 install -m 0775 "$SRC/init-db/01-app-user.sh"                    "$ROOT/init-db/01-app-user.sh"
@@ -150,13 +151,27 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 EOF
 chmod 0644 /etc/cron.d/ttokttok-backup
 
-# ── 10. certbot 갱신 후 nginx reload ─────────────────────────────────────
-cat > /etc/cron.d/ttokttok-nginx-reload <<EOF
+# ── 10. 인증서 갱신 체계 ─────────────────────────────────────────────────
+# 갱신 자체는 ttokttok-certbot 컨테이너가 12시간마다 시도한다(compose 정의).
+# 여기서 거는 것은 나머지 두 고리다.
+#
+#   04:30  reload — 갱신된 인증서를 nginx 가 실제로 내보내게 한다.
+#                   조건 없이 매일 돌린다. reload 는 graceful 이라 비용이 없고,
+#                   "갱신됐는데 reload 를 놓쳤다" 를 원천 차단하는 쪽이 싸다.
+#   05:00  감시  — 실제 서빙 중인 인증서의 남은 일수를 보고, 임계치 미만이면
+#                   메일로 알린다. 갱신 실패는 컨테이너 로그로만 가서 아무도
+#                   보지 않는다. 만료 30일 전부터 시도하므로, 알림이 없으면
+#                   실패가 30일간 누적된 뒤 조용히 만료된다.
+log "인증서 갱신 cron 등록 (reload 04:30, 만료 감시 05:00)"
+cat > /etc/cron.d/ttokttok-certs <<EOF
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 30 4 * * * $RUN_USER cd $ROOT/app && docker compose exec -T nginx nginx -s reload >/dev/null 2>&1
+0  5 * * * $RUN_USER $ROOT/bin/check-certs.sh >> $ROOT/logs/certs.log 2>&1
 EOF
-chmod 0644 /etc/cron.d/ttokttok-nginx-reload
+chmod 0644 /etc/cron.d/ttokttok-certs
+# 이름이 바뀌었으므로 옛 파일을 지운다. 남겨두면 reload 가 두 번 등록된다.
+rm -f /etc/cron.d/ttokttok-nginx-reload
 
 log "완료."
 echo
@@ -164,5 +179,6 @@ echo "다음 순서:"
 echo "  1) $ROOT/app/.env 값 채우기 (DOMAIN/FILE_DOMAIN, 비밀번호들, SMTP 릴레이 계정)"
 echo "  2) sudo -u $RUN_USER $ROOT/bin/nginx-apply.sh              # HTTP 설정 생성"
 echo "  3) cd $ROOT/app && docker compose up -d postgres redis minio minio-init smtp nginx"
+echo "     (certbot 갱신 데몬은 5) 의 issue-cert.sh 가 발급 직후 띄운다)"
 echo "  4) sudo -u $RUN_USER $ROOT/bin/import-files.sh <resources.tar>  # 기존 S3 파일 적재"
 echo "  5) sudo -u $RUN_USER $ROOT/bin/issue-cert.sh <이메일>       # 인증서 발급"


### PR DESCRIPTION
Closes #369

> base 가 `fix/#367` 입니다. #366 → #368 순으로 머지되면 base 를 develop 으로 바꿔 주세요.

## 1. 발급이 항상 사전점검에서 막히던 문제

프로브를 웹루트 최상단에 쓰고 `.well-known/acme-challenge/` 로 요청하고 있었다.
nginx 의 `root` 는 `alias` 와 달리 요청 경로를 잘라내지 않으므로
`/var/www/certbot/.well-known/acme-challenge/<파일>` 을 찾는다. 최상단 파일은 매칭되지
않아 **DNS·포트포워딩·nginx 가 전부 정상이어도 404 → exit 1** 이었다.

실측으로 확인했다.

```
# 최상단에 프로브
$ curl http://www.hearmeout.kr/.well-known/acme-challenge/probe-117545
HTTP 404

# certbot 이 실제로 쓰는 경로에 프로브
$ curl http://www.hearmeout.kr/.well-known/acme-challenge/probe-118xxx
ok
HTTP 200 / 연결 IP 110.35.178.38
```

## 2. 갱신 데몬이 기동되지 않던 문제

`certbot` 서비스는 compose 에 정의돼 있지만 README·setup.sh 의 기동 목록에 없었다.
`deploy.sh` 의 `INFRA_SERVICES` 에만 있어서 **첫 배포 전까지 갱신이 아예 돌지 않는다.**
발급 직후 `docker compose up -d certbot` 을 걸어 그 시점부터 갱신 경로가 서게 했다.

## 3. 갱신 실패를 알 수 없던 문제 — `bin/check-certs.sh`

`certbot renew --quiet` 의 오류는 컨테이너 로그로만 간다. 갱신은 만료 30일 전부터
시도하므로, 실패가 누적되면 30일 뒤 HTTPS 가 죽고 나서야 알게 된다.

매일 05:00 에 남은 일수를 확인하고 21일 미만이면 경고 메일을 보낸다. 21일은
갱신 시도가 두 번 이상 실패해야 도달하는 값이다.

**파일이 아니라 실제로 서빙 중인 인증서를 본다.**

```bash
openssl s_client -connect 127.0.0.1:443 -servername "$host" | openssl x509 -noout -enddate
```

파일만 보면 "갱신은 됐는데 nginx reload 를 놓쳐 옛 인증서를 계속 내보내는" 상태를
놓친다. 클라이언트가 보는 것이 진실이다. 인증서 파일 권한(`archive/` 0700) 문제도
함께 피한다.

발급 전에는 조용히 종료한다. HTTPS 전환 전 단계에서 매일 경고가 오면 진짜 경고를
무시하게 된다.

메일은 이미 검증된 Postfix 릴레이로 보낸다 (`status=sent` 확인 완료).
`From` 은 컨테이너의 `RELAY_USER` 를 읽어 쓴다 — 네이버는 인증 계정과 다른 From 을
거절한다.

## cron 정리

`ttokttok-nginx-reload` → `ttokttok-certs` 로 합치고, 옛 파일은 삭제한다.
남겨두면 reload 가 두 번 등록된다.

```
30 4 * * *  nginx -s reload
0  5 * * *  check-certs.sh >> logs/certs.log
```

## 검증

- `bash -n` : `check-certs.sh`, `issue-cert.sh`, `setup.sh`
- 만료일 추출 로직을 14일짜리 자체 서명 인증서로 확인

```
enddate: Aug 21 08:43:26 2026 GMT
남은 일수: 13
WARN_DAYS=21 미만인가: 예-경고발송
--- 연결 실패 경로 ---
빈 결과 → problems 에 기록됨 (의도대로)
```