### PR TITLE
[Feat] 게시글 생성 시 내용을 선택 필드로 변경

### DIFF
--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/docs/ClubBoardAdminDocs.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/docs/ClubBoardAdminDocs.java
@@ -30,11 +30,12 @@ public interface ClubBoardAdminDocs {
                     **요청 형식**: Multipart Form Data
 
                     **요청 파라미터**:
-                    - `request`: JSON 형태의 게시글 정보 (CreateBoardRequest, 제목/내용 필수)
+                    - `request`: JSON 형태의 게시글 정보 (CreateBoardRequest, 제목 필수 / 내용 선택)
                     - `thumbnail`: 대표(썸네일) 이미지 파일 (**필수**)
 
                     *주의사항*:
                     - 해당 동아리의 관리자만 작성 가능합니다.
+                    - 내용은 생략하거나 null로 보낼 수 있으며, 이 경우 빈 내용으로 저장됩니다.
                     - 썸네일은 JPG, PNG, WEBP, GIF, HEIC 형식만 지원됩니다. (최대 20MB)
                     - 업로드된 썸네일은 S3(board-images/)에 저장되며 목록 조회 응답의 thumbnailUrl로 내려갑니다.
                     """
@@ -43,7 +44,7 @@ public interface ClubBoardAdminDocs {
             content = @Content(
                     mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
                     schemaProperties = {
-                            @SchemaProperty(name = "request", schema = @Schema(type = "string", format = "json", description = "게시글 생성 데이터 (title, content)")),
+                            @SchemaProperty(name = "request", schema = @Schema(type = "string", format = "json", description = "게시글 생성 데이터 (title 필수, content 선택)")),
                             @SchemaProperty(name = "thumbnail", schema = @Schema(type = "string", format = "binary", description = "대표(썸네일) 이미지 파일 (필수)"))
                     }
             )

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/CreateBoardRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/CreateBoardRequest.java
@@ -1,5 +1,6 @@
 package org.project.ttokttok.domain.clubboard.controller.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import org.project.ttokttok.domain.clubboard.service.dto.request.CreateBoardServiceRequest;
@@ -11,7 +12,8 @@ public record CreateBoardRequest(
         @Size(max = 255, message = "제목은 최대 255자까지 입력할 수 있습니다.")
         String title,
 
-        @NotBlank(message = "내용은 비어 있을 수 없습니다.")
+        // 내용은 선택 입력이다. 생략하면 빈 내용으로 저장된다.
+        @Schema(description = "선택적 필드 (생략 또는 null이면 빈 내용으로 저장)", nullable = true)
         String content
 ) {
     public CreateBoardServiceRequest toServiceRequest(String username, String clubId, MultipartFile thumbnail) {

--- a/src/main/java/org/project/ttokttok/domain/clubboard/domain/ClubBoard.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/domain/ClubBoard.java
@@ -55,7 +55,6 @@ public class ClubBoard extends BaseTimeEntity {
             this.title = title;
         }
         if (content != null) {
-            validateContent(content);
             this.content = content;
         }
     }
@@ -68,13 +67,12 @@ public class ClubBoard extends BaseTimeEntity {
     // ------- 정적 메서드 -------
     public static ClubBoard create(String title, String content, String thumbnailUrl, Club club) {
         validateTitle(title);
-        validateContent(content);
         validateThumbnailUrl(thumbnailUrl);
         validateClub(club);
 
         return ClubBoard.builder()
                 .title(title)
-                .content(content)
+                .content(normalizeContent(content))
                 .thumbnailUrl(thumbnailUrl)
                 .club(club)
                 .build();
@@ -87,10 +85,9 @@ public class ClubBoard extends BaseTimeEntity {
         }
     }
 
-    private static void validateContent(String content) {
-        if (content == null || content.isBlank()) {
-            throw new IllegalArgumentException("Content cannot be null or blank.");
-        }
+    // 내용은 선택 입력이다. 저장 컬럼이 NOT NULL 이라 미입력은 빈 문자열로 맞춰 둔다.
+    private static String normalizeContent(String content) {
+        return content != null ? content : "";
     }
 
     private static void validateTitle(String title) {

--- a/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminControllerTest.java
@@ -172,6 +172,38 @@ class ClubBoardAdminControllerTest {
     }
 
     @Test
+    @DisplayName("createBoard(): 내용이 null이어도 생성에 성공하고 빈 내용으로 저장된다.")
+    void createBoard_withoutContent() throws Exception {
+        CreateBoardRequest request = new CreateBoardRequest("제목입니다", null);
+
+        String response = mockMvc.perform(multipart("/api/admin/clubs/{clubId}/boards", myClub.getId())
+                        .file(jsonPart(request))
+                        .file(thumbnailPart())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        String boardId = objectMapper.readTree(response).get("boardId").asText();
+
+        assertThat(clubBoardRepository.findById(boardId))
+                .get()
+                .extracting(ClubBoard::getContent)
+                .isEqualTo("");
+    }
+
+    @Test
+    @DisplayName("createBoard(): 내용이 빈 문자열이어도 생성에 성공한다.")
+    void createBoard_withBlankContent() throws Exception {
+        CreateBoardRequest request = new CreateBoardRequest("제목입니다", "");
+
+        mockMvc.perform(multipart("/api/admin/clubs/{clubId}/boards", myClub.getId())
+                        .file(jsonPart(request))
+                        .file(thumbnailPart())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
     @DisplayName("createBoard(): 제목이 255자를 넘으면 400이 발생한다.")
     void createBoard_titleTooLong() throws Exception {
         CreateBoardRequest request = new CreateBoardRequest("가".repeat(256), "본문입니다");

--- a/src/test/java/org/project/ttokttok/domain/clubboard/domain/ClubBoardTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/domain/ClubBoardTest.java
@@ -52,13 +52,23 @@ class ClubBoardTest {
         }
 
         @Test
-        @DisplayName("내용이 비어있으면 예외가 발생한다.")
-        void createFailBlankContent() {
+        @DisplayName("내용이 null이면 빈 문자열로 저장된다.")
+        void createWithNullContent() {
             Club club = mock(Club.class);
 
-            assertThatThrownBy(() -> ClubBoard.create("제목", " ", THUMBNAIL_URL, club))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Content cannot be null or blank.");
+            ClubBoard board = ClubBoard.create("제목", null, THUMBNAIL_URL, club);
+
+            assertThat(board.getContent()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("내용이 비어있어도 생성에 성공한다.")
+        void createWithBlankContent() {
+            Club club = mock(Club.class);
+
+            ClubBoard board = ClubBoard.create("제목", "", THUMBNAIL_URL, club);
+
+            assertThat(board.getContent()).isEmpty();
         }
 
         @Test
@@ -143,13 +153,24 @@ class ClubBoardTest {
         }
 
         @Test
-        @DisplayName("빈 문자열로 수정을 시도하면 예외가 발생한다.")
+        @DisplayName("빈 문자열로 제목 수정을 시도하면 예외가 발생한다.")
         void updateBlankTitleThrows() {
             ClubBoard board = newBoard();
 
             assertThatThrownBy(() -> board.update(" ", null))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("Title cannot be null or blank.");
+        }
+
+        @Test
+        @DisplayName("빈 문자열을 전달하면 내용을 비울 수 있다.")
+        void updateContentToBlank() {
+            ClubBoard board = newBoard();
+
+            board.update(null, "");
+
+            assertThat(board.getTitle()).isEqualTo("원제목");
+            assertThat(board.getContent()).isEmpty();
         }
     }
 


### PR DESCRIPTION
## ✨ 작업 내용

- 게시글 생성 시 **내용(`content`)을 선택 입력**으로 변경 (`@NotBlank` 제거)
- 저장 컬럼이 `TEXT NOT NULL` 이라 **미입력은 빈 문자열로 정규화** (`ClubBoard.create()`)
- 수정 API 의 blank 거부도 함께 해제 — **내용 비우기 허용** (`ClubBoard.update()`)
- Swagger 문서에 내용이 선택 필드임을 명시 (생성 API description / schema)
- **DB 변경 없음** — Flyway 마이그레이션 추가하지 않았습니다

### 왜 nullable 컬럼이 아니라 빈 문자열인가

컬럼을 nullable 로 바꾸면 마이그레이션이 필요하고 상세 조회 응답에 `content: null` 이
내려가 프론트에 null 처리 부담이 생깁니다. 빈 문자열 정규화는 마이그레이션 없이 처리되고
응답의 `content` 가 항상 문자열로 유지됩니다. 대신 '미입력'과 '빈 내용'을 DB 에서
구분할 수 없는데, 지금 요구사항엔 그 구분이 필요 없다고 판단했습니다.

### 수정 API 도 함께 푼 이유

생성에서 내용을 비울 수 있는데 수정에서는 못 비우면 한 번 내용을 넣은 게시글은
영원히 비울 수 없는 상태가 됩니다.

---

## 🔍 관련 이슈
- 해결한 이슈 번호: #386

---

## ✅ 체크리스트
- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요? (`maintenance/verify.sh` 통과)
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항

**API 계약 변경**: 이전에는 내용 없이 생성 시 400 이었지만 이제 201 입니다. 완화 방향이라
기존 클라이언트는 그대로 동작합니다.

**제목은 그대로 필수**이며 `@Size(max = 255)` 제약도 유지됩니다.

추가한 테스트:

| 테스트 | 내용 |
|---|---|
| `ClubBoardTest` | 내용 null → 빈 문자열 저장, 빈 문자열 생성 성공, 수정으로 내용 비우기 |
| `ClubBoardAdminControllerTest` | 내용 null 로 201 + 빈 문자열 저장 확인, 빈 문자열로 201 |
