### PR TITLE
Deploy Trigger — v2 QA 버그 수정 및 온프렘 인프라 결함 2건 반영

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -147,6 +147,28 @@ Postfix 는 `mynetworks` 안에서 오는 요청을 인증 없이 받으므로 �
   **내부 문자열**에도 박혀 있다. 도메인을 유지하는 대가로 DB 를 한 줄도 안 건드린다.
 - **`POSTGRES_USER` 는 `postgres` 여야 한다.** 백업 덤프의 객체 소유자가 `postgres` 라,
   다른 이름으로 초기화하면 `ALTER ... OWNER TO postgres` 가 "role does not exist" 로 실패한다.
+- **`data/` 를 쓰는 컨테이너는 uid 를 명시해야 한다.** `setup.sh` 는 `data/*` 를
+  `ttokttokuser:ttokttok`(1001:1003) 로 통일한다. 이미지 기본 uid 가 그와 다르면 컨테이너가
+  자기 데이터 디렉터리에 못 쓴다. `minio`·`redis` 는 그래서 `user: "1001:1003"` 을 박아뒀다.
+  `postgres` 만 이미지가 uid 70 을 강제해서 예외이고, 대신 `data/postgres` 를 70:70 으로 둔다.
+
+  | 서비스 | 프로세스 uid | `data/` 소유 |
+  |---|---|---|
+  | postgres | 70 (이미지 고정) | 70:70 |
+  | minio | 1001:1003 (`user:`) | 1001:1003 |
+  | redis | 1001:1003 (`user:`) | 1001:1003 |
+
+  redis 에서 이게 어긋나면 **읽기는 되고 쓰기만 죽는다.** BGSAVE 가 temp 파일을 못 만들고,
+  `stop-writes-on-bgsave-error` 기본값이 `yes` 라 모든 쓰기가 `MISCONF` 로 거부된다.
+  컨테이너는 healthy 고 `PING` 도 `PONG` 이라 헬스체크로는 안 잡힌다. 게다가 이미 열어둔
+  AOF fd 로 append 는 계속되므로, 소유권이 바뀐 직후가 아니라 **다음 자동 BGSAVE 시점에**
+  터진다. 증상은 로그인 실패로 나타난다.
+
+  ```bash
+  docker exec ttokttok-redis id -u                          # user: 값과 같아야 한다
+  docker logs ttokttok-redis | grep -i 'bgsave\|permission'
+  ```
+
 - **헬스 엔드포인트는 `/health` 다.** 이 앱에는 actuator 의존성이 없어서
   `/actuator/health` 는 404 다. `/health` 는 `SecurityWhiteList` 에 등록된 공개 경로다.
 - **`upstream.conf` 는 단일 파일 바인드 마운트**다. `sed -i` 처럼 inode 를 바꾸는 방식으로

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -147,6 +147,15 @@ Postfix 는 `mynetworks` 안에서 오는 요청을 인증 없이 받으므로 �
   **내부 문자열**에도 박혀 있다. 도메인을 유지하는 대가로 DB 를 한 줄도 안 건드린다.
 - **`POSTGRES_USER` 는 `postgres` 여야 한다.** 백업 덤프의 객체 소유자가 `postgres` 라,
   다른 이름으로 초기화하면 `ALTER ... OWNER TO postgres` 가 "role does not exist" 로 실패한다.
+- **`docker-compose.yml` 은 CI 로 배포되지 않는다.** GitHub Actions 는 `deploy.sh` 만 부르고,
+  `deploy.sh` 는 **이미 서버에 있는** compose 를 읽을 뿐이다. 서버의
+  `/opt/ttokttok/app/docker-compose.yml` 을 갱신하는 경로는 `setup.sh` 하나뿐이다.
+  compose·nginx 템플릿·`bin/` 스크립트를 고쳐 머지했다면 **`sudo deploy/setup.sh` 를
+  따로 돌려야 한다.** 앱 코드만 고쳤다면 배포로 충분하다.
+
+  `setup.sh` 는 compose 내용이 실제로 바뀐 경우에만 인프라 서비스를 재조정한다.
+  파일만 갈아끼우고 끝내면 로그는 "배치 완료" 인데 컨테이너는 옛 정의로 계속 돈다.
+
 - **`data/` 를 쓰는 컨테이너는 uid 를 명시해야 한다.** `setup.sh` 는 `data/*` 를
   `ttokttokuser:ttokttok`(1001:1003) 로 통일한다. 이미지 기본 uid 가 그와 다르면 컨테이너가
   자기 데이터 디렉터리에 못 쓴다. `minio`·`redis` 는 그래서 `user: "1001:1003"` 을 박아뒀다.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -192,6 +192,11 @@ services:
     image: redis:7.2-alpine
     container_name: ttokttok-redis
     restart: unless-stopped
+    # 이미지 entrypoint 가 uid 999(redis) 로 강등하는데 data/redis 는 setup.sh 가
+    # ttokttokuser(1001:1003) 로 chown 한다. 그대로 두면 BGSAVE 가 /data 에 temp
+    # 파일을 못 만들고, stop-writes-on-bgsave-error 기본값 때문에 쓰기 명령 전체가
+    # MISCONF 로 거부된다. minio 와 같은 이유로 호스트 계정에 맞춰 고정한다.
+    user: "1001:1003"
     ports:
       - "127.0.0.1:16379:6379"
     command: >

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -21,10 +21,36 @@ log() { printf '\033[36m[setup]\033[0m %s\n' "$*"; }
 # /opt 은 루트 파티션(46G 중 34G 여유)이라 DB+업로드가 쌓이면 위험하다.
 log "데이터 디렉터리: $DATA_SRC"
 mkdir -p "$DATA_SRC"/{postgres,redis,minio,certbot/conf,certbot/www}
