### PR TITLE
[Fix] setup.sh — data 소유권을 컨테이너 uid 에 맞추고, compose 반영과 결과를 검증

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -147,6 +147,15 @@ Postfix 는 `mynetworks` 안에서 오는 요청을 인증 없이 받으므로 �
   **내부 문자열**에도 박혀 있다. 도메인을 유지하는 대가로 DB 를 한 줄도 안 건드린다.
 - **`POSTGRES_USER` 는 `postgres` 여야 한다.** 백업 덤프의 객체 소유자가 `postgres` 라,
   다른 이름으로 초기화하면 `ALTER ... OWNER TO postgres` 가 "role does not exist" 로 실패한다.
+- **`docker-compose.yml` 은 CI 로 배포되지 않는다.** GitHub Actions 는 `deploy.sh` 만 부르고,
+  `deploy.sh` 는 **이미 서버에 있는** compose 를 읽을 뿐이다. 서버의
+  `/opt/ttokttok/app/docker-compose.yml` 을 갱신하는 경로는 `setup.sh` 하나뿐이다.
+  compose·nginx 템플릿·`bin/` 스크립트를 고쳐 머지했다면 **`sudo deploy/setup.sh` 를
+  따로 돌려야 한다.** 앱 코드만 고쳤다면 배포로 충분하다.
+
+  `setup.sh` 는 compose 내용이 실제로 바뀐 경우에만 인프라 서비스를 재조정한다.
+  파일만 갈아끼우고 끝내면 로그는 "배치 완료" 인데 컨테이너는 옛 정의로 계속 돈다.
+
 - **`data/` 를 쓰는 컨테이너는 uid 를 명시해야 한다.** `setup.sh` 는 `data/*` 를
   `ttokttokuser:ttokttok`(1001:1003) 로 통일한다. 이미지 기본 uid 가 그와 다르면 컨테이너가
   자기 데이터 디렉터리에 못 쓴다. `minio`·`redis` 는 그래서 `user: "1001:1003"` 을 박아뒀다.

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -21,10 +21,36 @@ log() { printf '\033[36m[setup]\033[0m %s\n' "$*"; }
 # /opt 은 루트 파티션(46G 중 34G 여유)이라 DB+업로드가 쌓이면 위험하다.
 log "데이터 디렉터리: $DATA_SRC"
 mkdir -p "$DATA_SRC"/{postgres,redis,minio,certbot/conf,certbot/www}
-# 디렉터리 자체만 chown 한다. -R 을 쓰면 실행 중인 컨테이너의 데이터 파일까지
-# 소유권이 바뀐다 — 6단계 주석 참고.
-chown "$RUN_USER:$RUN_GROUP" \
-      "$DATA_SRC" "$DATA_SRC"/{postgres,redis,minio,certbot,certbot/conf,certbot/www}
+
+# data/<서비스> 의 소유자는 "그 디렉터리에 실제로 쓰는 컨테이너의 uid" 여야 한다.
+# 전부 $RUN_USER 로 통일하면 안 된다. 컨테이너마다 uid 가 다르고, 어긋나면 컨테이너가
+# 자기 데이터 디렉터리에 못 쓴다.
+#
+#   postgres  uid 70      이미지가 강제한다. user: 를 줄 수 없다.
+#   redis     compose user: "1001:1003"   (기본값은 uid 999 — #382)
+#   minio     compose user: "1001:1003"
+#   certbot   root 로 돈다. root 는 권한을 안 타므로 호스트 도구가 읽기 좋은 쪽에 맞춘다.
+#
+# 이 표는 docker-compose.yml 의 user: 와 반드시 같이 움직여야 한다. 아래 12단계가
+# 실제로 대조하므로, 어긋난 채로 이 스크립트가 끝나지는 않는다.
+#
+# redis 를 $RUN_USER 로 맞춰둔 채 이미지 기본 uid(999)로 돌렸다가 BGSAVE 가 막혀
+# 쓰기 전체가 MISCONF 로 거부된 적이 있다. 로그인이 20시간 죽었는데 컨테이너는
+# 내내 healthy 였다 — #382.
+declare -A DATA_OWNER=(
+    [postgres]="70:70"
+    [redis]="$RUN_USER:$RUN_GROUP"
+    [minio]="$RUN_USER:$RUN_GROUP"
+    [certbot]="$RUN_USER:$RUN_GROUP"
+    [certbot/conf]="$RUN_USER:$RUN_GROUP"
+    [certbot/www]="$RUN_USER:$RUN_GROUP"
+)
+chown "$RUN_USER:$RUN_GROUP" "$DATA_SRC"
+for d in "${!DATA_OWNER[@]}"; do
+    # 디렉터리 자체만 chown 한다. -R 을 쓰면 실행 중인 컨테이너의 데이터 파일까지
+    # 소유권이 바뀐다 — 6단계 주석 참고.
+    chown "${DATA_OWNER[$d]}" "$DATA_SRC/$d"
+done
 
 # ── 2. /opt/ttokttok 구조 ────────────────────────────────────────────────
 log "디렉터리 구조 생성"
