### PR TITLE
[#372] - 앱 컨테이너 UID/GID 를 호스트와 맞춰 고정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,18 @@ RUN ./gradlew bootJar -x test --no-daemon
 FROM eclipse-temurin:17-jre-alpine
 WORKDIR /app
 
-RUN addgroup -S ttokttok && adduser -S -G ttokttok ttokttok
+# UID/GID 를 호스트와 같은 값으로 고정한다. adduser -S 에 맡기면 Alpine 이 100 부터
+# 자동 할당하는데, 그러면 마운트되는 /app/config 를 읽지 못한다 —
+# setup.sh 가 그 디렉터리를 ttokttokuser(1001):ttokttok(1003) 0770 으로 두고,
+# CI(ttokttok-cicd, 1002)가 설정 파일을 0640 으로 배치하기 때문이다.
+#
+# 더 나쁜 것은 실패가 조용하다는 점이다. Spring 의 기본 탐색 경로는
+# optional:file:./config/ 라 읽을 수 없으면 예외 없이 건너뛴다. 설정이 통째로
+# 무시된 채 기동하다가 한참 뒤 첫 플레이스홀더(jwt.secret)에서 터진다.
+#
+# 파일 권한을 0644 로 넓히는 방법도 있지만, 여기 들어 있는 것은 JWT 시크릿과
+# Firebase 서비스 계정 키다. MinIO 를 user: "1001:1003" 으로 고정한 것과 같은 판단.
+RUN addgroup -g 1003 -S ttokttok && adduser -u 1001 -S -G ttokttok ttokttok
 
 # bootJar 는 실행 가능한 부트 jar 하나만 만든다(`build` 와 달리 *-plain.jar 를 만들지 않는다).
 COPY --from=builder /build/build/libs/*-SNAPSHOT.jar app.jar


### PR DESCRIPTION
Closes #372

## 증상

첫 실배포([run 31164201021](https://github.com/SMU-TtokTtok/backend/actions/runs/31164201021))에서 앱이 크래시 루프를 돌고 배포가 중단됐다.

```
Caused by: org.springframework.util.PlaceholderResolutionException:
  Could not resolve placeholder 'jwt.secret' in value "${jwt.secret}"
```

`jwt.secret` 은 `application-prod.yml` 85행에 정상적으로 있고, 서버에 배치된 파일도
바이트 단위로 동일하다(4934 바이트 / 127행). `spring.profiles.active: prod` 도 정상.

## 원인 — 설정 파일이 아예 읽히지 않았다

```
$ docker run --rm --entrypoint sh ttokttok:16b5ee5 -c 'id ttokttok'
uid=100(ttokttok) gid=101(ttokttok)

$ ls -ln /opt/ttokttok/config/app
drwxrws---  2 1001 1003   .                     ← 디렉터리 0770
-rw-r-----  1 1002 1003   application-prod.yml  ← 파일 0640

$ docker run --rm -v /opt/ttokttok/config/app:/app/config:ro \
    --entrypoint sh ttokttok:16b5ee5 -c 'cat /app/config/application.yml'
cat: /app/config/application.yml: Permission denied
```

`Dockerfile` 이 `adduser -S` 로 사용자를 만들어 Alpine 이 UID 를 100 부터 자동
할당한다. `setup.sh` 는 `/opt/ttokttok` 을 `ttokttokuser(1001):ttokttok(1003)` 로 두고,
CI(`ttokttok-cicd`, 1002)가 설정 파일을 `0640` 으로 배치한다. 셋 다 각자 의도대로
동작하지만 서로 맞지 않는다.

## 왜 진단이 어려웠는가

Spring Boot 의 기본 설정 탐색 경로는 `optional:file:./config/` 다. `optional:` 이라
**읽을 수 없으면 예외 없이 건너뛴다.** "설정을 못 읽었다"가 아니라, 설정이 통째로
무시된 채 기동하다가 한참 뒤 첫 플레이스홀더에서 터진다. 원인과 증상이 멀다.

## 조치

```diff
-RUN addgroup -S ttokttok && adduser -S -G ttokttok ttokttok
+RUN addgroup -g 1003 -S ttokttok && adduser -u 1001 -S -G ttokttok ttokttok
```

- 디렉터리 `0770 1001:1003` → 소유자로서 접근
- 파일 `0640 1002:1003` → 그룹으로서 읽기

파일 권한을 `0644` 로 넓히는 선택지도 있지만, 여기 들어 있는 것은 JWT 시크릿과
Firebase 서비스 계정 키다. MinIO 를 `user: "1001:1003"` 으로 고정한 것과 같은 판단이고
README 에 그 선례가 적혀 있다.

## 검증

동일한 사용자 생성 구문으로 이미지를 만들어 **실제 운영 설정 디렉터리**를 마운트해 확인했다.

```
uid=1001(ttokttok) gid=1003(ttokttok) groups=1003(ttokttok)

$ cat /app/config/application.yml
spring:
  profiles:
    active: prod
$ head -1 /app/config/application-prod.yml
# 운영용 yml (prod 프로필)
$ head -c 40 /app/config/ttokttok-push-firebase-adminsdk-....json
{
  "type": "service_account",
  "projec
```

세 파일 모두 읽힌다.