### PR TITLE
[#374] - 스모크 테스트가 공개 DNS 로 해석하게

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -78,11 +78,35 @@ jobs:
         run: $TTOK_ROOT/app/deploy.sh "${{ steps.image.outputs.tag }}"
 
       - name: Smoke test
+        env:
+          DOMAIN: ${{ secrets.SERVICE_DOMAIN }}
         run: |
           set -euo pipefail
+          # 이름 해석은 공개 리졸버에 직접 묻고, 그 IP 로 --resolve 한다.
+          #
+          # 확인하려는 것은 "공개된 서비스가 실제로 200 을 주는가" 이지 "러너가 도는
+          # 이 PC 가 이름을 풀 수 있는가" 가 아니다. 그런데 이 PC 의 systemd-resolved
+          # 업스트림 두 개 중 하나가 SERVFAIL 을 내고 있어서, 캐시가 만료된 순간에
+          # 걸리면 배포가 멀쩡히 끝났는데도 curl 이 종료코드 6(Could not resolve host)
+          # 으로 죽는다. 실제로 그렇게 실패한 적이 있다. 검증 대상이 아닌 것이
+          # 실패 지점으로 들어와 있으면 진짜 실패를 가린다.
+          #
+          # 공개 DNS → 공유기 → nginx → 앱 경로는 그대로 검증된다.
+          # dig 의존성을 늘리지 않으려고 DoH 를 쓴다(curl 은 어차피 쓴다).
+          ip=""
+          for r in 1.1.1.1 8.8.8.8 9.9.9.9; do
+            ip="$(curl -fsS --max-time 6 -H 'accept: application/dns-json' \
+                    "https://${r}/dns-query?name=${DOMAIN}&type=A" 2>/dev/null \
+                  | grep -oE '"data":"[0-9]{1,3}(\.[0-9]{1,3}){3}"' | tail -1 | cut -d'"' -f4)" || true
+            [ -n "$ip" ] && break
+          done
+          [ -n "$ip" ] || { echo "::error::공개 DNS 가 $DOMAIN 의 A 레코드를 돌려주지 않는다"; exit 1; }
+          echo "공개 DNS 해석: $DOMAIN → $ip"
+
           # 이 앱에는 actuator 의존성이 없다. /health 가 공개 헬스 엔드포인트다.
           for _ in $(seq 1 10); do
-            code=$(curl -s -o /dev/null -w '%{http_code}' "https://${{ secrets.SERVICE_DOMAIN }}/health")
+            code=$(curl -s -o /dev/null -w '%{http_code}' \
+                     --resolve "${DOMAIN}:443:${ip}" "https://${DOMAIN}/health")
             [ "$code" = "200" ] || { echo "예상 200, 실제 $code"; exit 1; }
             sleep 1
           done


### PR DESCRIPTION
Closes #374

## 증상

앱이 정상 기동해 트래픽 전환까지 끝났는데 스모크 테스트에서 배포가 실패했다.
([run 31165720674](https://github.com/SMU-TtokTtok/backend/actions/runs/31165720674))

```
##[error]Process completed with exit code 6
```

`curl` 종료코드 6 = **Could not resolve host**. 서비스는 멀쩡했다.

```
$ curl http://127.0.0.1:18081/health    → 200 {"status":"Healthy"}
$ curl https://www.hearmeout.kr/health  → 200 {"status":"Healthy"}
state=blue, ttokttok-app-blue: Up (healthy)
```

## 원인

러너가 도는 PC 의 `systemd-resolved` 업스트림 두 개 중 하나가 고장나 있다.

```
$ dig @111.118.0.11 www.hearmeout.kr
status: SERVFAIL

$ resolvectl query www.hearmeout.kr
110.35.178.38            ← 캐시가 살아 있는 동안은 정상 (20/20 성공)
```

캐시가 만료된 뒤 고장난 업스트림을 고르면 실패한다. 네임서버를 가비아로 옮긴
직후부터 관측됐고, 인증서 사전점검도 같은 이유로 막혀 #369 에서 한 번 고쳤다.

## 왜 고치는가

스모크 테스트가 확인하려는 것은 **"공개된 서비스가 200 을 주는가"** 다.
이 PC 가 이름을 풀 수 있는지는 그 질문과 무관한데, 실패 지점으로만 들어와 있다.
배포가 성공했는데 CI 가 빨갛게 되는 것은 진짜 실패를 가리는 노이즈다.

## 조치

공개 리졸버에 DoH 로 A 레코드를 묻고 그 IP 로 `curl --resolve` 한다.
공개 DNS → 공유기 → nginx → 앱 경로는 그대로 검증되고, 로컬 재귀만 빠진다.
`#369` 의 `issue-cert.sh` 와 같은 방식이다.

## 검증

`.github/workflows/ci-cd.yml` YAML 파싱 확인 후, 스크립트 본문을 그대로 실행했다.

```
공개 DNS 해석: www.hearmeout.kr → 110.35.178.38
200 200 200 200 200 200 200 200 200 200
```