@@ -49,7 +75,10 @@ mountpoint -q "$ROOT/data" \
 
 # ── 4. 파일 배치 ─────────────────────────────────────────────────────────
 log "설정/스크립트 배치"
+# compose 정의가 이번 실행으로 바뀌었는지 기록해둔다. 11단계에서 쓴다.
+compose_before="$(sha256sum "$ROOT/app/docker-compose.yml" 2>/dev/null | cut -d' ' -f1 || true)"
 install -m 0664 "$SRC/docker-compose.yml"                        "$ROOT/app/docker-compose.yml"
+compose_after="$(sha256sum "$ROOT/app/docker-compose.yml" | cut -d' ' -f1)"
 install -m 0775 "$SRC/deploy.sh"                                 "$ROOT/app/deploy.sh"
 install -m 0664 "$SRC/docker/postfix/Dockerfile"                 "$ROOT/docker/postfix/Dockerfile"
 install -m 0775 "$SRC/docker/postfix/entrypoint.sh"              "$ROOT/docker/postfix/entrypoint.sh"
@@ -189,6 +218,84 @@ EOF
 chmod 0644 /etc/cron.d/ttokttok-certs
 # 이름이 바뀌었으므로 옛 파일을 지운다. 남겨두면 reload 가 두 번 등록된다.
 rm -f /etc/cron.d/ttokttok-nginx-reload
