### PR TITLE
[Fix] Redis 컨테이너 uid 고정 — RDB 저장 실패로 인한 쓰기 전면 차단 해소

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -147,6 +147,28 @@ Postfix 는 `mynetworks` 안에서 오는 요청을 인증 없이 받으므로 �
   **내부 문자열**에도 박혀 있다. 도메인을 유지하는 대가로 DB 를 한 줄도 안 건드린다.
 - **`POSTGRES_USER` 는 `postgres` 여야 한다.** 백업 덤프의 객체 소유자가 `postgres` 라,
   다른 이름으로 초기화하면 `ALTER ... OWNER TO postgres` 가 "role does not exist" 로 실패한다.
+- **`data/` 를 쓰는 컨테이너는 uid 를 명시해야 한다.** `setup.sh` 는 `data/*` 를
+  `ttokttokuser:ttokttok`(1001:1003) 로 통일한다. 이미지 기본 uid 가 그와 다르면 컨테이너가
+  자기 데이터 디렉터리에 못 쓴다. `minio`·`redis` 는 그래서 `user: "1001:1003"` 을 박아뒀다.
+  `postgres` 만 이미지가 uid 70 을 강제해서 예외이고, 대신 `data/postgres` 를 70:70 으로 둔다.
+
+  | 서비스 | 프로세스 uid | `data/` 소유 |
+  |---|---|---|
+  | postgres | 70 (이미지 고정) | 70:70 |
+  | minio | 1001:1003 (`user:`) | 1001:1003 |
+  | redis | 1001:1003 (`user:`) | 1001:1003 |
+
+  redis 에서 이게 어긋나면 **읽기는 되고 쓰기만 죽는다.** BGSAVE 가 temp 파일을 못 만들고,
+  `stop-writes-on-bgsave-error` 기본값이 `yes` 라 모든 쓰기가 `MISCONF` 로 거부된다.
+  컨테이너는 healthy 고 `PING` 도 `PONG` 이라 헬스체크로는 안 잡힌다. 게다가 이미 열어둔
+  AOF fd 로 append 는 계속되므로, 소유권이 바뀐 직후가 아니라 **다음 자동 BGSAVE 시점에**
+  터진다. 증상은 로그인 실패로 나타난다.
+
+  ```bash
+  docker exec ttokttok-redis id -u                          # user: 값과 같아야 한다
+  docker logs ttokttok-redis | grep -i 'bgsave\|permission'
+  ```
+
 - **헬스 엔드포인트는 `/health` 다.** 이 앱에는 actuator 의존성이 없어서
   `/actuator/health` 는 404 다. `/health` 는 `SecurityWhiteList` 에 등록된 공개 경로다.
 - **`upstream.conf` 는 단일 파일 바인드 마운트**다. `sed -i` 처럼 inode 를 바꾸는 방식으로

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -192,6 +192,11 @@ services:
     image: redis:7.2-alpine
     container_name: ttokttok-redis
     restart: unless-stopped
+    # 이미지 entrypoint 가 uid 999(redis) 로 강등하는데 data/redis 는 setup.sh 가
+    # ttokttokuser(1001:1003) 로 chown 한다. 그대로 두면 BGSAVE 가 /data 에 temp
+    # 파일을 못 만들고, stop-writes-on-bgsave-error 기본값 때문에 쓰기 명령 전체가
+    # MISCONF 로 거부된다. minio 와 같은 이유로 호스트 계정에 맞춰 고정한다.
+    user: "1001:1003"
     ports:
       - "127.0.0.1:16379:6379"
     command: >


### PR DESCRIPTION
Closes #382

## 문제

구글 로그인이 500 으로 죽었다. 원인은 Redis 가 **모든 쓰기를 거부**하고 있던 것.

```
RedisCommandExecutionException: MISCONF Redis is configured to save RDB snapshots,
but it's currently unable to persist to disk. Commands that may modify the data set
are disabled ... (stop-writes-on-bgsave-error option)
  ← RefreshTokenRedisService.save(...:32) ← GoogleOAuthService.issueTokenResponse(...:158)
```

