### PR TITLE
[Fix] 구글 자동 연동 대상이 없을 때 500이 반환되는 문제

### DIFF
--- a/src/main/java/org/project/ttokttok/domain/user/exception/GoogleLinkTargetNotFoundException.java
+++ b/src/main/java/org/project/ttokttok/domain/user/exception/GoogleLinkTargetNotFoundException.java
@@ -1,0 +1,16 @@
+package org.project.ttokttok.domain.user.exception;
+
+import org.project.ttokttok.global.exception.ErrorMessage;
+import org.project.ttokttok.global.exception.exception.CustomException;
+
+/**
+ * 구글 계정 자동 연동 대상 사용자를 찾지 못했을 때 발생한다.
+ *
+ * 트랜잭션 밖에서 이메일로 대상을 확인한 뒤 연동 트랜잭션 안에서 재조회하는 사이에
+ * 계정이 삭제된 경쟁 상황이다. 재시도로 해소되는 성격이라 404 가 아니라 409 로 응답한다.
+ */
+public class GoogleLinkTargetNotFoundException extends CustomException {
+    public GoogleLinkTargetNotFoundException() {
+        super(ErrorMessage.GOOGLE_LINK_TARGET_NOT_FOUND);
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/user/service/GoogleAccountWriter.java
+++ b/src/main/java/org/project/ttokttok/domain/user/service/GoogleAccountWriter.java
@@ -3,6 +3,7 @@ package org.project.ttokttok.domain.user.service;
 import lombok.RequiredArgsConstructor;
 import org.project.ttokttok.domain.user.domain.User;
 import org.project.ttokttok.domain.user.domain.enums.AuthProvider;
+import org.project.ttokttok.domain.user.exception.GoogleLinkTargetNotFoundException;
 import org.project.ttokttok.domain.user.repository.UserRepository;
 import org.project.ttokttok.global.auth.jwt.service.OnboardingTokenProvider.OnboardingClaims;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -57,11 +58,13 @@ public class GoogleAccountWriter {
      * 관리 상태 엔티티를 다루기 위해 트랜잭션 내부에서 재조회 후 연동한다.
      *
      * @throws DataIntegrityViolationException 병렬 연동 경쟁 시 (호출부에서 멱등 복구)
+     * @throws GoogleLinkTargetNotFoundException 재조회 시점에 대상 계정이 사라진 경우
      */
     @Transactional
     public User autoLink(String email, String sub) {
+        // 트랜잭션 밖 조회와 이 재조회 사이에 계정이 삭제된 경쟁 상황. 이메일은 메시지에 담지 않는다.
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalStateException("연동 대상 사용자가 존재하지 않습니다: " + email));
+                .orElseThrow(GoogleLinkTargetNotFoundException::new);
         user.linkGoogle(sub); // 다른 sub 와 이미 연동 시 GoogleAccountConflictException
         return userRepository.saveAndFlush(user);
     }

--- a/src/main/java/org/project/ttokttok/global/exception/ErrorMessage.java
+++ b/src/main/java/org/project/ttokttok/global/exception/ErrorMessage.java
@@ -104,7 +104,8 @@ public enum ErrorMessage {
     OAUTH_ONLY_ACCOUNT("구글 로그인으로 가입된 계정입니다. 구글 로그인을 이용해주세요.", HttpStatus.CONFLICT),
     INVALID_ONBOARDING_TOKEN("유효하지 않은 가입 세션입니다. 다시 로그인해주세요.", HttpStatus.UNAUTHORIZED),
     ONBOARDING_TOKEN_EXPIRED("가입 세션이 만료되었습니다. 다시 로그인해주세요.", HttpStatus.UNAUTHORIZED),
-    ONBOARDING_ALREADY_COMPLETED("이미 처리된 가입 요청입니다.", HttpStatus.CONFLICT);
+    ONBOARDING_ALREADY_COMPLETED("이미 처리된 가입 요청입니다.", HttpStatus.CONFLICT),
+    GOOGLE_LINK_TARGET_NOT_FOUND("계정 상태가 변경되었습니다. 다시 로그인해주세요.", HttpStatus.CONFLICT);
 
     private final String message;
     private final HttpStatus status;

--- a/src/test/java/org/project/ttokttok/domain/user/service/GoogleAccountWriterTest.java
+++ b/src/test/java/org/project/ttokttok/domain/user/service/GoogleAccountWriterTest.java
@@ -1,0 +1,68 @@
+package org.project.ttokttok.domain.user.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.domain.user.domain.User;
+import org.project.ttokttok.domain.user.exception.GoogleLinkTargetNotFoundException;
+import org.project.ttokttok.domain.user.repository.UserRepository;
+import org.springframework.http.HttpStatus;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class GoogleAccountWriterTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private GoogleAccountWriter googleAccountWriter;
+
+    private static final String SUB = "google-sub-123";
+    private static final String SMU_EMAIL = "202021000@sangmyung.kr";
+
+    private User localUser() {
+        return User.signUp(SMU_EMAIL, "encoded-password", "김철수", true);
+    }
+
+    @Test
+    @DisplayName("autoLink(): 연동 대상 계정이 사라졌으면 500이 아니라 409로 응답한다.")
+    void autoLink_targetMissing_throwsConflict() {
+        given(userRepository.findByEmail(SMU_EMAIL)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> googleAccountWriter.autoLink(SMU_EMAIL, SUB))
+                .isInstanceOf(GoogleLinkTargetNotFoundException.class)
+                .extracting(e -> ((GoogleLinkTargetNotFoundException) e).getStatus())
+                .isEqualTo(HttpStatus.CONFLICT);
+    }
+
+    @Test
+    @DisplayName("autoLink(): 연동 대상이 없을 때 예외 메시지에 이메일이 노출되지 않는다.")
+    void autoLink_targetMissing_doesNotLeakEmail() {
+        given(userRepository.findByEmail(SMU_EMAIL)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> googleAccountWriter.autoLink(SMU_EMAIL, SUB))
+                .isInstanceOf(GoogleLinkTargetNotFoundException.class)
+                .hasMessageNotContaining(SMU_EMAIL);
+    }
+
+    @Test
+    @DisplayName("autoLink(): 연동 대상이 있으면 구글 계정을 연동해 저장한다.")
+    void autoLink_success() {
+        User user = localUser();
+        given(userRepository.findByEmail(SMU_EMAIL)).willReturn(Optional.of(user));
+        given(userRepository.saveAndFlush(user)).willReturn(user);
+
+        User linked = googleAccountWriter.autoLink(SMU_EMAIL, SUB);
+
+        assertThat(linked.getProviderId()).isEqualTo(SUB);
+    }
+}


### PR DESCRIPTION
## ✨ 작업 내용

구글 계정 자동 연동 경로에서 연동 대상을 찾지 못할 때 **500 이 나가던 것을 409 로 교정**했습니다.

```java
// 변경 전 — CustomException 도 IllegalArgumentException 도 아니라 catch-all(500) 로 떨어진다
.orElseThrow(() -> new IllegalStateException("연동 대상 사용자가 존재하지 않습니다: " + email));

// 변경 후
.orElseThrow(GoogleLinkTargetNotFoundException::new);
```

- `ErrorMessage.GOOGLE_LINK_TARGET_NOT_FOUND` 추가 (409 CONFLICT)
- `CustomException` 을 상속한 `GoogleLinkTargetNotFoundException` 신규
- 예외 메시지에서 **사용자 이메일 제거** (로그·응답 노출 방지)
- Swagger 문서 변경 없음 / **DB 변경 없음**

### 왜 404 가 아니라 409 인가

`GoogleOAuthService.login()` 이 트랜잭션 밖에서 `findByEmail` 로 대상을 확인한 뒤
`autoLink` 트랜잭션 안에서 재조회하는데, 그 사이에 계정이 삭제되면 두 번째 조회가 빕니다.
"없는 리소스"가 아니라 **조회와 쓰기 사이의 경쟁 상황**이고 재시도로 해소되는 성격이라
409 + "다시 로그인해주세요" 안내가 맞다고 판단했습니다.

---

## 🔍 관련 이슈
- 해결한 이슈 번호: #387

---

## ✅ 체크리스트
- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요? (`maintenance/verify.sh` 통과)
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항

구글 OAuth 흐름의 나머지 실패 경로(토큰 위조/만료, aud 불일치, 이메일 미검증, 온보딩 토큰
재사용, 동시 가입 유니크 충돌)는 이미 전부 4xx 로 매핑되어 있었습니다. 이 경로만 예외적으로
500 이었습니다.

동시 가입 경쟁(`DataIntegrityViolationException` 멱등 복구)은 기존 로직 그대로 두었습니다.

신규 `GoogleAccountWriterTest` 3건: 연동 대상 없을 때 409, 메시지에 이메일 미포함,
정상 연동 성공.