+
+# ── 11. compose 정의 반영 ────────────────────────────────────────────────
+# 이 스크립트가 docker-compose.yml 을 서버에 옮기는 유일한 경로다. CI 는
+# deploy.sh 만 부르고, deploy.sh 는 이미 서버에 있는 compose 를 읽을 뿐이다.
+# 그래서 compose 를 고쳐 머지해도 setup.sh 를 돌리기 전까지는 아무 일도 안 일어난다.
+#
+# 파일만 갈아끼우고 끝내면 "배치했다" 는 로그만 남고 실행 중인 컨테이너는 옛 정의
+# 그대로 돈다. 다음 배포(deploy.sh 의 up -d)까지 반영이 미뤄지는데, 그 사이에
+# 재발한 게 #382 였다. 그래서 여기서 바로 재조정한다.
+#
+# 내용이 안 바뀌었으면 건드리지 않는다. up -d 는 정의가 바뀐 서비스만 재생성하지만,
+# 굳이 매번 부를 이유도 없다.
+INFRA_SERVICES="${INFRA_SERVICES:-postgres redis minio minio-init smtp nginx certbot}"
+compose_up() { sudo -u "$RUN_USER" sh -c "cd '$ROOT/app' && docker compose $*"; }
+
+if [[ -z "$compose_before" ]]; then
+    log "compose 최초 배치 — 기동은 아래 '다음 순서' 참고"
+elif [[ "$compose_before" == "$compose_after" ]]; then
+    log "compose 정의 변경 없음"
+elif ! compose_up ps -q 2>/dev/null | grep -q .; then
+    log "compose 정의가 바뀌었지만 스택이 떠 있지 않다 — 재조정 생략"
+else
+    log "compose 정의가 바뀌었다 — 인프라 서비스 재조정"
+    # shellcheck disable=SC2086
+    compose_up up -d $INFRA_SERVICES
+fi
+
+# ── 12. 소유권 검증 ──────────────────────────────────────────────────────
+# 1단계의 DATA_OWNER 표가 compose 의 user: 와 어긋나지 않았는지, 표가 아니라
+# 실제로 확인한다. 각 컨테이너의 실행 uid 로 자기 데이터 디렉터리에 파일을
+# 만들어 본다.
+#
+# 이 검증이 필요한 이유는 실패가 조용하기 때문이다. redis 를 예로 들면
+#   - 컨테이너는 계속 healthy 다. 헬스체크가 PING 이고 PONG 은 정상적으로 온다.
+#   - 읽기는 전부 된다. 쓰기만 죽는다.
+#   - 소유권이 바뀐 직후에 안 터진다. 이미 열어둔 AOF fd 로 append 는 계속되므로
+#     최대 1시간 뒤 첫 자동 BGSAVE 에서야 실패한다.
+# postgres 만 PANIC 으로 즉시 티가 났고, 그건 이 이미지의 성질이지 규칙이 아니다.
+log "데이터 디렉터리 쓰기 권한 검증"
+probe_failed=0
+for cid in $(compose_up ps -q 2>/dev/null); do
+    name="$(docker inspect -f '{{.Name}}' "$cid" 2>/dev/null | tr -d /)" || continue
+    [[ "$(docker inspect -f '{{.State.Running}}' "$cid")" == true ]] || continue
+    pid="$(docker inspect -f '{{.State.Pid}}' "$cid")"
+    uid="$(awk '/^Uid:/{print $2}' "/proc/$pid/status" 2>/dev/null)" || continue
+    gid="$(awk '/^Gid:/{print $2}' "/proc/$pid/status" 2>/dev/null)"
+
+    # 읽기 전용 마운트와 data/ 밖은 검사 대상이 아니다. 경로 필터는 셸에서 한다 —
+    # docker inspect 의 템플릿 함수에는 접두사 비교가 없다.
+    while read -r src dest; do
+        [[ -n "$dest" ]] || continue
+        [[ "$src" == "$ROOT/data/"* || "$src" == "$DATA_SRC/"* ]] || continue
+        if docker exec -u "$uid:$gid" "$cid" \
+             sh -c "touch '$dest/.setup-probe' 2>/dev/null && rm -f '$dest/.setup-probe'" 2>/dev/null
+        then
+            printf '  \033[32mOK\033[0m      %-14s uid %-10s %s\n' "${name#ttokttok-}" "$uid:$gid" "$dest"
+        else
+            printf '  \033[31mDENIED\033[0m  %-14s uid %-10s %s\n' "${name#ttokttok-}" "$uid:$gid" "$dest"
+            probe_failed=1
+        fi
+    done < <(docker inspect -f \
+        '{{range .Mounts}}{{if and (eq .Type "bind") .RW}}{{.Source}} {{println .Destination}}{{end}}{{end}}' \
+        "$cid" 2>/dev/null)
+done
+
+if (( probe_failed )); then
+    cat >&2 <<EOF
+
+[setup] 컨테이너가 자기 데이터 디렉터리에 쓰지 못한다.
+
+  compose 의 user: 와 1단계 DATA_OWNER 표가 어긋났다는 뜻이다. 둘을 맞춘 뒤
+  해당 서비스를 재생성해야 한다. 이대로 두면 서비스는 healthy 인 채로 쓰기만
+  실패한다 — redis 는 MISCONF 로 로그인이 죽고, minio 는 업로드가 죽는다.
+
+    cd $ROOT/app && docker compose up -d --force-recreate <서비스>
+EOF
+    exit 1
+fi
 
 log "완료."
 echo


### PR DESCRIPTION
Closes #384

#382(#383 에서 머지) 의 나머지 절반이다. compose 에 `user:` 를 넣었지만, **그 파일이
서버에 도달하는 경로가 없다.**

```
GitHub Actions ──► deploy.sh ──► 이미 서버에 있는 compose 를 읽을 뿐
                                        ▲
레포 docker-compose.yml ──► setup.sh ───┘   ← 서버로 옮기는 유일한 경로 (수동)
```

`ci-cd.yml` 에 `setup.sh` 호출이 없다. `deploy.sh:85` 의
`docker compose up -d $INFRA_SERVICES` 는 서버에 이미 있는 compose 를 읽는다.
`compose`·`config/nginx/*`·`bin/*` 는 배포 대상이 아니고, 앱 코드만 배포된다.

## 1단계 — 소유권을 컨테이너 uid 에 맞춘다

6단계 주석에는 이미 이렇게 적혀 있었다.

