### PR TITLE
[#376] - upstream.conf 바인드 마운트가 끊겨도 배포가 성공으로 끝나던 문제

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -151,6 +151,25 @@ Postfix 는 `mynetworks` 안에서 오는 요청을 인증 없이 받으므로 �
   `/actuator/health` 는 404 다. `/health` 는 `SecurityWhiteList` 에 등록된 공개 경로다.
 - **`upstream.conf` 는 단일 파일 바인드 마운트**다. `sed -i` 처럼 inode 를 바꾸는 방식으로
   고치면 컨테이너가 옛 파일을 계속 본다. `deploy.sh` 는 truncate-write 를 쓴다.
+  `install`·`cp`·일부 편집기의 저장도 전부 교체로 동작하니 같은 함정이다. 그래서
+  `setup.sh` 는 이 파일만 "없을 때만 생성" 으로 다루고, `deploy.sh` 는 전환 직후
+  컨테이너가 새 내용을 실제로 보는지 확인한 뒤에야 구 색을 정리한다.
+
+  inode 가 갈리면 전환 절차가 **전부 성공한 것처럼 끝난다.** 컨테이너 입장에서는
+  내용이 안 바뀌었으니 `nginx -t` 도 `reload` 도 통과하고, 구 색을 정리하는 순간
+  전 요청이 502 가 된다. 배포는 초록인데 사이트만 죽는다. 복구는 nginx 재생성이다.
+
+  ```bash
+  # 호스트와 컨테이너가 같은 것을 보는지
+  cat /opt/ttokttok/config/nginx/upstream.conf
+  docker exec ttokttok-nginx cat /etc/nginx/upstream.conf
+  # 다르면
+  cd /opt/ttokttok/app && docker compose up -d --force-recreate nginx
+  ```
+
+- **`upstream.conf` 는 설정이 아니라 런타임 상태다.** 현재 활성 색을 가리킨다.
+  레포 쪽 파일은 `app-blue` 로 고정돼 있어, 덮어쓰면 실제 상태와 무관하게 blue 를
+  가리키게 된다. `.env`·`state` 와 같은 성격이다.
 - **`proxy_pass` 에 변수를 쓴다.** 그래야 nginx 기동 시점에 대상 색 컨테이너가 없어도
   "host not found in upstream" 으로 죽지 않는다. 블루-그린이 nginx 재기동 없이 되는 이유.
 - **`minio-public.inc` 는 `set` 이 `rewrite` 보다 먼저 와야 한다.** 둘 다 rewrite 모듈

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -143,6 +143,26 @@ fi
 log "nginx 트래픽 전환: $active → $target"
 printf 'set $backend "http://app-%s:8080";\n' "$target" >"$UPSTREAM_FILE"
 
+# 컨테이너가 실제로 새 내용을 보는지 확인한다.
+#
+# 바인드 마운트는 inode 를 물고 있다. 호스트에서 이 파일의 inode 가 한 번이라도
+# 바뀌면(install, sed -i, 일부 편집기의 저장 방식 — 전부 교체로 동작한다) 컨테이너는
+# 옛 inode 를 계속 보고, 위의 쓰기는 컨테이너에 닿지 않는다.
+#
+# 이 확인이 없으면 전환 절차가 전부 "성공" 한다. 컨테이너 입장에서는 내용이 안 바뀌었으니
+# nginx -t 도 reload 도 통과하고, state 갱신까지 끝난다. 그리고 구 색을 정리하는
+# 순간 nginx 가 사라진 컨테이너를 가리킨 채 전 요청이 502 가 된다. 배포는 성공으로
+# 보고되고 사이트만 죽는다. 실제로 그렇게 서비스가 내려갔다 — 이슈 #376.
+#
+# 아직 구 색이 살아 있는 지점이라, 여기서 멈추면 서비스는 무사하다.
+if ! docker compose exec -T nginx cat /etc/nginx/upstream.conf 2>/dev/null | grep -q "app-$target"; then
+  printf 'set $backend "http://app-%s:8080";\n' "$active" >"$UPSTREAM_FILE"
+  cleanup_target
+  die "nginx 컨테이너가 upstream.conf 갱신을 보지 못한다 (바인드 마운트 inode 불일치).
+       호스트 파일이 교체된 적이 있다. 'docker compose up -d --force-recreate nginx' 로
+       마운트를 다시 걸어야 한다. 트래픽은 $active 에 그대로 있다."
+fi
+
 if ! docker compose exec -T nginx nginx -t; then
   printf 'set $backend "http://app-%s:8080";\n' "$active" >"$UPSTREAM_FILE"
   cleanup_target

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -54,7 +54,24 @@ install -m 0775 "$SRC/deploy.sh"                                 "$ROOT/app/depl
 install -m 0664 "$SRC/docker/postfix/Dockerfile"                 "$ROOT/docker/postfix/Dockerfile"
 install -m 0775 "$SRC/docker/postfix/entrypoint.sh"              "$ROOT/docker/postfix/entrypoint.sh"
 install -m 0775 "$SRC/docker/minio/init.sh"                      "$ROOT/docker/minio/init.sh"
-install -m 0664 "$SRC/config/nginx/upstream.conf"                "$ROOT/config/nginx/upstream.conf"
+# upstream.conf 는 여기서 다룬다 — 다른 파일과 달리 덮어쓰면 안 된다.
+#
+# (1) 이건 설정이 아니라 런타임 상태다. 현재 활성 색을 가리키고 deploy.sh 가 갱신한다.
+#     레포 쪽 파일은 app-blue 로 고정돼 있어서, 재실행하면 실제 상태와 무관하게
+#     blue 로 되돌아간다. 지금이 green 이면 트래픽 없는 색을 가리키게 된다.
+#
+# (2) install 은 덮어쓰는 게 아니라 파일을 교체해서 inode 가 바뀐다. nginx 는 이 파일을
+#     단일 파일 바인드 마운트로 물고 있어, 교체되면 컨테이너는 옛 inode 를 계속 본다.
+#     그 뒤 deploy.sh 의 truncate-write 는 컨테이너에 닿지 않는다. 전환 절차는 전부
+#     "성공" 으로 끝나고(nginx -t / reload 도 통과한다) 구 색을 정리하는 순간 전 요청이
+#     502 가 된다. 실제로 그렇게 서비스가 내려갔다 — 이슈 #376.
+#
+# .env / state 와 같은 성격이라 같은 방식으로 다룬다.
+if [[ -f "$ROOT/config/nginx/upstream.conf" ]]; then
+    log "upstream.conf 이미 존재 — 건드리지 않음 (현재 활성 색 상태)"
+else
+    install -m 0664 "$SRC/config/nginx/upstream.conf"            "$ROOT/config/nginx/upstream.conf"
+fi
 install -m 0664 "$SRC/config/nginx/conf.d/proxy-common.inc"      "$ROOT/config/nginx/conf.d/proxy-common.inc"
 install -m 0664 "$SRC/config/nginx/templates/http-only.conf"     "$ROOT/config/nginx/templates/http-only.conf"
 install -m 0664 "$SRC/config/nginx/templates/https.conf"         "$ROOT/config/nginx/templates/https.conf"


### PR DESCRIPTION
Closes #376

## 무슨 일이 있었나

무중단 배포 검증 중 **전 요청 502** 로 서비스가 내려갔다. 전환 구간은 무결이었는데,
구 색 컨테이너가 정리되는 순간부터 1180건 연속 502.

```
[3] state=green | app-green(healthy) app-blue(healthy) | 1764건, 비200 0
[4] state=green | app-green(healthy) app-blue(healthy) | 2243건, 비200 0
[5] state=green | app-green(healthy)                   | 2561건, 비200 163   ← blue 제거
[6] state=green | app-green(healthy)                   | 3039건, 비200 641

nginx: app-blue could not be resolved (2: Server failure) → 502
```

## 원인 — 호스트와 컨테이너가 다른 파일을 보고 있었다

```
$ cat /opt/ttokttok/config/nginx/upstream.conf
set $backend "http://app-green:8080";        ← 호스트

$ docker exec ttokttok-nginx cat /etc/nginx/upstream.conf
set $backend "http://app-blue:8080";         ← 컨테이너
```

`setup.sh` 가 `install` 로 이 파일을 배치한다. `install` 은 덮어쓰지 않고 **교체**해서
inode 가 바뀐다.

```
install 전 inode=8870 / 후 inode=8871
> 리다이렉트는 inode 유지
```

`upstream.conf` 는 nginx 에 단일 파일 바인드 마운트다. 마운트는 inode 를 물고 있어서,
교체되면 컨테이너는 옛 inode 를 계속 본다. 그 뒤 `deploy.sh` 의 truncate-write 는
새 inode 에만 반영되고 컨테이너에 닿지 않는다.

README 에 `sed -i` 를 쓰지 말라고 적어둔 바로 그 함정인데, `setup.sh` 자신이
`install` 로 같은 일을 하고 있었다.

## 가장 나쁜 점 — 전부 "성공" 한다

1. 호스트 파일에 `app-green` 기록 — 성공
2. `nginx -t` — 성공 (컨테이너 입장에선 내용이 안 바뀌었고 app-blue 는 살아 있다)
3. `nginx -s reload` — 성공
4. `state` 갱신 — 성공
5. 드레인 후 app-blue 정리 — 성공

어떤 단계도 실패를 보고하지 않는다. 그리고 **5번 직후 서비스 전체가 죽는다.**
CI 는 초록인데 사이트가 내려간다.

## 조치

### 1. `setup.sh` — 없을 때만 생성

`upstream.conf` 는 설정이 아니라 **런타임 상태**(현재 활성 색)다. 게다가 레포 쪽 파일은
`set $backend "http://app-blue:8080";` 로 고정이라, 재실행하면 실제 상태와 무관하게
blue 로 되돌아간다. 지금이 green 이면 트래픽 없는 색을 가리키게 된다.

`.env` 와 `state` 는 이미 같은 방식으로 다루고 있다. 이 파일만 매번 덮어쓰고 있었다.
inode 교체와 상태 되돌림이 한 번에 해결된다.

### 2. `deploy.sh` — 전환 직후 컨테이너의 시야를 확인

```bash
if ! docker compose exec -T nginx cat /etc/nginx/upstream.conf | grep -q "app-$target"; then
  # 되돌리고 중단
fi
```

`setup.sh` 만 고치면 될 것 같지만 그렇지 않다. inode 가 갈리는 경로는 하나가 아니다 —
`cp`, `sed -i`, 일부 편집기의 저장이 전부 교체로 동작한다. 확인은 아직 **구 색이
살아 있는 지점**에 두었으므로, 걸리면 서비스 무사한 채로 배포만 실패한다.
이번 사고도 이 확인만 있었으면 중단 없이 끝났다.

### 3. README

증상·원인·복구 절차(`docker compose up -d --force-recreate nginx`)를 적었다.

## 검증

```
$ bash -n deploy/setup.sh && bash -n deploy/deploy.sh
syntax OK

# 실제 서버 상태(state=green, 컨테이너도 green)에서 판정
  target=green  일치 → 진행
  target=blue   불일치 → 중단
```

양방향 다 의도대로 동작한다.