### PR TITLE
게시글 본문 길이 상한 추가 및 도메인 검증 메시지 한글화 (fix/#390 -> develop)

### DIFF
--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/ClubBoardUpdateRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/ClubBoardUpdateRequest.java
@@ -12,6 +12,8 @@ public record ClubBoardUpdateRequest(
         String title,
 
         @Schema(description = "선택적 필드 (생략 또는 null이면 기존 값 유지)", nullable = true, example = "값 또는 null")
+        // 저장 컬럼은 TEXT 라 무제한이지만, 저장소·응답 비대화를 막으려면 API 단에서 상한이 필요하다.
+        @Size(max = 10000, message = "내용은 최대 10000자까지 입력할 수 있습니다.")
         String content
 ) {
     public ClubBoardUpdateServiceRequest toServiceRequest(String username, String clubId, String boardId, MultipartFile thumbnail) {

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/CreateBoardRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/CreateBoardRequest.java
@@ -13,7 +13,9 @@ public record CreateBoardRequest(
         String title,
 
         // 내용은 선택 입력이다. 생략하면 빈 내용으로 저장된다.
+        // 저장 컬럼은 TEXT 라 무제한이지만, 저장소·응답 비대화를 막으려면 API 단에서 상한이 필요하다.
         @Schema(description = "선택적 필드 (생략 또는 null이면 빈 내용으로 저장)", nullable = true)
+        @Size(max = 10000, message = "내용은 최대 10000자까지 입력할 수 있습니다.")
         String content
 ) {
     public CreateBoardServiceRequest toServiceRequest(String username, String clubId, MultipartFile thumbnail) {

--- a/src/main/java/org/project/ttokttok/domain/clubboard/domain/ClubBoard.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/domain/ClubBoard.java
@@ -81,7 +81,7 @@ public class ClubBoard extends BaseTimeEntity {
     // ------- 유효성 검사 메서드 -------
     private static void validateClub(Club club) {
         if (club == null) {
-            throw new IllegalArgumentException("Club cannot be null.");
+            throw new IllegalArgumentException("동아리 정보가 없습니다.");
         }
     }
 
@@ -92,13 +92,13 @@ public class ClubBoard extends BaseTimeEntity {
 
     private static void validateTitle(String title) {
         if (title == null || title.isBlank()) {
-            throw new IllegalArgumentException("Title cannot be null or blank.");
+            throw new IllegalArgumentException("제목은 비어 있을 수 없습니다.");
         }
     }
 
     private static void validateThumbnailUrl(String thumbnailUrl) {
         if (thumbnailUrl == null || thumbnailUrl.isBlank()) {
-            throw new IllegalArgumentException("Thumbnail URL cannot be null or blank.");
+            throw new IllegalArgumentException("대표 이미지가 없습니다.");
         }
     }
 }

--- a/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminControllerTest.java
@@ -228,6 +228,43 @@ class ClubBoardAdminControllerTest {
     }
 
     @Test
+    @DisplayName("createBoard(): 내용이 10000자를 넘으면 400이 발생한다.")
+    void createBoard_contentTooLong() throws Exception {
+        CreateBoardRequest request = new CreateBoardRequest("제목입니다", "가".repeat(10001));
+
+        mockMvc.perform(multipart("/api/admin/clubs/{clubId}/boards", myClub.getId())
+                        .file(jsonPart(request))
+                        .file(thumbnailPart())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("createBoard(): 내용이 10000자면 생성에 성공한다.")
+    void createBoard_contentAtMaxLength() throws Exception {
+        CreateBoardRequest request = new CreateBoardRequest("제목입니다", "가".repeat(10000));
+
+        mockMvc.perform(multipart("/api/admin/clubs/{clubId}/boards", myClub.getId())
+                        .file(jsonPart(request))
+                        .file(thumbnailPart())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("updateBoard(): 내용이 10000자를 넘으면 400이 발생한다.")
+    void updateBoard_contentTooLong() throws Exception {
+        ClubBoard board = saveBoard("원래 제목", "원래 내용");
+
+        ClubBoardUpdateRequest request = new ClubBoardUpdateRequest(null, "가".repeat(10001));
+
+        mockMvc.perform(multipart(HttpMethod.PATCH, "/api/admin/clubs/{clubId}/boards/{boardId}", myClub.getId(), board.getId())
+                        .file(jsonPart(request))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     @DisplayName("updateBoard(): 제목이 255자를 넘으면 400이 발생한다.")
     void updateBoard_titleTooLong() throws Exception {
         ClubBoard board = saveBoard("원래 제목", "원래 내용");

--- a/src/test/java/org/project/ttokttok/domain/clubboard/domain/ClubBoardTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/domain/ClubBoardTest.java
@@ -38,7 +38,7 @@ class ClubBoardTest {
 
             assertThatThrownBy(() -> ClubBoard.create(" ", "내용", THUMBNAIL_URL, club))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Title cannot be null or blank.");
+                    .hasMessage("제목은 비어 있을 수 없습니다.");
         }
 
         @Test
@@ -48,7 +48,7 @@ class ClubBoardTest {
 
             assertThatThrownBy(() -> ClubBoard.create(null, "내용", THUMBNAIL_URL, club))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Title cannot be null or blank.");
+                    .hasMessage("제목은 비어 있을 수 없습니다.");
         }
 
         @Test
@@ -78,7 +78,7 @@ class ClubBoardTest {
 
             assertThatThrownBy(() -> ClubBoard.create("제목", "내용", null, club))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Thumbnail URL cannot be null or blank.");
+                    .hasMessage("대표 이미지가 없습니다.");
         }
 
         @Test
@@ -88,7 +88,7 @@ class ClubBoardTest {
 
             assertThatThrownBy(() -> ClubBoard.create("제목", "내용", " ", club))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Thumbnail URL cannot be null or blank.");
+                    .hasMessage("대표 이미지가 없습니다.");
         }
 
         @Test
@@ -96,7 +96,7 @@ class ClubBoardTest {
         void createFailNullClub() {
             assertThatThrownBy(() -> ClubBoard.create("제목", "내용", THUMBNAIL_URL, null))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Club cannot be null.");
+                    .hasMessage("동아리 정보가 없습니다.");
         }
     }
 
@@ -159,7 +159,7 @@ class ClubBoardTest {
 
             assertThatThrownBy(() -> board.update(" ", null))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Title cannot be null or blank.");
+                    .hasMessage("제목은 비어 있을 수 없습니다.");
         }
 
         @Test
@@ -196,10 +196,10 @@ class ClubBoardTest {
 
             assertThatThrownBy(() -> board.updateThumbnailUrl(null))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Thumbnail URL cannot be null or blank.");
+                    .hasMessage("대표 이미지가 없습니다.");
             assertThatThrownBy(() -> board.updateThumbnailUrl(" "))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Thumbnail URL cannot be null or blank.");
+                    .hasMessage("대표 이미지가 없습니다.");
         }
     }
 }


### PR DESCRIPTION
## ✨ 작업 내용

#379(제목 길이 검증)와 #386(내용 선택 필드화)에서 후속으로 남겨둔 게시판 검증 항목 두 가지를
정리했습니다. 관심사가 달라 커밋을 2개로 나눴습니다.

### 1. 본문 길이 상한 추가 (동작 변경)

`content` 는 저장 컬럼이 `TEXT` 라 상한이 없어, 수십만 자짜리 본문도 그대로 저장됐습니다.
제목만 `@Size(max = 255)` 로 막혀 있고 본문은 무제한이었습니다.

- `CreateBoardRequest.content` / `ClubBoardUpdateRequest.content` 에 `@Size(max = 10000)` 추가

**10,000자로 정한 근거**: 동아리 공지·모집글 본문으로 충분하고(A4 기준 대략 5~6장),
UTF-8 약 30KB 라 썸네일 업로드 제한(20MB)과 충돌하지 않습니다. 기존 선례(메모 100자,
제목 255자, 이름 2~10자)와 같은 축입니다.

### 2. 도메인 검증 메시지 한글화 (동작 불변)

`ClubBoard` 의 검증 예외 메시지가 영문이라, `IllegalArgumentException` 핸들러를 타고
**응답 바디 `details` 에 영문이 그대로 노출**됐습니다. DTO 검증 메시지는 전부 한글이라
같은 400 인데도 어느 계층에서 걸렸느냐에 따라 언어가 달라졌습니다.

| 변경 전 | 변경 후 |
|---|---|
| `Title cannot be null or blank.` | `제목은 비어 있을 수 없습니다.` |
| `Thumbnail URL cannot be null or blank.` | `대표 이미지가 없습니다.` |
| `Club cannot be null.` | `동아리 정보가 없습니다.` |

Swagger 문서 변경 없음 / **DB 변경 없음**.

---

## 🔍 관련 이슈
- 해결한 이슈 번호: #390

---

## ✅ 체크리스트
- [x] Assign 확인하였나요?
- [x] 로컬 테스트 완료하였나요? (`maintenance/verify.sh` 그린)
- [x] 라벨을 붙혔나요?
- [x] 팀 코드 컨벤션 준수하였나요?

---

## 💬 기타 참고 사항

**API 계약 변경**: 10,001자 이상 본문이 이전에는 통과했지만 이제 400 입니다. 기존에 저장된
초과 데이터가 있어도 컬럼은 `TEXT` 그대로라 조회에는 영향이 없습니다.

추가한 테스트 (`ClubBoardAdminControllerTest`):

| 테스트 | 기대 |
|---|---|
| 생성 본문 10,000자 | 201 |
| 생성 본문 10,001자 | 400 |
| 수정 본문 10,001자 | 400 |

`ClubBoardTest` 는 메시지를 검증하던 기존 단언 8곳의 문구만 교정했습니다 (케이스 증감 없음).

**이번 범위에서 제외한 것**

- `ErrorMessage` 의 `TITLE_NULL_OR_BLANK` / `CONTENT_NULL_OR_BLANK` / `CLUB_NULL_POINTER`
  상수는 정의만 되어 있고 어디서도 쓰이지 않습니다. 예외 타입 교체
  (`IllegalArgumentException` → `CustomException`)는 상태 코드가 바뀌는 변경이라
  (`CLUB_NULL_POINTER` 는 500) 별도로 다루는 편이 안전해 손대지 않았습니다.
- `Notice` 도메인에도 동일한 영문 메시지가 있습니다. 이번엔 신고된 `clubboard` 로 한정했고,
  같은 성격이라 후속으로 묶어 처리하면 됩니다.