> `data/` 안쪽은 건드리지 않는다. 거기는 각 컨테이너가 자기 uid 로 소유하는 영역이고,
> 호스트에서 소유권을 강제할 이유가 없다. 반대로 강제하면 실행 중인 서비스가 깨진다

그런데 1단계가 `data/{postgres,redis,minio,certbot,...}` 를 전부 `ttokttokuser` 로
chown 하고 있었다. **정책을 적어놓고 같은 스크립트가 어기고 있었다.** #382 의 직접 원인이다.

```bash
declare -A DATA_OWNER=(
    [postgres]="70:70"                  # 이미지가 강제. user: 를 줄 수 없다
    [redis]="$RUN_USER:$RUN_GROUP"      # compose user: 와 일치
    [minio]="$RUN_USER:$RUN_GROUP"      # compose user: 와 일치
    [certbot]="$RUN_USER:$RUN_GROUP"    # root 로 도므로 호스트가 읽기 편한 쪽
    ...
)
```

`chown` 은 여전히 비재귀다. `-R` 이 실행 중인 PGDATA 를 걸어 postgres 가 PANIC 한
전례(#367)가 있어 그 부분은 그대로 뒀다.

## 11단계 (신설) — compose 가 바뀌었으면 실제로 반영한다

파일만 갈아끼우고 끝내면 로그에는 "설정/스크립트 배치" 만 남고 컨테이너는 옛 정의로
계속 돈다. 설치 전후 해시를 비교해 **내용이 실제로 바뀐 경우에만** 인프라를 재조정한다.

- 변경 없음 → no-op
- 최초 배치 → 생략 (아직 스택이 없다)
- 스택 미기동 → 생략
- 변경 있음 + 기동 중 → `docker compose up -d $INFRA_SERVICES`

`up -d` 는 정의가 바뀐 서비스만 재생성하므로, redis 만 바뀌었으면 nginx·postgres 는
건드리지 않는다.

## 12단계 (신설) — 표가 아니라 실물로 검증한다

`user:` 는 compose 에, 소유권은 `setup.sh` 에 있다. 표가 두 군데인 이상 언젠가
어긋난다. 그래서 표끼리 비교하지 않고 **각 컨테이너의 실행 uid 로 자기 데이터
디렉터리에 파일을 만들어 본다.** 하나라도 실패하면 `exit 1`.

실제 스택에 돌려서 확인했다.

```
데이터 디렉터리 쓰기 권한 검증
  OK      redis          uid 1001:1003  /data
  OK      certbot        uid 0:0        /etc/letsencrypt
  OK      certbot        uid 0:0        /var/www/certbot
  OK      postgres       uid 70:70      /var/lib/postgresql/data
  OK      minio          uid 1001:1003  /data
```

수정 전 같은 로직을 돌렸을 때는 redis 만 `DENIED` 로 잡혔다.

이 검증이 필요한 이유는 실패가 조용하기 때문이다. redis 기준으로

1. 컨테이너는 계속 **healthy** 다. 헬스체크가 `PING` 이고 `PONG` 은 정상적으로 온다.
2. **읽기는 전부 된다.** 쓰기만 죽는다.
3. 소유권이 바뀐 **직후에 안 터진다.** 이미 열어둔 AOF fd 로 append 는 계속되므로
   최대 1시간 뒤 첫 자동 BGSAVE 에서야 실패한다.

postgres 만 PANIC 으로 즉시 티가 났는데, 그건 그 이미지의 성질이지 규칙이 아니다.

## 검증

- [x] `bash -n` 문법 검사
- [x] `docker inspect` 템플릿이 실제 컨테이너에서 동작 (Go 템플릿에 접두사 비교 함수가
      없어 경로 필터는 셸에서 한다)
- [x] 12단계 로직을 실제 스택에 돌려 5개 마운트 전부 판정
- [x] 수정 전 로직으로 redis `DENIED` 재현
- [ ] 머지 후 `sudo deploy/setup.sh` 실행 — 11단계 no-op, 12단계 전부 OK 확인

## 배포 시 주의

머지 후 **`sudo deploy/setup.sh` 를 한 번 돌려야** 레포의 compose 가 서버에 반영된다.
현재 서버는 #382 복구 때 손으로 고쳐둔 상태(`user: "1001:1003"`)라 11단계 재조정은
no-op 이고 12단계 검증만 통과하고 끝난다.