`redis:7.2-alpine` 은 entrypoint 가 uid 999(redis) 로 강등해 돈다. 그런데 `setup.sh` 는
`data/*` 를 `ttokttokuser`(1001:1003) 로 통일한다. uid 999 는 `data/redis` 에 쓸 수 없다.

```
Failed opening the temp RDB file temp-4636.rdb (in server root dir /data) for saving: Permission denied
```

`stop-writes-on-bgsave-error` 기본값이 `yes` 라 **RDB 실패가 곧 쓰기 전면 차단**이 된다.

## 변경

`minio` 가 같은 이유로 이미 하고 있던 것을 redis 에도 적용한다.

```yaml
  redis:
    image: redis:7.2-alpine
    container_name: ttokttok-redis
+   user: "1001:1003"
```

`setup.sh` 의 chown 규칙은 건드리지 않았다. 이미지가 uid 를 강제하는 postgres 가 아닌 이상
컨테이너 쪽을 호스트에 맞추는 편이 setup.sh 에 예외를 늘리지 않는다.
기존 `data/redis/appendonlydir` 도 이미 1001:1003 이라 그대로 로드된다.

## 전 서비스 전수 조사

같은 문제가 다른 데도 있는지 확인했다. 각 컨테이너 메인 프로세스의 실제 uid 로
쓰기 가능한 바인드 마운트에 `touch` 를 시도한 결과다.

| 컨테이너 | 실행 uid:gid | 쓰기 대상 | 호스트 소유권 | 결과 |
|---|---|---|---|---|
| app | 1001:1003 | 없음 (`/app/config` 는 ro) | 1002:1003 0640 | OK (그룹 읽기) |
| nginx | 0:0 | 없음 (전부 ro) | — | OK |
| smtp | 0:0 | 없음 | — | OK |
| postgres | 70:70 | `data/postgres` | 70:70 0700 | OK |
| minio | 1001:1003 | `data/minio` | 1001:1003 0755 | OK |
| certbot | 0:0 | `data/certbot/{conf,www}` | 1001:1003 0755 | OK (root) |
| **redis** | **999:1000** | **`data/redis`** | **1001:1003 0755** | **DENIED** |

**redis 하나뿐이다.** 이름 있는 볼륨은 없고, 다른 rw 바인드 마운트도 없다.

## 이 유형이 위험한 이유 (README 에 추가)

세 겹으로 신호가 가려진다.

1. 컨테이너는 계속 **healthy** 다. 헬스체크가 `redis-cli ping` 이고 `PONG` 은 정상적으로 온다.
2. **읽기는 전부 된다.** 쓰기만 죽는다.
3. 소유권이 바뀐 **직후에 안 터진다.** 이미 열어둔 AOF fd 로 append 는 계속되므로,
   최대 1시간 뒤 첫 자동 BGSAVE 에서야 실패한다.

```
17:18:20 * Creating AOF base file appendonly.aof.1.base.rdb on server start   ← 정상
18:54:54 # Failed opening the temp RDB file ... Permission denied             ← 첫 실패
```

postgres 는 동일한 chown 에 PANIC 으로 즉시 터져서 바로 잡혔는데, redis 는 아무 신호도
주지 않고 로그인 실패라는 한참 떨어진 증상으로만 나타났다. 그래서 `deploy/README.md`
「설계상 주의점」에 uid 대조표와 확인 명령을 남겼다.

## 검증

- [x] 전 컨테이너 uid × 마운트 쓰기 권한 전수 조사 (위 표)
- [x] compose YAML 파싱 → `.services.redis.user == "1001:1003"`
- [ ] 배포 후 `docker exec ttokttok-redis id -u` → 1001
- [ ] `redis-cli bgsave` → `rdb_last_bgsave_status:ok`
- [ ] `redis-cli set` 성공
- [ ] 구글 로그인 성공

## 배포 시 주의

이 변경은 `/opt/ttokttok/app/docker-compose.yml` 에 반영돼야 적용된다. 머지 후
`setup.sh` 재실행 또는 compose 파일 갱신 뒤 `docker compose up -d redis` 가 필요하다.
`deploy.sh` 는 app 컨테이너만 다루므로 배포만으로는 반영되지 않는다.