### PR TITLE
v2 QA 백엔드 버그 수정 — 로그아웃 500·게시글 제목 길이 검증 (fix/#379 -> develop)

### DIFF
--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminController.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminController.java
@@ -49,7 +49,7 @@ public class ClubBoardAdminController implements ClubBoardAdminDocs {
             @AuthUserInfo String username,
             @PathVariable String clubId,
             @PathVariable String boardId,
-            @RequestPart(value = "request", required = false) ClubBoardUpdateRequest request,
+            @RequestPart(value = "request", required = false) @Valid ClubBoardUpdateRequest request,
             @RequestPart(value = "thumbnail", required = false) MultipartFile thumbnail
     ) {
         ClubBoardUpdateRequest safeRequest = request != null

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/ClubBoardUpdateRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/ClubBoardUpdateRequest.java
@@ -1,11 +1,14 @@
 package org.project.ttokttok.domain.clubboard.controller.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
 import org.project.ttokttok.domain.clubboard.service.dto.request.ClubBoardUpdateServiceRequest;
 import org.springframework.web.multipart.MultipartFile;
 
 public record ClubBoardUpdateRequest(
         @Schema(description = "선택적 필드 (생략 또는 null이면 기존 값 유지)", nullable = true, example = "값 또는 null")
+        // 저장 컬럼이 VARCHAR(255) 라 초과하면 DB 단에서 터진다. 여기서 막아 400 으로 돌려준다.
+        @Size(max = 255, message = "제목은 최대 255자까지 입력할 수 있습니다.")
         String title,
 
         @Schema(description = "선택적 필드 (생략 또는 null이면 기존 값 유지)", nullable = true, example = "값 또는 null")

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/CreateBoardRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/CreateBoardRequest.java
@@ -1,11 +1,14 @@
 package org.project.ttokttok.domain.clubboard.controller.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import org.project.ttokttok.domain.clubboard.service.dto.request.CreateBoardServiceRequest;
 import org.springframework.web.multipart.MultipartFile;
 
 public record CreateBoardRequest(
         @NotBlank(message = "제목은 비어 있을 수 없습니다.")
+        // 저장 컬럼이 VARCHAR(255) 라 초과하면 DB 단에서 터진다. 여기서 막아 400 으로 돌려준다.
+        @Size(max = 255, message = "제목은 최대 255자까지 입력할 수 있습니다.")
         String title,
 
         @NotBlank(message = "내용은 비어 있을 수 없습니다.")

--- a/src/main/java/org/project/ttokttok/infrastructure/redis/service/RefreshTokenRedisService.java
+++ b/src/main/java/org/project/ttokttok/infrastructure/redis/service/RefreshTokenRedisService.java
@@ -64,6 +64,13 @@ public class RefreshTokenRedisService {
 
     // 액세스 토큰 블랙리스트 추가 - 로그아웃 시
     public void addAccessTokenToBlacklist(String accessToken, long expiryTime) {
+        // 이미 만료된 토큰은 만료 검증만으로 거부되므로 블랙리스트가 필요 없다.
+        // 게다가 Redis 는 TTL 이 0 이하인 SET 을 거부하므로(ERR invalid expire time) 그대로 넘기면 500 이 된다.
+        if (expiryTime <= 0) {
+            log.debug("이미 만료된 액세스 토큰이라 블랙리스트 등록을 생략한다");
+            return;
+        }
+
         // 액세스 토큰의 남은 만료 시간만큼 블랙리스트에 저장
         redisTemplate.opsForValue().set(
                 ACCESS_BLACKLIST_KEY + accessToken,

--- a/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminControllerTest.java
@@ -150,6 +150,43 @@ class ClubBoardAdminControllerTest {
     }
 
     @Test
+    @DisplayName("createBoard(): 제목이 255자를 넘으면 400이 발생한다.")
+    void createBoard_titleTooLong() throws Exception {
+        CreateBoardRequest request = new CreateBoardRequest("가".repeat(256), "본문입니다");
+
+        mockMvc.perform(multipart("/api/admin/clubs/{clubId}/boards", myClub.getId())
+                        .file(jsonPart(request))
+                        .file(thumbnailPart())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("createBoard(): 제목이 255자면 생성에 성공한다.")
+    void createBoard_titleAtMaxLength() throws Exception {
+        CreateBoardRequest request = new CreateBoardRequest("가".repeat(255), "본문입니다");
+
+        mockMvc.perform(multipart("/api/admin/clubs/{clubId}/boards", myClub.getId())
+                        .file(jsonPart(request))
+                        .file(thumbnailPart())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("updateBoard(): 제목이 255자를 넘으면 400이 발생한다.")
+    void updateBoard_titleTooLong() throws Exception {
+        ClubBoard board = saveBoard("원래 제목", "원래 내용");
+
+        ClubBoardUpdateRequest request = new ClubBoardUpdateRequest("가".repeat(256), null);
+
+        mockMvc.perform(multipart(HttpMethod.PATCH, "/api/admin/clubs/{clubId}/boards/{boardId}", myClub.getId(), board.getId())
+                        .file(jsonPart(request))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     @DisplayName("updateBoard(): 게시글 수정에 성공한다.")
     void updateBoard_success() throws Exception {
         ClubBoard board = saveBoard("원래 제목", "원래 내용");

--- a/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminControllerTest.java
@@ -29,6 +29,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -147,6 +148,27 @@ class ClubBoardAdminControllerTest {
                         .file(thumbnailPart())
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + otherAccessToken))
                 .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("createBoard(): 본문의 줄바꿈이 저장 후에도 그대로 유지된다.")
+    void createBoard_preservesLineBreaks() throws Exception {
+        String content = "첫째 줄\n둘째 줄\n\n넷째 줄";
+        CreateBoardRequest request = new CreateBoardRequest("제목입니다", content);
+
+        String response = mockMvc.perform(multipart("/api/admin/clubs/{clubId}/boards", myClub.getId())
+                        .file(jsonPart(request))
+                        .file(thumbnailPart())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        String boardId = objectMapper.readTree(response).get("boardId").asText();
+
+        assertThat(clubBoardRepository.findById(boardId))
+                .get()
+                .extracting(ClubBoard::getContent)
+                .isEqualTo(content);
     }
 
     @Test

--- a/src/test/java/org/project/ttokttok/global/exception/GlobalExceptionHandlerUploadSizeTest.java
+++ b/src/test/java/org/project/ttokttok/global/exception/GlobalExceptionHandlerUploadSizeTest.java
@@ -1,0 +1,39 @@
+package org.project.ttokttok.global.exception;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.global.exception.dto.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 업로드 용량 초과 응답을 검증한다.
+ *
+ * QA 항목 "허용되지 않은 파일 형식/용량 초과 시 안내가 표시되는가" 중 용량 초과 경로다.
+ * 형식 검증은 서비스 계층에서 이미 다루므로 여기서는 용량만 본다.
+ */
+class GlobalExceptionHandlerUploadSizeTest {
+
+    private static final long MAX_UPLOAD_BYTES = 20L * 1024 * 1024;
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    @DisplayName("업로드 용량을 초과하면 413과 안내 문구를 반환한다")
+    void handleMaxSize_returnsPayloadTooLarge() {
+        // given
+        MaxUploadSizeExceededException exception = new MaxUploadSizeExceededException(MAX_UPLOAD_BYTES);
+
+        // when
+        ResponseEntity<ErrorResponse> response = handler.handleMaxSize(exception);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().statusCode()).isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE.value());
+        assertThat(response.getBody().details()).isEqualTo("업로드 가능한 최대 용량을 초과했습니다.");
+    }
+}

--- a/src/test/java/org/project/ttokttok/infrastructure/redis/service/RefreshTokenRedisServiceBlacklistIT.java
+++ b/src/test/java/org/project/ttokttok/infrastructure/redis/service/RefreshTokenRedisServiceBlacklistIT.java
@@ -1,0 +1,71 @@
+package org.project.ttokttok.infrastructure.redis.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * 액세스 토큰 블랙리스트 등록을 <b>실제 Redis</b>에 대해 검증한다.
+ *
+ * {@link RefreshTokenRedisServiceTest}는 {@code RedisTemplate}을 목으로 대체하므로
+ * TTL 0을 넘겨도 통과한다. 실제 Redis는 TTL 0인 SET을 거부하기 때문에
+ * 만료된 액세스 토큰으로 로그아웃하면 500이 발생했다. 그 회귀를 막는 테스트다.
+ */
+@SpringBootTest
+class RefreshTokenRedisServiceBlacklistIT {
+
+    @Autowired
+    private RefreshTokenRedisService refreshTokenRedisService;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    private static final String BLACKLIST_KEY_PREFIX = "blacklist:access:";
+    private static final String REFRESH_KEY_PREFIX = "refresh:";
+
+    private final String accessToken = "it-access-" + UUID.randomUUID();
+    private final String refreshToken = "it-refresh-" + UUID.randomUUID();
+
+    @AfterEach
+    void tearDown() {
+        redisTemplate.delete(BLACKLIST_KEY_PREFIX + accessToken);
+        redisTemplate.delete(REFRESH_KEY_PREFIX + refreshToken);
+    }
+
+    @Test
+    @DisplayName("남은 만료시간이 0이어도 블랙리스트 등록이 예외 없이 끝난다")
+    void addAccessTokenToBlacklist_withZeroExpiry_doesNotThrow() {
+        assertThatCode(() -> refreshTokenRedisService.addAccessTokenToBlacklist(accessToken, 0L))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("남은 만료시간이 음수여도 블랙리스트 등록이 예외 없이 끝난다")
+    void addAccessTokenToBlacklist_withNegativeExpiry_doesNotThrow() {
+        assertThatCode(() -> refreshTokenRedisService.addAccessTokenToBlacklist(accessToken, -1000L))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("남은 만료시간이 양수면 블랙리스트에 등록된다")
+    void addAccessTokenToBlacklist_withPositiveExpiry_marksBlacklisted() {
+        refreshTokenRedisService.addAccessTokenToBlacklist(accessToken, 60_000L);
+
+        assertThat(refreshTokenRedisService.isAccessTokenBlacklisted(accessToken)).isTrue();
+    }
+
+    @Test
+    @DisplayName("이미 만료된 액세스 토큰으로 로그아웃해도 예외 없이 끝난다")
+    void logout_withExpiredAccessToken_doesNotThrow() {
+        assertThatCode(() -> refreshTokenRedisService.logout(refreshToken, accessToken, 0L))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/org/project/ttokttok/infrastructure/redis/service/RefreshTokenRedisServiceTest.java
+++ b/src/test/java/org/project/ttokttok/infrastructure/redis/service/RefreshTokenRedisServiceTest.java
@@ -151,8 +151,8 @@ class RefreshTokenRedisServiceTest {
         }
 
         @ParameterizedTest
-        @DisplayName("다양한 만료시간이 주어져도 블랙리스트에 추가한다")
-        @ValueSource(longs = {1000L, 60000L, 3600000L, 0L})
+        @DisplayName("남은 만료시간이 양수면 블랙리스트에 추가한다")
+        @ValueSource(longs = {1L, 1000L, 60000L, 3600000L})
         void addAccessTokenToBlacklist_withVariousExpiryTimes_addsToBlacklist(long expiryTime) {
             // given
             when(redisTemplate.opsForValue()).thenReturn(valueOperations);
@@ -166,6 +166,17 @@ class RefreshTokenRedisServiceTest {
                     "blacklisted",
                     Duration.ofMillis(expiryTime)
             );
+        }
+
+        @ParameterizedTest
+        @DisplayName("남은 만료시간이 0 이하면 Redis 를 호출하지 않는다")
+        @ValueSource(longs = {0L, -1L, -1000L})
+        void addAccessTokenToBlacklist_withNonPositiveExpiry_skipsRedis(long expiryTime) {
+            // when
+            service.addAccessTokenToBlacklist(TEST_ACCESS_TOKEN, expiryTime);
+
+            // then
+            verify(redisTemplate, never()).opsForValue();
         }
     }
 


### PR DESCRIPTION
## ✨ 작업 내용

v2 QA 중 발견한 백엔드 버그 2건 수정 + QA 커버리지 보강. (Swagger 변경 없음, DB 변경 없음)

- **로그아웃 500 수정** — 이미 만료된 액세스 토큰으로 로그아웃 시 남은 만료시간이 0이 되어 Redis가 TTL 0 `SET`을 거부(`ERR invalid expire time in set`)하며 500이 나던 문제. 잔여시간 0 이하이면 블랙리스트 등록을 생략하도록 수정하고, 버그 동작을 고정하던 목 테스트 교정 + 실 Redis 회귀 테스트 추가.
- **게시글 제목 길이 검증 추가** — 256자 이상 제목이 API를 통과해 운영 DB(`varchar(255)`)에서 500을 유발하던 문제. `@Size(max = 255)` 추가로 400 반환. `updateBoard`의 `request` 파트에 누락돼 있던 `@Valid`도 함께 수정.
- **QA 커버리지 보강** — 본문 줄바꿈 보존, 업로드 용량 초과 413 응답 검증 테스트 추가.

커밋 3개(관심사 분리):

| 커밋 | 내용 |
|---|---|
| `4b83b4b` | 로그아웃 시 만료된 액세스 토큰 블랙리스트 500 수정 |
| `57ac2a5` | 게시글 제목 길이 검증 추가 |
| `f81f06d` | 게시판 QA 커버리지 보강 (줄바꿈 보존·업로드 용량 초과) |

---

## 🔍 관련 이슈

- 해결한 이슈 번호: #379

---

## ✅ 체크리스트

- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요?
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항

- `bash maintenance/verify.sh` 그린 (BUILD SUCCESSFUL, 910 tests / 0 fail). 커밋별 `compileJava compileTestJava` 게이트도 3커밋 모두 통과.
- 로그아웃 500은 목이 실제 Redis 제약을 재현하지 못해 가려져 있던 케이스라, 실 Redis 통합 테스트(`RefreshTokenRedisServiceBlacklistIT`)로 회귀를 잡았습니다.
- QA 중 별도로 확인된 후속 항목(리뷰 참고용, 이 PR 범위 밖):
  - 인증 없는 관리자 비밀번호 재설정 취약점(`/api/admin/auth/reset-password`) — 방향 결정 필요
  - 토큰이 응답 바디로 반환됨(`LoginResponse.refreshToken`), `httpOnly` 쿠키 유틸은 미사용 죽은 코드
