### PR TITLE
[#367][#369] - develop 에 도달하지 못한 인프라 수정 5건 반영

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -16,6 +16,7 @@ EB → 자체 우분투 서버(`/opt/ttokttok`) 이관용 인프라 코드. 이�
 | `bin/nginx-apply.sh` | 도메인 치환 후 nginx 설정 적용 (`--https` 로 HTTPS 전환) |
 | `bin/issue-cert.sh` | Let's Encrypt 최초 발급 (API/파일 도메인 각각, 사전 도달성 점검 포함) |
 | `bin/import-files.sh` | 기존 S3 백업(`resources.tar`)을 MinIO 버킷에 적재 |
+| `bin/check-certs.sh` | 서빙 중인 인증서 만료 감시 → 임박 시 경고 메일 |
 | `bin/backup-db.sh` | 일일 pg_dump + 주간 파일 백업 |
 | `test/bluegreen-test.sh` | 앱 없이 배포·프록시 로직 검증 |
 
@@ -60,6 +61,34 @@ cd /opt/ttokttok/app && docker compose logs -f app-$(cat ./state)
 
 # MinIO 콘솔 / psql (외부 노출 없음. SSH 터널로만)
 ssh -L 19001:127.0.0.1:19001 -L 15432:127.0.0.1:15432 <서버>
+```
+
+## 인증서 갱신
+
+세 고리가 물려 돌아간다. 하나라도 빠지면 만료가 조용히 진행된다.
+
+| 주체 | 주기 | 하는 일 |
+|---|---|---|
+| `ttokttok-certbot` 컨테이너 | 12시간 | `certbot renew` — 만료 30일 전부터 실제 갱신 |
+| cron `04:30` | 매일 | `nginx -s reload` — 갱신된 인증서를 실제로 내보내게 |
+| cron `05:00` | 매일 | `check-certs.sh` — 남은 일수 확인, 21일 미만이면 경고 메일 |
+
+`reload` 는 조건 없이 매일 돈다. graceful 이라 비용이 없고, "갱신은 됐는데 reload 를
+놓쳤다"를 원천 차단하는 쪽이 조건 판정보다 싸다.
+
+**감시가 핵심이다.** `certbot renew --quiet` 의 오류는 컨테이너 로그로만 간다. 갱신은
+만료 30일 전부터 시도하므로, 실패가 누적되면 30일 뒤 HTTPS 가 죽고 나서야 알게 된다.
+`check-certs.sh` 는 파일이 아니라 **실제로 서빙 중인 인증서**(`openssl s_client` 로
+`127.0.0.1:443`)를 보므로, 갱신은 됐지만 reload 가 안 된 상태까지 잡는다. 경고는
+이미 검증된 Postfix 릴레이로 `CERT_EMAIL` 에 보낸다.
+
+발급 전에는 조용히 넘어간다. 아직 HTTPS 로 전환하지 않은 단계에서 매일 경고가 오면
+진짜 경고를 무시하게 되기 때문이다.
+
+```bash
+/opt/ttokttok/bin/check-certs.sh          # 수동 확인
+tail -20 /opt/ttokttok/logs/certs.log
+docker logs --tail 50 ttokttok-certbot
 ```
 
 ## 앱 설정

--- a/deploy/bin/check-certs.sh
+++ b/deploy/bin/check-certs.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# 인증서 만료 감시. cron 이 매일 돌린다.
+#
+# 갱신은 ttokttok-certbot 컨테이너가 12시간마다 시도하지만, 실패해도 오류가
+# 컨테이너 로그로만 간다. 갱신은 만료 30일 전부터 시작하므로 실패가 누적되면
+# 30일 뒤 조용히 만료되고, HTTPS 가 죽고 나서야 알게 된다. 이 스크립트가
+# 그 사이에 사람에게 알리는 유일한 경로다.
+#
+#   check-certs.sh
+#
+set -Eeuo pipefail
+
+ROOT="${ROOT:-/opt/ttokttok}"
+ENV_FILE="$ROOT/app/.env"
+WARN_DAYS="${WARN_DAYS:-21}"   # 갱신 시작(30일)이 두 번 이상 실패해야 도달하는 값
+
+# shellcheck disable=SC1090
+set -a; . "$ENV_FILE"; set +a
+: "${DOMAIN:?.env 에 DOMAIN 이 필요하다}"
+: "${FILE_DOMAIN:?.env 에 FILE_DOMAIN 이 필요하다}"
+
+log() { printf '[check-certs] %s\n' "$*"; }
+
+# 발급 전이면 조용히 끝낸다. 아직 HTTPS 로 전환하지 않은 단계에서 매일 경고가
+# 오면 진짜 경고를 무시하게 된다.
+if ! compgen -G "$ROOT/data/certbot/conf/live/*/" >/dev/null; then
+    log "발급된 인증서 없음 — 건너뜀"
+    exit 0
+fi
+
+# 파일이 아니라 **실제로 서빙 중인 인증서**를 본다. 파일만 보면
+# "갱신은 됐지만 nginx 가 reload 되지 않아 옛 인증서를 계속 내보내는" 상태를
+# 놓친다. 클라이언트가 보는 것이 곧 진실이다.
+days_left() {
+    local host="$1" end
+    end="$(echo | openssl s_client -connect 127.0.0.1:443 -servername "$host" 2>/dev/null \
+           | openssl x509 -noout -enddate 2>/dev/null | cut -d= -f2)" || return 1
+    [[ -n "$end" ]] || return 1
+    echo $(( ( $(date -d "$end" +%s) - $(date +%s) ) / 86400 ))
+}
+
+problems=()
+for h in "$DOMAIN" "$FILE_DOMAIN"; do
+    if d="$(days_left "$h")"; then
+        log "$h: ${d}일 남음"
+        (( d < WARN_DAYS )) && problems+=("$h — 만료까지 ${d}일")
+    else
+        log "$h: 인증서를 읽지 못했다"
+        problems+=("$h — HTTPS 응답 없음 (nginx 중단 또는 설정 오류)")
+    fi
+done
+
+[[ ${#problems[@]} -eq 0 ]] && exit 0
+
+# ── 경고 메일 ───────────────────────────────────────────────────────────────
+TO="${CERT_EMAIL:-}"
+if [[ -z "$TO" ]]; then
+    log "CERT_EMAIL 이 비어 있어 메일을 보내지 못한다. 문제: ${problems[*]}"
+    exit 1
+fi
+
+# 컨테이너 안에서의 이름은 RELAY_USER 다 (compose 가 SMTP_RELAY_USER 를 바꿔 넘긴다).
+# 네이버는 인증 계정과 다른 From 을 거절하므로 반드시 이 값을 써야 한다.
+FROM="$(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' ttokttok-smtp 2>/dev/null \
+        | grep '^RELAY_USER=' | cut -d= -f2- || true)"
+if [[ -z "$FROM" ]]; then
+    log "smtp 컨테이너에서 RELAY_USER 를 찾지 못했다. 문제: ${problems[*]}"
+    exit 1
+fi
+
+log "경고 메일 발송 → $TO"
+{
+    printf 'From: TtokTtok <%s>\n' "$FROM"
+    printf 'To: %s\n' "$TO"
+    printf 'Subject: [TtokTtok] HTTPS 인증서 경고\n'
+    printf 'Content-Type: text/plain; charset=UTF-8\n\n'
+    printf '자체 서버의 인증서 상태에 문제가 있다.\n\n'
+    printf '  - %s\n' "${problems[@]}"
+    printf '\n확인:\n'
+    printf '  docker logs --tail 50 ttokttok-certbot\n'
+    printf '  cd %s/app && docker compose exec -T nginx nginx -s reload\n' "$ROOT"
+    printf '  %s/bin/issue-cert.sh    # 재발급이 필요한 경우\n' "$ROOT"
+    printf '\n검사 시각: %s\n' "$(date '+%F %T %Z')"
+} | docker exec -i ttokttok-smtp sh -c "sendmail -f '$FROM' '$TO'"
+
+exit 1

--- a/deploy/bin/check-certs.sh
+++ b/deploy/bin/check-certs.sh
@@ -24,8 +24,15 @@ log() { printf '[check-certs] %s\n' "$*"; }
 
 # 발급 전이면 조용히 끝낸다. 아직 HTTPS 로 전환하지 않은 단계에서 매일 경고가
 # 오면 진짜 경고를 무시하게 된다.
-if ! compgen -G "$ROOT/data/certbot/conf/live/*/" >/dev/null; then
-    log "발급된 인증서 없음 — 건너뜀"
+#
+# 판정 기준은 인증서 파일이 아니라 **적용된 nginx 설정**이다. certbot 이 live/ 를
+# 0700 root 로 만들어서 ttokttokuser 는 그 안을 들여다볼 수 없다. 파일로 판정하면
+# 발급이 끝난 뒤에도 영영 "없음" 으로 보고 감시가 한 번도 돌지 않는다.
+# nginx 설정에 ssl_certificate 가 있다는 것은 nginx-apply.sh --https 가 성공했다는
+# 뜻이고, 그때부터가 감시할 가치가 있는 구간이다.
+NGINX_CONF="$ROOT/config/nginx/conf.d/ttokttok.conf"
+if ! grep -q '^\s*ssl_certificate' "$NGINX_CONF" 2>/dev/null; then
+    log "HTTPS 미전환 상태 — 건너뜀"
     exit 0
 fi
 

--- a/deploy/bin/issue-cert.sh
+++ b/deploy/bin/issue-cert.sh
@@ -21,9 +21,15 @@ EMAIL="${CERT_EMAIL:-${1:-}}"
 
 cd "$ROOT/app"
 
+# 프로브는 certbot 이 실제로 쓰는 경로에 둬야 한다. nginx 는
+#   location /.well-known/acme-challenge/ { root /var/www/certbot; }
+# 이므로 /var/www/certbot/.well-known/acme-challenge/<파일> 을 찾는다. root 는 alias 와
+# 달리 요청 경로를 잘라내지 않는다. 웹루트 최상단에 두면 전부 정상이어도 404 다.
 probe="acme-probe-$$"
-echo ok > "$ROOT/data/certbot/www/$probe"
-trap 'rm -f "$ROOT/data/certbot/www/$probe"' EXIT
+probe_dir="$ROOT/data/certbot/www/.well-known/acme-challenge"
+mkdir -p "$probe_dir"
+echo ok > "$probe_dir/$probe"
+trap 'rm -f "$probe_dir/$probe"' EXIT
 
 for d in $SERVER_NAMES $FILE_SERVER_NAMES; do
     echo "[cert] 사전 점검: $d 의 ACME 경로가 외부에서 열려 있는지 확인"
@@ -56,3 +62,15 @@ issue "$FILE_DOMAIN" $FILE_SERVER_NAMES
 
 echo "[cert] 발급 완료. HTTPS 로 전환한다."
 "$ROOT/bin/nginx-apply.sh" --https
+
+# 갱신 데몬을 여기서 띄운다. compose 에 정의는 있지만 기동 목록에서 빠지기 쉽고,
+# 배포가 한 번도 없으면 deploy.sh 의 INFRA_SERVICES 도 실행되지 않는다.
+# 발급 직후가 갱신 경로를 세우기에 가장 자연스러운 지점이다.
+echo "[cert] 갱신 데몬 기동 (12시간 주기)"
+docker compose up -d certbot
+
+echo
+echo "갱신 체계:"
+echo "  - ttokttok-certbot   12시간마다 certbot renew (만료 30일 전부터 실제 갱신)"
+echo "  - cron 04:30         nginx reload (갱신된 인증서 반영)"
+echo "  - cron 05:00         check-certs.sh — 만료 임박 시 경고 메일"

--- a/deploy/bin/issue-cert.sh
+++ b/deploy/bin/issue-cert.sh
@@ -21,15 +21,23 @@ EMAIL="${CERT_EMAIL:-${1:-}}"
 
 cd "$ROOT/app"
 
-# 프로브는 certbot 이 실제로 쓰는 경로에 둬야 한다. nginx 는
+# 프로브 파일에는 조건이 둘 있다.
+#
+# 경로: certbot 이 실제로 쓰는 자리에 둬야 한다. nginx 는
 #   location /.well-known/acme-challenge/ { root /var/www/certbot; }
 # 이므로 /var/www/certbot/.well-known/acme-challenge/<파일> 을 찾는다. root 는 alias 와
 # 달리 요청 경로를 잘라내지 않는다. 웹루트 최상단에 두면 전부 정상이어도 404 다.
+#
+# 쓰는 주체: 호스트가 아니라 certbot 컨테이너다. certbot 은 컨테이너 안에서 root 로
+# 돌면서 .well-known/acme-challenge/ 를 만든다. 그 뒤로 그 디렉터리는 root 소유가 되고,
+# ttokttokuser 로 실행되는 이 스크립트는 거기에 파일을 만들 수 없다 — 재발급할 때마다
+# "허가 거부" 로 막힌다. 컨테이너는 같은 웹루트를 rw 로 마운트하고 root 로 도므로
+# 호스트 소유권과 무관하게 항상 쓸 수 있다.
 probe="acme-probe-$$"
-probe_dir="$ROOT/data/certbot/www/.well-known/acme-challenge"
-mkdir -p "$probe_dir"
-echo ok > "$probe_dir/$probe"
-trap 'rm -f "$probe_dir/$probe"' EXIT
+webroot_sh() { docker compose run --rm --entrypoint sh certbot -c "$1"; }
+webroot_sh "mkdir -p /var/www/certbot/.well-known/acme-challenge \
+            && echo ok > /var/www/certbot/.well-known/acme-challenge/$probe" >/dev/null
+trap 'webroot_sh "rm -f /var/www/certbot/.well-known/acme-challenge/'"$probe"'" >/dev/null 2>&1 || true' EXIT
 
 # 이름 해석은 공개 리졸버에 직접 묻는다. 로컬 리졸버(systemd-resolved → ISP)가
 # 죽어 있어도 Let's Encrypt 는 자기 리졸버로 우리를 찾으므로, 로컬 해석 실패는

--- a/deploy/bin/issue-cert.sh
+++ b/deploy/bin/issue-cert.sh
@@ -31,11 +31,35 @@ mkdir -p "$probe_dir"
 echo ok > "$probe_dir/$probe"
 trap 'rm -f "$probe_dir/$probe"' EXIT
 
+# 이름 해석은 공개 리졸버에 직접 묻는다. 로컬 리졸버(systemd-resolved → ISP)가
+# 죽어 있어도 Let's Encrypt 는 자기 리졸버로 우리를 찾으므로, 로컬 해석 실패는
+# 발급 가능 여부와 아무 상관이 없다. 실제로 네임서버 변경 직후 ISP 리졸버가
+# 오래된 SERVFAIL 을 붙들고 있어 발급이 막히는 일이 있었다. 여기서 확인하려는 것은
+# "공개 DNS 가 가리키는 곳이 우리 nginx 인가" 이지 "이 PC 가 이름을 풀 수 있는가"
+# 가 아니다. DoH 를 쓰는 이유는 dig 의존성을 늘리지 않기 위해서다 (curl 은 이미 쓴다).
+resolve_public() {
+    local host="$1" r ip
+    for r in 1.1.1.1 8.8.8.8 9.9.9.9; do
+        ip="$(curl -fsS --max-time 6 -H 'accept: application/dns-json' \
+                "https://${r}/dns-query?name=${host}&type=A" 2>/dev/null \
+              | grep -oE '"data":"[0-9]{1,3}(\.[0-9]{1,3}){3}"' | tail -1 | cut -d'"' -f4)" || true
+        [[ -n "$ip" ]] && { echo "$ip"; return 0; }
+    done
+    return 1
+}
+
 for d in $SERVER_NAMES $FILE_SERVER_NAMES; do
     echo "[cert] 사전 점검: $d 의 ACME 경로가 외부에서 열려 있는지 확인"
-    if ! curl -fsS --max-time 10 "http://${d}/.well-known/acme-challenge/${probe}" | grep -q ok; then
-        echo "[cert] 실패: http://${d}/.well-known/acme-challenge/ 로 외부 접근이 안 된다." >&2
-        echo "       DNS A 레코드와 공유기 80 포트 포워딩을 먼저 확인할 것." >&2
+    if ! ip="$(resolve_public "$d")"; then
+        echo "[cert] 실패: 공개 DNS 가 $d 의 A 레코드를 돌려주지 않는다." >&2
+        echo "       네임서버 위임과 A/CNAME 레코드를 먼저 확인할 것." >&2
+        exit 1
+    fi
+    echo "[cert]   공개 DNS 해석: $d → $ip"
+    if ! curl -fsS --max-time 10 --resolve "${d}:80:${ip}" \
+              "http://${d}/.well-known/acme-challenge/${probe}" | grep -q ok; then
+        echo "[cert] 실패: http://${d}/.well-known/acme-challenge/ 로 접근이 안 된다 (→ $ip)." >&2
+        echo "       공유기 80 포트 포워딩과 nginx 상태를 확인할 것." >&2
         exit 1
     fi
 done

--- a/deploy/bin/nginx-apply.sh
+++ b/deploy/bin/nginx-apply.sh
@@ -37,9 +37,15 @@ render() {
 
 if [[ "${1:-}" == "--https" ]]; then
     src="$TPL_DIR/https.conf"
+    # 존재 확인은 컨테이너 안에서 한다. certbot 은 live/ 와 archive/ 를 0700 root 로
+    # 만들기 때문에, 호스트에서 ttokttokuser 로 stat 하면 발급이 정상으로 끝났어도
+    # "없음" 으로 보인다. 실제로 이 인증서를 읽는 주체는 nginx 컨테이너(root)이고,
+    # 거기서 읽히는지가 유일하게 의미 있는 판정이다.
     for d in "$DOMAIN" "$FILE_DOMAIN"; do
-        cert="$ROOT/data/certbot/conf/live/$d/fullchain.pem"
-        [[ -f "$cert" ]] || { echo "인증서가 없다: $cert — 먼저 issue-cert.sh 를 실행해야 한다" >&2; exit 1; }
+        docker run --rm --entrypoint test \
+            -v "$ROOT/data/certbot/conf:/etc/letsencrypt:ro" \
+            certbot/certbot:latest -f "/etc/letsencrypt/live/$d/fullchain.pem" \
+          || { echo "인증서가 없다: live/$d/fullchain.pem — 먼저 issue-cert.sh 를 실행해야 한다" >&2; exit 1; }
     done
 else
     src="$TPL_DIR/http-only.conf"

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -21,7 +21,10 @@ log() { printf '\033[36m[setup]\033[0m %s\n' "$*"; }
 # /opt 은 루트 파티션(46G 중 34G 여유)이라 DB+업로드가 쌓이면 위험하다.
 log "데이터 디렉터리: $DATA_SRC"
 mkdir -p "$DATA_SRC"/{postgres,redis,minio,certbot/conf,certbot/www}
-chown -R "$RUN_USER:$RUN_GROUP" "$DATA_SRC"
+# 디렉터리 자체만 chown 한다. -R 을 쓰면 실행 중인 컨테이너의 데이터 파일까지
+# 소유권이 바뀐다 — 6단계 주석 참고.
+chown "$RUN_USER:$RUN_GROUP" \
+      "$DATA_SRC" "$DATA_SRC"/{postgres,redis,minio,certbot,certbot/conf,certbot/www}
 
 # ── 2. /opt/ttokttok 구조 ────────────────────────────────────────────────
 log "디렉터리 구조 생성"
@@ -79,9 +82,24 @@ fi
 # ── 6. 소유권/권한 ───────────────────────────────────────────────────────
 # setgid(2775): ttokttok-cicd 가 만든 파일도 ttokttok 그룹을 상속 →
 # ttokttokuser 와 파일을 주고받을 수 있다.
+#
+# data/ 안쪽은 건드리지 않는다. 거기는 각 컨테이너가 자기 uid 로 소유하는 영역이고,
+# 호스트에서 소유권을 강제할 이유가 없다. 반대로 강제하면 실행 중인 서비스가 깨진다 —
+# postgres 는 user: 지정 없이 내부 uid 70 으로 도는데, PGDATA 를 1001:1003 으로
+# 바꾸는 순간 자기 파일을 못 읽고 PANIC 한다.
+#
+#   FATAL: could not open file "global/pg_filenode.map": Permission denied
+#   PANIC: could not open file "global/pg_control": Permission denied
+#
+# 이 스크립트는 멱등이라 스택이 뜬 상태에서도 재실행될 수 있으므로 실제로 일어난다.
+# postgres 는 엔트리포인트가 root 로 시작하면서 PGDATA 를 다시 chown 해 복구하지만,
+# 그건 이 이미지의 우연한 성질이다. redis/minio 에는 그런 복구 경로가 없다.
+#
+# 마운트 포인트($ROOT/data) 자체는 제외하지 않는다. 그건 /home 쪽 디렉터리 하나이고
+# 1단계에서 이미 같은 소유권으로 맞춰둔다.
 log "소유권/권한 설정"
-chown -R "$RUN_USER:$RUN_GROUP" "$ROOT"
-find "$ROOT" -type d -not -path "$ROOT/data/*" -exec chmod 2775 {} +
+find "$ROOT" -path "$ROOT/data/*" -prune -o -exec chown "$RUN_USER:$RUN_GROUP" {} +
+find "$ROOT" -path "$ROOT/data/*" -prune -o -type d -exec chmod 2775 {} +
 chmod 0660 "$ROOT/app/.env"
 chmod 0770 "$ROOT/config/app"     # 시크릿(application-prod.yml, firebase.json)
 

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -61,6 +61,7 @@ install -m 0664 "$SRC/config/nginx/templates/https.conf"         "$ROOT/config/n
 install -m 0664 "$SRC/config/nginx/templates/minio-public.inc"   "$ROOT/config/nginx/templates/minio-public.inc"
 install -m 0775 "$SRC/bin/nginx-apply.sh"                        "$ROOT/bin/nginx-apply.sh"
 install -m 0775 "$SRC/bin/issue-cert.sh"                         "$ROOT/bin/issue-cert.sh"
+install -m 0775 "$SRC/bin/check-certs.sh"                        "$ROOT/bin/check-certs.sh"
 install -m 0775 "$SRC/bin/backup-db.sh"                          "$ROOT/bin/backup-db.sh"
 install -m 0775 "$SRC/bin/import-files.sh"                       "$ROOT/bin/import-files.sh"
 install -m 0775 "$SRC/init-db/01-app-user.sh"                    "$ROOT/init-db/01-app-user.sh"
@@ -150,13 +151,27 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 EOF
 chmod 0644 /etc/cron.d/ttokttok-backup
 
-# ── 10. certbot 갱신 후 nginx reload ─────────────────────────────────────
-cat > /etc/cron.d/ttokttok-nginx-reload <<EOF
+# ── 10. 인증서 갱신 체계 ─────────────────────────────────────────────────
+# 갱신 자체는 ttokttok-certbot 컨테이너가 12시간마다 시도한다(compose 정의).
+# 여기서 거는 것은 나머지 두 고리다.
+#
+#   04:30  reload — 갱신된 인증서를 nginx 가 실제로 내보내게 한다.
+#                   조건 없이 매일 돌린다. reload 는 graceful 이라 비용이 없고,
+#                   "갱신됐는데 reload 를 놓쳤다" 를 원천 차단하는 쪽이 싸다.
+#   05:00  감시  — 실제 서빙 중인 인증서의 남은 일수를 보고, 임계치 미만이면
+#                   메일로 알린다. 갱신 실패는 컨테이너 로그로만 가서 아무도
+#                   보지 않는다. 만료 30일 전부터 시도하므로, 알림이 없으면
+#                   실패가 30일간 누적된 뒤 조용히 만료된다.
+log "인증서 갱신 cron 등록 (reload 04:30, 만료 감시 05:00)"
+cat > /etc/cron.d/ttokttok-certs <<EOF
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 30 4 * * * $RUN_USER cd $ROOT/app && docker compose exec -T nginx nginx -s reload >/dev/null 2>&1
+0  5 * * * $RUN_USER $ROOT/bin/check-certs.sh >> $ROOT/logs/certs.log 2>&1
 EOF
-chmod 0644 /etc/cron.d/ttokttok-nginx-reload
+chmod 0644 /etc/cron.d/ttokttok-certs
+# 이름이 바뀌었으므로 옛 파일을 지운다. 남겨두면 reload 가 두 번 등록된다.
+rm -f /etc/cron.d/ttokttok-nginx-reload
 
 log "완료."
 echo
@@ -164,5 +179,6 @@ echo "다음 순서:"
 echo "  1) $ROOT/app/.env 값 채우기 (DOMAIN/FILE_DOMAIN, 비밀번호들, SMTP 릴레이 계정)"
 echo "  2) sudo -u $RUN_USER $ROOT/bin/nginx-apply.sh              # HTTP 설정 생성"
 echo "  3) cd $ROOT/app && docker compose up -d postgres redis minio minio-init smtp nginx"
+echo "     (certbot 갱신 데몬은 5) 의 issue-cert.sh 가 발급 직후 띄운다)"
 echo "  4) sudo -u $RUN_USER $ROOT/bin/import-files.sh <resources.tar>  # 기존 S3 파일 적재"
 echo "  5) sudo -u $RUN_USER $ROOT/bin/issue-cert.sh <이메일>       # 인증서 발급"


### PR DESCRIPTION
#367, #369 의 나머지를 develop 으로 올립니다.

## 왜 별도 PR 인가

base 를 서로에게 걸어둔 탓에 머지 순서가 엇갈려 develop 까지 도달하지 못했습니다.

| 브랜치 | develop 대비 내용 |
|---|---|
| `fix/#365` | #367 만 (#368 머지) |
| `fix/#367` | #367 + #369 첫 커밋만 (#370 이 나중 커밋 3개 push 전에 머지됨) |
| `fix/#369` | #367 + #369 4개 전부 ← 이 PR |

`#368`, `#370` 은 이미 MERGED 라 재사용할 수 없어 새로 엽니다. 내용은 그 둘의
합집합에 나중 커밋 3개를 더한 것이고, 새로 작성한 코드는 없습니다.

## 담긴 커밋

| 커밋 | 내용 |
|---|---|
| `a863df5` | #367 — 재귀 chown 이 실행 중인 컨테이너 데이터를 건드리지 않게 |
| `ea7f8f7` | #369 — 발급 사전점검 경로 수정 + 갱신 감시(`check-certs.sh`) 추가 |
| `7d04d44` | #369 — 사전점검이 로컬 리졸버 대신 공개 DNS 를 쓰게 |
| `34a3604` | #369 — 사전점검 프로브를 certbot 컨테이너로 쓰게 |
| `f7a2967` | #369 — 인증서 존재 확인을 호스트가 아닌 컨테이너에서 |

## 실서버 검증 완료

이 브랜치 그대로 `/opt/ttokttok` 에 적용해 전 구간을 확인했습니다.

- 인증서 2장 발급 (Let's Encrypt YE1, 만료 2026-11-05)
- TLS 체인 검증 `Verify return code: 0`, HTTP/2, HSTS `max-age=31536000`
- HTTP → HTTPS `301` (두 도메인)
- **MinIO 오브젝트 151개 전부 HTTPS 로 200** (비200 0건)
- 버킷 리스팅 / PUT 모두 `403`
- 404 응답에 캐시 헤더 없음 (#359 수정 동작 확인)
- `ttokttok-certbot` running, `restart=unless-stopped`
- 만료 감시 게이트 통과 → 89일 남음 → 조용히 종료
- 재귀 chown 수정 후 `setup.sh` 재실행 시 postgres `healthy` 유지

## 뒤에 남은 브랜치

`fix/#365`, `fix/#367` 은 이 PR 이 머지되면 develop 에 모두 포함되므로 삭제해도 됩니다.