-# 디렉터리 자체만 chown 한다. -R 을 쓰면 실행 중인 컨테이너의 데이터 파일까지
-# 소유권이 바뀐다 — 6단계 주석 참고.
-chown "$RUN_USER:$RUN_GROUP" \
-      "$DATA_SRC" "$DATA_SRC"/{postgres,redis,minio,certbot,certbot/conf,certbot/www}
+
+# data/<서비스> 의 소유자는 "그 디렉터리에 실제로 쓰는 컨테이너의 uid" 여야 한다.
+# 전부 $RUN_USER 로 통일하면 안 된다. 컨테이너마다 uid 가 다르고, 어긋나면 컨테이너가
+# 자기 데이터 디렉터리에 못 쓴다.
+#
+#   postgres  uid 70      이미지가 강제한다. user: 를 줄 수 없다.
+#   redis     compose user: "1001:1003"   (기본값은 uid 999 — #382)
+#   minio     compose user: "1001:1003"
+#   certbot   root 로 돈다. root 는 권한을 안 타므로 호스트 도구가 읽기 좋은 쪽에 맞춘다.
+#
+# 이 표는 docker-compose.yml 의 user: 와 반드시 같이 움직여야 한다. 아래 12단계가
+# 실제로 대조하므로, 어긋난 채로 이 스크립트가 끝나지는 않는다.
+#
+# redis 를 $RUN_USER 로 맞춰둔 채 이미지 기본 uid(999)로 돌렸다가 BGSAVE 가 막혀
+# 쓰기 전체가 MISCONF 로 거부된 적이 있다. 로그인이 20시간 죽었는데 컨테이너는
+# 내내 healthy 였다 — #382.
+declare -A DATA_OWNER=(
+    [postgres]="70:70"
+    [redis]="$RUN_USER:$RUN_GROUP"
+    [minio]="$RUN_USER:$RUN_GROUP"
+    [certbot]="$RUN_USER:$RUN_GROUP"
+    [certbot/conf]="$RUN_USER:$RUN_GROUP"
+    [certbot/www]="$RUN_USER:$RUN_GROUP"
+)
+chown "$RUN_USER:$RUN_GROUP" "$DATA_SRC"
+for d in "${!DATA_OWNER[@]}"; do
+    # 디렉터리 자체만 chown 한다. -R 을 쓰면 실행 중인 컨테이너의 데이터 파일까지
+    # 소유권이 바뀐다 — 6단계 주석 참고.
+    chown "${DATA_OWNER[$d]}" "$DATA_SRC/$d"
+done
 
 # ── 2. /opt/ttokttok 구조 ────────────────────────────────────────────────
 log "디렉터리 구조 생성"
@@ -49,7 +75,10 @@ mountpoint -q "$ROOT/data" \
 
 # ── 4. 파일 배치 ─────────────────────────────────────────────────────────
 log "설정/스크립트 배치"
+# compose 정의가 이번 실행으로 바뀌었는지 기록해둔다. 11단계에서 쓴다.
+compose_before="$(sha256sum "$ROOT/app/docker-compose.yml" 2>/dev/null | cut -d' ' -f1 || true)"
 install -m 0664 "$SRC/docker-compose.yml"                        "$ROOT/app/docker-compose.yml"
+compose_after="$(sha256sum "$ROOT/app/docker-compose.yml" | cut -d' ' -f1)"
 install -m 0775 "$SRC/deploy.sh"                                 "$ROOT/app/deploy.sh"
 install -m 0664 "$SRC/docker/postfix/Dockerfile"                 "$ROOT/docker/postfix/Dockerfile"
 install -m 0775 "$SRC/docker/postfix/entrypoint.sh"              "$ROOT/docker/postfix/entrypoint.sh"
@@ -189,6 +218,84 @@ EOF
 chmod 0644 /etc/cron.d/ttokttok-certs
 # 이름이 바뀌었으므로 옛 파일을 지운다. 남겨두면 reload 가 두 번 등록된다.
 rm -f /etc/cron.d/ttokttok-nginx-reload
+
+# ── 11. compose 정의 반영 ────────────────────────────────────────────────
+# 이 스크립트가 docker-compose.yml 을 서버에 옮기는 유일한 경로다. CI 는
+# deploy.sh 만 부르고, deploy.sh 는 이미 서버에 있는 compose 를 읽을 뿐이다.
+# 그래서 compose 를 고쳐 머지해도 setup.sh 를 돌리기 전까지는 아무 일도 안 일어난다.
+#
+# 파일만 갈아끼우고 끝내면 "배치했다" 는 로그만 남고 실행 중인 컨테이너는 옛 정의
+# 그대로 돈다. 다음 배포(deploy.sh 의 up -d)까지 반영이 미뤄지는데, 그 사이에
+# 재발한 게 #382 였다. 그래서 여기서 바로 재조정한다.
+#
+# 내용이 안 바뀌었으면 건드리지 않는다. up -d 는 정의가 바뀐 서비스만 재생성하지만,
+# 굳이 매번 부를 이유도 없다.
+INFRA_SERVICES="${INFRA_SERVICES:-postgres redis minio minio-init smtp nginx certbot}"
+compose_up() { sudo -u "$RUN_USER" sh -c "cd '$ROOT/app' && docker compose $*"; }
+
+if [[ -z "$compose_before" ]]; then
+    log "compose 최초 배치 — 기동은 아래 '다음 순서' 참고"
+elif [[ "$compose_before" == "$compose_after" ]]; then
+    log "compose 정의 변경 없음"
+elif ! compose_up ps -q 2>/dev/null | grep -q .; then
+    log "compose 정의가 바뀌었지만 스택이 떠 있지 않다 — 재조정 생략"
+else
+    log "compose 정의가 바뀌었다 — 인프라 서비스 재조정"
+    # shellcheck disable=SC2086
+    compose_up up -d $INFRA_SERVICES
+fi
+
+# ── 12. 소유권 검증 ──────────────────────────────────────────────────────
+# 1단계의 DATA_OWNER 표가 compose 의 user: 와 어긋나지 않았는지, 표가 아니라
+# 실제로 확인한다. 각 컨테이너의 실행 uid 로 자기 데이터 디렉터리에 파일을
+# 만들어 본다.
+#
+# 이 검증이 필요한 이유는 실패가 조용하기 때문이다. redis 를 예로 들면
+#   - 컨테이너는 계속 healthy 다. 헬스체크가 PING 이고 PONG 은 정상적으로 온다.
+#   - 읽기는 전부 된다. 쓰기만 죽는다.
+#   - 소유권이 바뀐 직후에 안 터진다. 이미 열어둔 AOF fd 로 append 는 계속되므로
+#     최대 1시간 뒤 첫 자동 BGSAVE 에서야 실패한다.
+# postgres 만 PANIC 으로 즉시 티가 났고, 그건 이 이미지의 성질이지 규칙이 아니다.
+log "데이터 디렉터리 쓰기 권한 검증"
+probe_failed=0
+for cid in $(compose_up ps -q 2>/dev/null); do
+    name="$(docker inspect -f '{{.Name}}' "$cid" 2>/dev/null | tr -d /)" || continue
+    [[ "$(docker inspect -f '{{.State.Running}}' "$cid")" == true ]] || continue
+    pid="$(docker inspect -f '{{.State.Pid}}' "$cid")"
+    uid="$(awk '/^Uid:/{print $2}' "/proc/$pid/status" 2>/dev/null)" || continue
+    gid="$(awk '/^Gid:/{print $2}' "/proc/$pid/status" 2>/dev/null)"
+
+    # 읽기 전용 마운트와 data/ 밖은 검사 대상이 아니다. 경로 필터는 셸에서 한다 —
+    # docker inspect 의 템플릿 함수에는 접두사 비교가 없다.
+    while read -r src dest; do
+        [[ -n "$dest" ]] || continue
+        [[ "$src" == "$ROOT/data/"* || "$src" == "$DATA_SRC/"* ]] || continue
+        if docker exec -u "$uid:$gid" "$cid" \
+             sh -c "touch '$dest/.setup-probe' 2>/dev/null && rm -f '$dest/.setup-probe'" 2>/dev/null
+        then
+            printf '  \033[32mOK\033[0m      %-14s uid %-10s %s\n' "${name#ttokttok-}" "$uid:$gid" "$dest"
+        else
+            printf '  \033[31mDENIED\033[0m  %-14s uid %-10s %s\n' "${name#ttokttok-}" "$uid:$gid" "$dest"
+            probe_failed=1
+        fi
+    done < <(docker inspect -f \
+        '{{range .Mounts}}{{if and (eq .Type "bind") .RW}}{{.Source}} {{println .Destination}}{{end}}{{end}}' \
+        "$cid" 2>/dev/null)
+done
+
+if (( probe_failed )); then
+    cat >&2 <<EOF
+
+[setup] 컨테이너가 자기 데이터 디렉터리에 쓰지 못한다.
+
+  compose 의 user: 와 1단계 DATA_OWNER 표가 어긋났다는 뜻이다. 둘을 맞춘 뒤
+  해당 서비스를 재생성해야 한다. 이대로 두면 서비스는 healthy 인 채로 쓰기만
+  실패한다 — redis 는 MISCONF 로 로그인이 죽고, minio 는 업로드가 죽는다.
+
+    cd $ROOT/app && docker compose up -d --force-recreate <서비스>
+EOF
+    exit 1
+fi
 
 log "완료."
 echo

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminController.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminController.java
@@ -49,7 +49,7 @@ public class ClubBoardAdminController implements ClubBoardAdminDocs {
             @AuthUserInfo String username,
             @PathVariable String clubId,
             @PathVariable String boardId,
-            @RequestPart(value = "request", required = false) ClubBoardUpdateRequest request,
+            @RequestPart(value = "request", required = false) @Valid ClubBoardUpdateRequest request,
             @RequestPart(value = "thumbnail", required = false) MultipartFile thumbnail
     ) {
         ClubBoardUpdateRequest safeRequest = request != null

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/docs/ClubBoardAdminDocs.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/docs/ClubBoardAdminDocs.java
@@ -30,11 +30,12 @@ public interface ClubBoardAdminDocs {
                     **요청 형식**: Multipart Form Data
 
                     **요청 파라미터**:
-                    - `request`: JSON 형태의 게시글 정보 (CreateBoardRequest, 제목/내용 필수)
+                    - `request`: JSON 형태의 게시글 정보 (CreateBoardRequest, 제목 필수 / 내용 선택)
                     - `thumbnail`: 대표(썸네일) 이미지 파일 (**필수**)
 
                     *주의사항*:
                     - 해당 동아리의 관리자만 작성 가능합니다.
+                    - 내용은 생략하거나 null로 보낼 수 있으며, 이 경우 빈 내용으로 저장됩니다.
                     - 썸네일은 JPG, PNG, WEBP, GIF, HEIC 형식만 지원됩니다. (최대 20MB)
                     - 업로드된 썸네일은 S3(board-images/)에 저장되며 목록 조회 응답의 thumbnailUrl로 내려갑니다.
                     """
@@ -43,7 +44,7 @@ public interface ClubBoardAdminDocs {
             content = @Content(
                     mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
                     schemaProperties = {
-                            @SchemaProperty(name = "request", schema = @Schema(type = "string", format = "json", description = "게시글 생성 데이터 (title, content)")),
+                            @SchemaProperty(name = "request", schema = @Schema(type = "string", format = "json", description = "게시글 생성 데이터 (title 필수, content 선택)")),
                             @SchemaProperty(name = "thumbnail", schema = @Schema(type = "string", format = "binary", description = "대표(썸네일) 이미지 파일 (필수)"))
                     }
             )

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/ClubBoardUpdateRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/ClubBoardUpdateRequest.java
@@ -1,11 +1,14 @@
 package org.project.ttokttok.domain.clubboard.controller.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
 import org.project.ttokttok.domain.clubboard.service.dto.request.ClubBoardUpdateServiceRequest;
 import org.springframework.web.multipart.MultipartFile;
 
 public record ClubBoardUpdateRequest(
         @Schema(description = "선택적 필드 (생략 또는 null이면 기존 값 유지)", nullable = true, example = "값 또는 null")
+        // 저장 컬럼이 VARCHAR(255) 라 초과하면 DB 단에서 터진다. 여기서 막아 400 으로 돌려준다.
+        @Size(max = 255, message = "제목은 최대 255자까지 입력할 수 있습니다.")
         String title,
 
         @Schema(description = "선택적 필드 (생략 또는 null이면 기존 값 유지)", nullable = true, example = "값 또는 null")

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/ClubBoardUpdateRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/ClubBoardUpdateRequest.java
@@ -12,6 +12,8 @@ public record ClubBoardUpdateRequest(
         String title,
 
         @Schema(description = "선택적 필드 (생략 또는 null이면 기존 값 유지)", nullable = true, example = "값 또는 null")
+        // 저장 컬럼은 TEXT 라 무제한이지만, 저장소·응답 비대화를 막으려면 API 단에서 상한이 필요하다.
+        @Size(max = 10000, message = "내용은 최대 10000자까지 입력할 수 있습니다.")
         String content
 ) {
     public ClubBoardUpdateServiceRequest toServiceRequest(String username, String clubId, String boardId, MultipartFile thumbnail) {

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/CreateBoardRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/CreateBoardRequest.java
@@ -13,7 +13,9 @@ public record CreateBoardRequest(
         String title,
 
         // 내용은 선택 입력이다. 생략하면 빈 내용으로 저장된다.
+        // 저장 컬럼은 TEXT 라 무제한이지만, 저장소·응답 비대화를 막으려면 API 단에서 상한이 필요하다.
         @Schema(description = "선택적 필드 (생략 또는 null이면 빈 내용으로 저장)", nullable = true)
+        @Size(max = 10000, message = "내용은 최대 10000자까지 입력할 수 있습니다.")
         String content
 ) {
     public CreateBoardServiceRequest toServiceRequest(String username, String clubId, MultipartFile thumbnail) {

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/CreateBoardRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/CreateBoardRequest.java
@@ -1,11 +1,14 @@
 package org.project.ttokttok.domain.clubboard.controller.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import org.project.ttokttok.domain.clubboard.service.dto.request.CreateBoardServiceRequest;
 import org.springframework.web.multipart.MultipartFile;
 
 public record CreateBoardRequest(
         @NotBlank(message = "제목은 비어 있을 수 없습니다.")
+        // 저장 컬럼이 VARCHAR(255) 라 초과하면 DB 단에서 터진다. 여기서 막아 400 으로 돌려준다.
+        @Size(max = 255, message = "제목은 최대 255자까지 입력할 수 있습니다.")
         String title,
 
         @NotBlank(message = "내용은 비어 있을 수 없습니다.")

--- a/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/CreateBoardRequest.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/controller/dto/request/CreateBoardRequest.java
@@ -1,5 +1,6 @@
 package org.project.ttokttok.domain.clubboard.controller.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import org.project.ttokttok.domain.clubboard.service.dto.request.CreateBoardServiceRequest;
@@ -11,7 +12,8 @@ public record CreateBoardRequest(
         @Size(max = 255, message = "제목은 최대 255자까지 입력할 수 있습니다.")
         String title,
 
-        @NotBlank(message = "내용은 비어 있을 수 없습니다.")
+        // 내용은 선택 입력이다. 생략하면 빈 내용으로 저장된다.
+        @Schema(description = "선택적 필드 (생략 또는 null이면 빈 내용으로 저장)", nullable = true)
         String content
 ) {
     public CreateBoardServiceRequest toServiceRequest(String username, String clubId, MultipartFile thumbnail) {

--- a/src/main/java/org/project/ttokttok/domain/clubboard/domain/ClubBoard.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/domain/ClubBoard.java
@@ -81,7 +81,7 @@ public class ClubBoard extends BaseTimeEntity {
     // ------- 유효성 검사 메서드 -------
     private static void validateClub(Club club) {
         if (club == null) {
-            throw new IllegalArgumentException("Club cannot be null.");
+            throw new IllegalArgumentException("동아리 정보가 없습니다.");
         }
     }
 
@@ -92,13 +92,13 @@ public class ClubBoard extends BaseTimeEntity {
 
     private static void validateTitle(String title) {
         if (title == null || title.isBlank()) {
-            throw new IllegalArgumentException("Title cannot be null or blank.");
+            throw new IllegalArgumentException("제목은 비어 있을 수 없습니다.");
         }
     }
 
     private static void validateThumbnailUrl(String thumbnailUrl) {
         if (thumbnailUrl == null || thumbnailUrl.isBlank()) {
-            throw new IllegalArgumentException("Thumbnail URL cannot be null or blank.");
+            throw new IllegalArgumentException("대표 이미지가 없습니다.");
         }
     }
 }

--- a/src/main/java/org/project/ttokttok/domain/clubboard/domain/ClubBoard.java
+++ b/src/main/java/org/project/ttokttok/domain/clubboard/domain/ClubBoard.java
@@ -55,7 +55,6 @@ public class ClubBoard extends BaseTimeEntity {
             this.title = title;
         }
         if (content != null) {
-            validateContent(content);
             this.content = content;
         }
     }
@@ -68,13 +67,12 @@ public class ClubBoard extends BaseTimeEntity {
     // ------- 정적 메서드 -------
     public static ClubBoard create(String title, String content, String thumbnailUrl, Club club) {
         validateTitle(title);
-        validateContent(content);
         validateThumbnailUrl(thumbnailUrl);
         validateClub(club);
 
         return ClubBoard.builder()
                 .title(title)
-                .content(content)
+                .content(normalizeContent(content))
                 .thumbnailUrl(thumbnailUrl)
                 .club(club)
                 .build();
@@ -87,10 +85,9 @@ public class ClubBoard extends BaseTimeEntity {
         }
     }
 
-    private static void validateContent(String content) {
-        if (content == null || content.isBlank()) {
-            throw new IllegalArgumentException("Content cannot be null or blank.");
-        }
+    // 내용은 선택 입력이다. 저장 컬럼이 NOT NULL 이라 미입력은 빈 문자열로 맞춰 둔다.
+    private static String normalizeContent(String content) {
+        return content != null ? content : "";
     }
 
     private static void validateTitle(String title) {

--- a/src/main/java/org/project/ttokttok/domain/user/exception/GoogleLinkTargetNotFoundException.java
+++ b/src/main/java/org/project/ttokttok/domain/user/exception/GoogleLinkTargetNotFoundException.java
@@ -1,0 +1,16 @@
+package org.project.ttokttok.domain.user.exception;
+
+import org.project.ttokttok.global.exception.ErrorMessage;
+import org.project.ttokttok.global.exception.exception.CustomException;
+
+/**
+ * 구글 계정 자동 연동 대상 사용자를 찾지 못했을 때 발생한다.
+ *
+ * 트랜잭션 밖에서 이메일로 대상을 확인한 뒤 연동 트랜잭션 안에서 재조회하는 사이에
+ * 계정이 삭제된 경쟁 상황이다. 재시도로 해소되는 성격이라 404 가 아니라 409 로 응답한다.
+ */
+public class GoogleLinkTargetNotFoundException extends CustomException {
+    public GoogleLinkTargetNotFoundException() {
+        super(ErrorMessage.GOOGLE_LINK_TARGET_NOT_FOUND);
+    }
+}

--- a/src/main/java/org/project/ttokttok/domain/user/service/GoogleAccountWriter.java
+++ b/src/main/java/org/project/ttokttok/domain/user/service/GoogleAccountWriter.java
@@ -3,6 +3,7 @@ package org.project.ttokttok.domain.user.service;
 import lombok.RequiredArgsConstructor;
 import org.project.ttokttok.domain.user.domain.User;
 import org.project.ttokttok.domain.user.domain.enums.AuthProvider;
+import org.project.ttokttok.domain.user.exception.GoogleLinkTargetNotFoundException;
 import org.project.ttokttok.domain.user.repository.UserRepository;
 import org.project.ttokttok.global.auth.jwt.service.OnboardingTokenProvider.OnboardingClaims;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -57,11 +58,13 @@ public class GoogleAccountWriter {
      * 관리 상태 엔티티를 다루기 위해 트랜잭션 내부에서 재조회 후 연동한다.
      *
      * @throws DataIntegrityViolationException 병렬 연동 경쟁 시 (호출부에서 멱등 복구)
+     * @throws GoogleLinkTargetNotFoundException 재조회 시점에 대상 계정이 사라진 경우
      */
     @Transactional
     public User autoLink(String email, String sub) {
+        // 트랜잭션 밖 조회와 이 재조회 사이에 계정이 삭제된 경쟁 상황. 이메일은 메시지에 담지 않는다.
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalStateException("연동 대상 사용자가 존재하지 않습니다: " + email));
+                .orElseThrow(GoogleLinkTargetNotFoundException::new);
         user.linkGoogle(sub); // 다른 sub 와 이미 연동 시 GoogleAccountConflictException
         return userRepository.saveAndFlush(user);
     }

--- a/src/main/java/org/project/ttokttok/global/exception/ErrorMessage.java
+++ b/src/main/java/org/project/ttokttok/global/exception/ErrorMessage.java
@@ -104,7 +104,8 @@ public enum ErrorMessage {
     OAUTH_ONLY_ACCOUNT("구글 로그인으로 가입된 계정입니다. 구글 로그인을 이용해주세요.", HttpStatus.CONFLICT),
     INVALID_ONBOARDING_TOKEN("유효하지 않은 가입 세션입니다. 다시 로그인해주세요.", HttpStatus.UNAUTHORIZED),
     ONBOARDING_TOKEN_EXPIRED("가입 세션이 만료되었습니다. 다시 로그인해주세요.", HttpStatus.UNAUTHORIZED),
-    ONBOARDING_ALREADY_COMPLETED("이미 처리된 가입 요청입니다.", HttpStatus.CONFLICT);
+    ONBOARDING_ALREADY_COMPLETED("이미 처리된 가입 요청입니다.", HttpStatus.CONFLICT),
+    GOOGLE_LINK_TARGET_NOT_FOUND("계정 상태가 변경되었습니다. 다시 로그인해주세요.", HttpStatus.CONFLICT);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/org/project/ttokttok/infrastructure/redis/service/RefreshTokenRedisService.java
+++ b/src/main/java/org/project/ttokttok/infrastructure/redis/service/RefreshTokenRedisService.java
@@ -64,6 +64,13 @@ public class RefreshTokenRedisService {
 
     // 액세스 토큰 블랙리스트 추가 - 로그아웃 시
     public void addAccessTokenToBlacklist(String accessToken, long expiryTime) {
+        // 이미 만료된 토큰은 만료 검증만으로 거부되므로 블랙리스트가 필요 없다.
+        // 게다가 Redis 는 TTL 이 0 이하인 SET 을 거부하므로(ERR invalid expire time) 그대로 넘기면 500 이 된다.
+        if (expiryTime <= 0) {
+            log.debug("이미 만료된 액세스 토큰이라 블랙리스트 등록을 생략한다");
+            return;
+        }
+
         // 액세스 토큰의 남은 만료 시간만큼 블랙리스트에 저장
         redisTemplate.opsForValue().set(
                 ACCESS_BLACKLIST_KEY + accessToken,

--- a/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminControllerTest.java
@@ -150,6 +150,43 @@ class ClubBoardAdminControllerTest {
     }
 
     @Test
+    @DisplayName("createBoard(): 제목이 255자를 넘으면 400이 발생한다.")
+    void createBoard_titleTooLong() throws Exception {
+        CreateBoardRequest request = new CreateBoardRequest("가".repeat(256), "본문입니다");
+
+        mockMvc.perform(multipart("/api/admin/clubs/{clubId}/boards", myClub.getId())
+                        .file(jsonPart(request))
+                        .file(thumbnailPart())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("createBoard(): 제목이 255자면 생성에 성공한다.")
+    void createBoard_titleAtMaxLength() throws Exception {
+        CreateBoardRequest request = new CreateBoardRequest("가".repeat(255), "본문입니다");
+
+        mockMvc.perform(multipart("/api/admin/clubs/{clubId}/boards", myClub.getId())
+                        .file(jsonPart(request))
+                        .file(thumbnailPart())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("updateBoard(): 제목이 255자를 넘으면 400이 발생한다.")
+    void updateBoard_titleTooLong() throws Exception {
+        ClubBoard board = saveBoard("원래 제목", "원래 내용");
+
+        ClubBoardUpdateRequest request = new ClubBoardUpdateRequest("가".repeat(256), null);
+
+        mockMvc.perform(multipart(HttpMethod.PATCH, "/api/admin/clubs/{clubId}/boards/{boardId}", myClub.getId(), board.getId())
+                        .file(jsonPart(request))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     @DisplayName("updateBoard(): 게시글 수정에 성공한다.")
     void updateBoard_success() throws Exception {
         ClubBoard board = saveBoard("원래 제목", "원래 내용");

--- a/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminControllerTest.java
@@ -228,6 +228,43 @@ class ClubBoardAdminControllerTest {
     }
 
     @Test
+    @DisplayName("createBoard(): 내용이 10000자를 넘으면 400이 발생한다.")
+    void createBoard_contentTooLong() throws Exception {
+        CreateBoardRequest request = new CreateBoardRequest("제목입니다", "가".repeat(10001));
+
+        mockMvc.perform(multipart("/api/admin/clubs/{clubId}/boards", myClub.getId())
+                        .file(jsonPart(request))
+                        .file(thumbnailPart())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("createBoard(): 내용이 10000자면 생성에 성공한다.")
+    void createBoard_contentAtMaxLength() throws Exception {
+        CreateBoardRequest request = new CreateBoardRequest("제목입니다", "가".repeat(10000));
+
+        mockMvc.perform(multipart("/api/admin/clubs/{clubId}/boards", myClub.getId())
+                        .file(jsonPart(request))
+                        .file(thumbnailPart())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("updateBoard(): 내용이 10000자를 넘으면 400이 발생한다.")
+    void updateBoard_contentTooLong() throws Exception {
+        ClubBoard board = saveBoard("원래 제목", "원래 내용");
+
+        ClubBoardUpdateRequest request = new ClubBoardUpdateRequest(null, "가".repeat(10001));
+
+        mockMvc.perform(multipart(HttpMethod.PATCH, "/api/admin/clubs/{clubId}/boards/{boardId}", myClub.getId(), board.getId())
+                        .file(jsonPart(request))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     @DisplayName("updateBoard(): 제목이 255자를 넘으면 400이 발생한다.")
     void updateBoard_titleTooLong() throws Exception {
         ClubBoard board = saveBoard("원래 제목", "원래 내용");

--- a/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminControllerTest.java
@@ -29,6 +29,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -147,6 +148,27 @@ class ClubBoardAdminControllerTest {
                         .file(thumbnailPart())
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + otherAccessToken))
                 .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("createBoard(): 본문의 줄바꿈이 저장 후에도 그대로 유지된다.")
+    void createBoard_preservesLineBreaks() throws Exception {
+        String content = "첫째 줄\n둘째 줄\n\n넷째 줄";
+        CreateBoardRequest request = new CreateBoardRequest("제목입니다", content);
+
+        String response = mockMvc.perform(multipart("/api/admin/clubs/{clubId}/boards", myClub.getId())
+                        .file(jsonPart(request))
+                        .file(thumbnailPart())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        String boardId = objectMapper.readTree(response).get("boardId").asText();
+
+        assertThat(clubBoardRepository.findById(boardId))
+                .get()
+                .extracting(ClubBoard::getContent)
+                .isEqualTo(content);
     }
 
     @Test

--- a/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminControllerTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/controller/ClubBoardAdminControllerTest.java
@@ -172,6 +172,38 @@ class ClubBoardAdminControllerTest {
     }
 
     @Test
+    @DisplayName("createBoard(): 내용이 null이어도 생성에 성공하고 빈 내용으로 저장된다.")
+    void createBoard_withoutContent() throws Exception {
+        CreateBoardRequest request = new CreateBoardRequest("제목입니다", null);
+
+        String response = mockMvc.perform(multipart("/api/admin/clubs/{clubId}/boards", myClub.getId())
+                        .file(jsonPart(request))
+                        .file(thumbnailPart())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        String boardId = objectMapper.readTree(response).get("boardId").asText();
+
+        assertThat(clubBoardRepository.findById(boardId))
+                .get()
+                .extracting(ClubBoard::getContent)
+                .isEqualTo("");
+    }
+
+    @Test
+    @DisplayName("createBoard(): 내용이 빈 문자열이어도 생성에 성공한다.")
+    void createBoard_withBlankContent() throws Exception {
+        CreateBoardRequest request = new CreateBoardRequest("제목입니다", "");
+
+        mockMvc.perform(multipart("/api/admin/clubs/{clubId}/boards", myClub.getId())
+                        .file(jsonPart(request))
+                        .file(thumbnailPart())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + myAccessToken))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
     @DisplayName("createBoard(): 제목이 255자를 넘으면 400이 발생한다.")
     void createBoard_titleTooLong() throws Exception {
         CreateBoardRequest request = new CreateBoardRequest("가".repeat(256), "본문입니다");

--- a/src/test/java/org/project/ttokttok/domain/clubboard/domain/ClubBoardTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/domain/ClubBoardTest.java
@@ -38,7 +38,7 @@ class ClubBoardTest {
 
             assertThatThrownBy(() -> ClubBoard.create(" ", "내용", THUMBNAIL_URL, club))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Title cannot be null or blank.");
+                    .hasMessage("제목은 비어 있을 수 없습니다.");
         }
 
         @Test
@@ -48,7 +48,7 @@ class ClubBoardTest {
 
             assertThatThrownBy(() -> ClubBoard.create(null, "내용", THUMBNAIL_URL, club))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Title cannot be null or blank.");
+                    .hasMessage("제목은 비어 있을 수 없습니다.");
         }
 
         @Test
@@ -78,7 +78,7 @@ class ClubBoardTest {
 
             assertThatThrownBy(() -> ClubBoard.create("제목", "내용", null, club))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Thumbnail URL cannot be null or blank.");
+                    .hasMessage("대표 이미지가 없습니다.");
         }
 
         @Test
@@ -88,7 +88,7 @@ class ClubBoardTest {
 
             assertThatThrownBy(() -> ClubBoard.create("제목", "내용", " ", club))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Thumbnail URL cannot be null or blank.");
+                    .hasMessage("대표 이미지가 없습니다.");
         }
 
         @Test
@@ -96,7 +96,7 @@ class ClubBoardTest {
         void createFailNullClub() {
             assertThatThrownBy(() -> ClubBoard.create("제목", "내용", THUMBNAIL_URL, null))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Club cannot be null.");
+                    .hasMessage("동아리 정보가 없습니다.");
         }
     }
 
@@ -159,7 +159,7 @@ class ClubBoardTest {
 
             assertThatThrownBy(() -> board.update(" ", null))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Title cannot be null or blank.");
+                    .hasMessage("제목은 비어 있을 수 없습니다.");
         }
 
         @Test
@@ -196,10 +196,10 @@ class ClubBoardTest {
 
             assertThatThrownBy(() -> board.updateThumbnailUrl(null))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Thumbnail URL cannot be null or blank.");
+                    .hasMessage("대표 이미지가 없습니다.");
             assertThatThrownBy(() -> board.updateThumbnailUrl(" "))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Thumbnail URL cannot be null or blank.");
+                    .hasMessage("대표 이미지가 없습니다.");
         }
     }
 }

--- a/src/test/java/org/project/ttokttok/domain/clubboard/domain/ClubBoardTest.java
+++ b/src/test/java/org/project/ttokttok/domain/clubboard/domain/ClubBoardTest.java
@@ -52,13 +52,23 @@ class ClubBoardTest {
         }
 
         @Test
-        @DisplayName("내용이 비어있으면 예외가 발생한다.")
-        void createFailBlankContent() {
+        @DisplayName("내용이 null이면 빈 문자열로 저장된다.")
+        void createWithNullContent() {
             Club club = mock(Club.class);
 
-            assertThatThrownBy(() -> ClubBoard.create("제목", " ", THUMBNAIL_URL, club))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Content cannot be null or blank.");
+            ClubBoard board = ClubBoard.create("제목", null, THUMBNAIL_URL, club);
+
+            assertThat(board.getContent()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("내용이 비어있어도 생성에 성공한다.")
+        void createWithBlankContent() {
+            Club club = mock(Club.class);
+
+            ClubBoard board = ClubBoard.create("제목", "", THUMBNAIL_URL, club);
+
+            assertThat(board.getContent()).isEmpty();
         }
 
         @Test
@@ -143,13 +153,24 @@ class ClubBoardTest {
         }
 
         @Test
-        @DisplayName("빈 문자열로 수정을 시도하면 예외가 발생한다.")
+        @DisplayName("빈 문자열로 제목 수정을 시도하면 예외가 발생한다.")
         void updateBlankTitleThrows() {
             ClubBoard board = newBoard();
 
             assertThatThrownBy(() -> board.update(" ", null))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("Title cannot be null or blank.");
+        }
+
+        @Test
+        @DisplayName("빈 문자열을 전달하면 내용을 비울 수 있다.")
+        void updateContentToBlank() {
+            ClubBoard board = newBoard();
+
+            board.update(null, "");
+
+            assertThat(board.getTitle()).isEqualTo("원제목");
+            assertThat(board.getContent()).isEmpty();
         }
     }
 

--- a/src/test/java/org/project/ttokttok/domain/user/service/GoogleAccountWriterTest.java
+++ b/src/test/java/org/project/ttokttok/domain/user/service/GoogleAccountWriterTest.java
@@ -1,0 +1,68 @@
+package org.project.ttokttok.domain.user.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.project.ttokttok.domain.user.domain.User;
+import org.project.ttokttok.domain.user.exception.GoogleLinkTargetNotFoundException;
+import org.project.ttokttok.domain.user.repository.UserRepository;
+import org.springframework.http.HttpStatus;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class GoogleAccountWriterTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private GoogleAccountWriter googleAccountWriter;
+
+    private static final String SUB = "google-sub-123";
+    private static final String SMU_EMAIL = "202021000@sangmyung.kr";
+
+    private User localUser() {
+        return User.signUp(SMU_EMAIL, "encoded-password", "김철수", true);
+    }
+
+    @Test
+    @DisplayName("autoLink(): 연동 대상 계정이 사라졌으면 500이 아니라 409로 응답한다.")
+    void autoLink_targetMissing_throwsConflict() {
+        given(userRepository.findByEmail(SMU_EMAIL)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> googleAccountWriter.autoLink(SMU_EMAIL, SUB))
+                .isInstanceOf(GoogleLinkTargetNotFoundException.class)
+                .extracting(e -> ((GoogleLinkTargetNotFoundException) e).getStatus())
+                .isEqualTo(HttpStatus.CONFLICT);
+    }
+
+    @Test
+    @DisplayName("autoLink(): 연동 대상이 없을 때 예외 메시지에 이메일이 노출되지 않는다.")
+    void autoLink_targetMissing_doesNotLeakEmail() {
+        given(userRepository.findByEmail(SMU_EMAIL)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> googleAccountWriter.autoLink(SMU_EMAIL, SUB))
+                .isInstanceOf(GoogleLinkTargetNotFoundException.class)
+                .hasMessageNotContaining(SMU_EMAIL);
+    }
+
+    @Test
+    @DisplayName("autoLink(): 연동 대상이 있으면 구글 계정을 연동해 저장한다.")
+    void autoLink_success() {
+        User user = localUser();
+        given(userRepository.findByEmail(SMU_EMAIL)).willReturn(Optional.of(user));
+        given(userRepository.saveAndFlush(user)).willReturn(user);
+
+        User linked = googleAccountWriter.autoLink(SMU_EMAIL, SUB);
+
+        assertThat(linked.getProviderId()).isEqualTo(SUB);
+    }
+}

--- a/src/test/java/org/project/ttokttok/global/exception/GlobalExceptionHandlerUploadSizeTest.java
+++ b/src/test/java/org/project/ttokttok/global/exception/GlobalExceptionHandlerUploadSizeTest.java
@@ -1,0 +1,39 @@
+package org.project.ttokttok.global.exception;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.project.ttokttok.global.exception.dto.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 업로드 용량 초과 응답을 검증한다.
+ *
+ * QA 항목 "허용되지 않은 파일 형식/용량 초과 시 안내가 표시되는가" 중 용량 초과 경로다.
+ * 형식 검증은 서비스 계층에서 이미 다루므로 여기서는 용량만 본다.
+ */
+class GlobalExceptionHandlerUploadSizeTest {
+
+    private static final long MAX_UPLOAD_BYTES = 20L * 1024 * 1024;
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    @DisplayName("업로드 용량을 초과하면 413과 안내 문구를 반환한다")
+    void handleMaxSize_returnsPayloadTooLarge() {
+        // given
+        MaxUploadSizeExceededException exception = new MaxUploadSizeExceededException(MAX_UPLOAD_BYTES);
+
+        // when
+        ResponseEntity<ErrorResponse> response = handler.handleMaxSize(exception);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().statusCode()).isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE.value());
+        assertThat(response.getBody().details()).isEqualTo("업로드 가능한 최대 용량을 초과했습니다.");
+    }
+}

--- a/src/test/java/org/project/ttokttok/infrastructure/redis/service/RefreshTokenRedisServiceBlacklistIT.java
+++ b/src/test/java/org/project/ttokttok/infrastructure/redis/service/RefreshTokenRedisServiceBlacklistIT.java
@@ -1,0 +1,71 @@
+package org.project.ttokttok.infrastructure.redis.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * 액세스 토큰 블랙리스트 등록을 <b>실제 Redis</b>에 대해 검증한다.
+ *
+ * {@link RefreshTokenRedisServiceTest}는 {@code RedisTemplate}을 목으로 대체하므로
+ * TTL 0을 넘겨도 통과한다. 실제 Redis는 TTL 0인 SET을 거부하기 때문에
+ * 만료된 액세스 토큰으로 로그아웃하면 500이 발생했다. 그 회귀를 막는 테스트다.
+ */
+@SpringBootTest
+class RefreshTokenRedisServiceBlacklistIT {
+
+    @Autowired
+    private RefreshTokenRedisService refreshTokenRedisService;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    private static final String BLACKLIST_KEY_PREFIX = "blacklist:access:";
+    private static final String REFRESH_KEY_PREFIX = "refresh:";
+
+    private final String accessToken = "it-access-" + UUID.randomUUID();
+    private final String refreshToken = "it-refresh-" + UUID.randomUUID();
+
+    @AfterEach
+    void tearDown() {
+        redisTemplate.delete(BLACKLIST_KEY_PREFIX + accessToken);
+        redisTemplate.delete(REFRESH_KEY_PREFIX + refreshToken);
+    }
+
+    @Test
+    @DisplayName("남은 만료시간이 0이어도 블랙리스트 등록이 예외 없이 끝난다")
+    void addAccessTokenToBlacklist_withZeroExpiry_doesNotThrow() {
+        assertThatCode(() -> refreshTokenRedisService.addAccessTokenToBlacklist(accessToken, 0L))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("남은 만료시간이 음수여도 블랙리스트 등록이 예외 없이 끝난다")
+    void addAccessTokenToBlacklist_withNegativeExpiry_doesNotThrow() {
+        assertThatCode(() -> refreshTokenRedisService.addAccessTokenToBlacklist(accessToken, -1000L))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("남은 만료시간이 양수면 블랙리스트에 등록된다")
+    void addAccessTokenToBlacklist_withPositiveExpiry_marksBlacklisted() {
+        refreshTokenRedisService.addAccessTokenToBlacklist(accessToken, 60_000L);
+
+        assertThat(refreshTokenRedisService.isAccessTokenBlacklisted(accessToken)).isTrue();
+    }
+
+    @Test
+    @DisplayName("이미 만료된 액세스 토큰으로 로그아웃해도 예외 없이 끝난다")
+    void logout_withExpiredAccessToken_doesNotThrow() {
+        assertThatCode(() -> refreshTokenRedisService.logout(refreshToken, accessToken, 0L))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/org/project/ttokttok/infrastructure/redis/service/RefreshTokenRedisServiceTest.java
+++ b/src/test/java/org/project/ttokttok/infrastructure/redis/service/RefreshTokenRedisServiceTest.java
@@ -151,8 +151,8 @@ class RefreshTokenRedisServiceTest {
         }
 
         @ParameterizedTest
-        @DisplayName("다양한 만료시간이 주어져도 블랙리스트에 추가한다")
-        @ValueSource(longs = {1000L, 60000L, 3600000L, 0L})
+        @DisplayName("남은 만료시간이 양수면 블랙리스트에 추가한다")
+        @ValueSource(longs = {1L, 1000L, 60000L, 3600000L})
         void addAccessTokenToBlacklist_withVariousExpiryTimes_addsToBlacklist(long expiryTime) {
             // given
             when(redisTemplate.opsForValue()).thenReturn(valueOperations);
@@ -166,6 +166,17 @@ class RefreshTokenRedisServiceTest {
                     "blacklisted",
                     Duration.ofMillis(expiryTime)
             );
+        }
+
+        @ParameterizedTest
+        @DisplayName("남은 만료시간이 0 이하면 Redis 를 호출하지 않는다")
+        @ValueSource(longs = {0L, -1L, -1000L})
+        void addAccessTokenToBlacklist_withNonPositiveExpiry_skipsRedis(long expiryTime) {
+            // when
+            service.addAccessTokenToBlacklist(TEST_ACCESS_TOKEN, expiryTime);
+
+            // then
+            verify(redisTemplate, never()).opsForValue();
         }
     }
 


### PR DESCRIPTION
## 🚀 Release PR: develop → main

`#378` 자체 서버 이관 컷오버 이후 쌓인 **이슈 6건**을 배포합니다.
온프렘 전환 직후 드러난 인프라 결함 2건과, v2 QA 에서 나온 백엔드 버그·검증 보강입니다.

**DB 스키마 변경 없음** — Flyway 마이그레이션 추가가 없습니다.

---

## 📦 릴리즈 내용 요약

### 🔥 인프라 — 서비스 장애 직결 (#382, #384)

**#382 — Redis 가 RDB 를 저장하지 못해 모든 쓰기가 거부됨 (로그인 불가)**

`redis:7.2-alpine` 은 entrypoint 가 uid 999 로 강등되는데, `setup.sh` 는 `data/redis` 를
`ttokttokuser(1001:1003)` 로 chown 했습니다. uid 999 가 `/data` 에 temp 파일을 만들지 못해
BGSAVE 가 실패하고, `stop-writes-on-bgsave-error` 기본값 때문에 **쓰기 명령 전체가 MISCONF 로
거부**됐습니다. 리프레시 토큰 저장이 막혀 로그인이 500 으로 실패했습니다.

→ compose 에 `user: "1001:1003"` 고정 (minio 와 동일한 방식)

**#384 — compose·nginx·bin 변경이 서버에 반영되지 않던 문제**

`ci-cd.yml` 에 `setup.sh` 호출이 없고 `deploy.sh` 는 **서버에 이미 있는** compose 를 읽기만 해서,
레포의 `docker-compose.yml`·`config/nginx/*`·`bin/*` 을 고쳐 머지해도 서버에는 아무 반영이
없었습니다. #382 의 compose 수정도 그것만으로는 서버가 고쳐지지 않아 수동 복구가 필요했습니다.

→ `setup.sh` 가 컨테이너별 uid 표에 맞춰 소유권을 잡고(`data/` 안쪽을 일괄 chown 하던
정책 위반 제거), compose 정의 반영과 그 결과를 검증하도록 보강

### 🐛 백엔드 버그 수정 (#379, #387)

| 이슈 | 증상 | 원인 |
|---|---|---|
| #379 | 만료된 액세스 토큰으로 로그아웃 시 500 | 남은 만료시간 0 이하를 그대로 Redis TTL 로 전달 → `ERR invalid expire time` |
| #379 | 256자 이상 제목이 API 를 통과 (운영 DB 에서 500) | 요청 DTO 에 길이 제약 없음 + `updateBoard` 에 `@Valid` 누락 |
| #387 | 구글 자동 연동 대상이 없으면 500 | `IllegalStateException` 이 catch-all 로 떨어짐 → 409 로 교정, 메시지의 이메일 노출 제거 |

### ✨ 게시판 기능·검증 변경 (#386, #390)

- **#386** — 게시글 생성 시 **내용을 선택 입력**으로 변경. 저장 컬럼이 `TEXT NOT NULL` 이라
  미입력은 빈 문자열로 정규화(마이그레이션 없음). 수정 API 의 내용 비우기도 함께 허용.
- **#390** — 본문에 `@Size(max = 10000)` 상한 추가(이전엔 무제한). `ClubBoard` 의 검증 예외
  메시지 3건을 한글화 — 이 메시지는 응답 바디 `details` 에 그대로 실려 나갑니다.

### 🧪 QA 커버리지 보강 (#379)

실 Redis 기준 블랙리스트 회귀 테스트, 업로드 용량 초과 413, 본문 줄바꿈 보존, 제목·본문
길이 경계값 등. 기존 목 테스트가 TTL 0 을 "통과"로 고정해 #379 버그를 가리고 있던 것도
교정했습니다.

---

## 🔍 관련 이슈
- 총 포함된 이슈: #379, #382, #384, #386, #387, #390

---

## ✅ 배포 전 체크리스트
- [x] 모든 기능 브랜치가 `develop`에 병합되었나요? (develop 대상 열린 PR 없음)
- [x] Swagger 문서 최신 상태인가? (게시글 생성 API 의 내용 선택 여부 반영 완료)
- [x] `.env` 설정 등 환경 변수 확인 완료되었는가? (신규/변경 환경 변수 없음)
- [ ] 배포 서버에서 사전 테스트 완료하였는가?
- [ ] 릴리즈 버전 태그를 지정했는가? (현재 저장소에 버전 태그 운용 이력 없음)

---

## ⚠️ 기타 주의사항

**이번 배포의 핵심 리스크는 인프라 쪽입니다.** #384 로 `setup.sh` 가 실제로 compose 정의를
서버에 반영하게 되므로, 이번 배포에서 **처음으로 레포의 compose 가 서버에 적용**됩니다.
특히 #382 의 `user: "1001:1003"` 이 redis 컨테이너에 걸립니다.

- 배포 후 redis 컨테이너가 정상 기동하고 BGSAVE 가 성공하는지 확인 필요
  (`docker exec ttokttok-redis redis-cli bgsave` → `Background saving started`)
- 현재 서버는 #382 를 **수동 복구해둔 상태**입니다. 이번 배포로 그 수동 변경이 스크립트가
  관리하는 상태로 정리됩니다. 두 상태가 어긋나 있지 않은지 배포 로그를 확인해주세요.

**롤백**: DB 스키마 변경이 없어 되돌릴 데이터가 없습니다. 애플리케이션은 `main` 이전 커밋으로
되돌리면 되지만, `setup.sh` 가 이미 반영한 서버측 compose 는 코드 롤백만으로 되돌아가지
않으니 필요 시 별도 조치가 필요합니다.

**API 계약 변경 2건** (둘 다 완화 아니면 상한 신설):
- 내용 없는 게시글 생성이 400 → 201 (완화, 기존 클라이언트 영향 없음)
- 10,001자 이상 본문이 201 → 400 (신설 상한)
